### PR TITLE
Fix TOC indentation for intro headings

### DIFF
--- a/src/components/SectionPage.tsx
+++ b/src/components/SectionPage.tsx
@@ -23,7 +23,7 @@ export function SectionPage({ sectionId }: { sectionId: string }) {
   if (s.intro) {
     const introHeadings = [...s.intro.matchAll(/id='(toc-[^']+)'[^>]*>([^<]+)/g)]
     if (introHeadings.length > 0) {
-      introHeadings.forEach(m => tocEntries.unshift({ id: m[1], label: m[2], level: 2 }))
+      introHeadings.forEach(m => tocEntries.unshift({ id: m[1], label: m[2], level: 1 }))
     }
   }
 


### PR DESCRIPTION
Intro headings extracted from section HTML were assigned level 2 (indented) but unshifted to the top of the TOC list, creating a broken visual hierarchy where indented items appeared before the non-indented items they should be children of. Changed intro headings to level 1 since they are top-level page sections.

https://claude.ai/code/session_01N627tPm1rkno8VDsDcqQj5