### PR TITLE
Add h3 headers for tsconfig substep and bonus subpages on Start page

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -888,10 +888,37 @@
     display: none !important;
   }
 
+  .bonus-subpage {
+    margin-top: 12px;
+    padding-left: 14px;
+    border-left: 2px solid #e2e8f0;
+  }
+
+  .bonus-subpage-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--ink);
+    margin: 0 0 2px 0;
+  }
+
+  .bonus-subpage-desc {
+    font-size: 13px;
+    color: var(--body);
+    line-height: 1.5;
+    margin-bottom: 4px;
+  }
+
   .step-substep {
     margin-top: 10px;
     padding-left: 14px;
     border-left: 2px solid #e2e8f0;
+  }
+
+  .step-substep-title {
+    font-size: 14px;
+    font-weight: 700;
+    color: var(--ink);
+    margin: 0 0 2px 0;
   }
 
   .step-substep-text {
@@ -1633,6 +1660,10 @@
 
   body.dark .bonus-step {
     border-top-color: var(--border);
+  }
+
+  body.dark .bonus-subpage {
+    border-left-color: var(--border);
   }
 
   body.dark .step-substep {

--- a/src/components/RoadmapPage.tsx
+++ b/src/components/RoadmapPage.tsx
@@ -39,7 +39,8 @@ export function RoadmapPage() {
         || ciPages.find(p => p.id === step.substep!.jumpTo)
       const subLabel = subTarget ? subTarget.title : step.substep.jumpTo
       html += `<div class="step-substep">`
-      html += `<div class="step-substep-text">↳ ${step.substep.text}</div>`
+      html += `<h3 class="step-substep-title">↳ ${step.substep.title}</h3>`
+      html += `<div class="step-substep-text">${step.substep.text}</div>`
       html += `<button class="step-jump" data-jump="${step.substep.jumpTo}" style="margin-top: 4px;">→ Deep dive: ${subLabel}</button>`
       html += `</div>`
     }
@@ -53,18 +54,33 @@ export function RoadmapPage() {
   html += `<div class="step-title">Bonus: CI Pipeline & Checks</div>`
   html += `<div class="step-desc">Automate linting, build verification, and testing so they run on every push and pull request. A single YAML file can catch bugs before they're ever merged.</div>`
   ciPages.forEach(cp => {
-    html += `<button class="step-jump" data-jump="${cp.id}">→ ${cp.title}</button>`
+    const plainIntro = cp.intro.replace(/<[^>]*>/g, '')
+    const shortDesc = plainIntro.length > 150
+      ? plainIntro.substring(0, 150).replace(/\s+\S*$/, '') + '…'
+      : plainIntro
+    html += `<div class="bonus-subpage">`
+    html += `<h3 class="bonus-subpage-title">${cp.title}</h3>`
+    html += `<div class="bonus-subpage-desc">${shortDesc}</div>`
+    html += `<button class="step-jump" data-jump="${cp.id}">→ Deep dive: ${cp.title}</button>`
+    html += `</div>`
   })
   html += `</div></div>`
 
   // Bonus: Storybook etc.
   bonusSections.forEach(bs => {
+    const plainIntro = bs.intro.replace(/<[^>]*>/g, '')
+    const shortDesc = plainIntro.length > 150
+      ? plainIntro.substring(0, 150).replace(/\s+\S*$/, '') + '…'
+      : plainIntro
     html += `<div class="step-card bonus-step">`
     html += `<div class="step-number bonus-number">★</div>`
     html += `<div class="step-content">`
     html += `<div class="step-title">Bonus: ${bs.title.replace(/^\S+\s+/, '')}</div>`
-    html += `<div class="step-desc">${bs.intro.substring(0, 200).replace(/<[^>]*>/g, '')}…</div>`
+    html += `<div class="bonus-subpage">`
+    html += `<h3 class="bonus-subpage-title">${bs.title}</h3>`
+    html += `<div class="bonus-subpage-desc">${shortDesc}</div>`
     html += `<button class="step-jump" data-jump="${bs.id}">→ Deep dive: ${bs.title}</button>`
+    html += `</div>`
     html += `</div></div>`
   })
 

--- a/src/data/roadmapSteps.ts
+++ b/src/data/roadmapSteps.ts
@@ -7,6 +7,7 @@ export interface RoadmapStep {
   detail: string
   jumpTo: string | null
   substep?: {
+    title: string
     text: string
     jumpTo: string
   }
@@ -41,7 +42,8 @@ export const roadmapSteps: RoadmapStep[] = [
     detail: "Packages should output ESM at minimum (and optionally CJS). Apps just need browser-optimized bundles. Your build tool compiles src/ into dist/.",
     jumpTo: "build",
     substep: {
-      text: "Configure your tsconfig.json — the TypeScript compiler settings that control how your code gets compiled.",
+      title: "Configure your tsconfig.json",
+      text: "The TypeScript compiler settings that control how your code gets compiled.",
       jumpTo: "tsconfig"
     }
   },


### PR DESCRIPTION
- Split the tsconfig substep into a separate h3 title and description text
- Give each CI Pipeline subpage (CI Overview, Linting & Formatting, etc.) its own h3 header and short description instead of just a button
- Give each bonus section (Storybook) its own h3 header and description
- Add CSS styles for the new bonus-subpage and step-substep-title elements

https://claude.ai/code/session_01J54hyT3F6Bu6YsGFzsb9kJ