### PR TITLE
Improve Start page layout: spacing, bonus sections, and resources link

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -874,9 +874,10 @@
   }
 
   .bonus-step {
-    margin-top: 12px;
+    margin-top: 28px;
     border-top: 2px dashed #cbd5e1;
     padding-top: 24px;
+    border-bottom: none;
   }
 
   .bonus-number {
@@ -909,7 +910,7 @@
   }
 
   .step-substep {
-    margin-top: 10px;
+    margin-top: 16px;
     padding-left: 14px;
     border-left: 2px solid #e2e8f0;
   }

--- a/src/components/RoadmapPage.tsx
+++ b/src/components/RoadmapPage.tsx
@@ -39,7 +39,7 @@ export function RoadmapPage() {
         || ciPages.find(p => p.id === step.substep!.jumpTo)
       const subLabel = subTarget ? subTarget.title : step.substep.jumpTo
       html += `<div class="step-substep">`
-      html += `<h3 class="step-substep-title">↳ ${step.substep.title}</h3>`
+      html += `<h3 class="step-substep-title">${step.substep.title}</h3>`
       html += `<div class="step-substep-text">${step.substep.text}</div>`
       html += `<button class="step-jump" data-jump="${step.substep.jumpTo}" style="margin-top: 4px;">→ Deep dive: ${subLabel}</button>`
       html += `</div>`
@@ -83,6 +83,15 @@ export function RoadmapPage() {
     html += `</div>`
     html += `</div></div>`
   })
+
+  // Bonus: Learning Resources
+  html += `<div class="step-card bonus-step">`
+  html += `<div class="step-number bonus-number">★</div>`
+  html += `<div class="step-content">`
+  html += `<div class="step-title">Bonus: Learning Resources</div>`
+  html += `<div class="step-desc">Documentation, articles, courses, and tools to go deeper on frontend development, npm packages, and the JavaScript ecosystem.</div>`
+  html += `<button class="step-jump" data-jump="overall-resources">→ Deep dive: 📚 Learning Resources</button>`
+  html += `</div></div>`
 
   return (
     <>


### PR DESCRIPTION
- Increase spacing between bonus sections (margin-top 12px → 28px)
- Remove border-bottom lines below bonus sections
- Remove arrow (↳) before "Configure your tsconfig.json" substep and add more spacing above it
- Add a Bonus section linking to the Learning Resources page

https://claude.ai/code/session_01TJ1MozetwvqWKBjbxCAZFD