### PR TITLE
Add Publish Checklist and Section References to Learning Resources bonus section

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -890,8 +890,8 @@
   }
 
   .bonus-subpage {
-    margin-top: 12px;
-    padding-left: 14px;
+    margin-top: 18px;
+    padding: 8px 0 8px 14px;
     border-left: 2px solid #e2e8f0;
   }
 

--- a/src/components/RoadmapPage.tsx
+++ b/src/components/RoadmapPage.tsx
@@ -90,7 +90,21 @@ export function RoadmapPage() {
   html += `<div class="step-content">`
   html += `<div class="step-title">Bonus: Learning Resources</div>`
   html += `<div class="step-desc">Documentation, articles, courses, and tools to go deeper on frontend development, npm packages, and the JavaScript ecosystem.</div>`
+  html += `<div class="bonus-subpage">`
+  html += `<h3 class="bonus-subpage-title">📚 Learning Resources</h3>`
+  html += `<div class="bonus-subpage-desc">Curated documentation, articles, free and paid courses, starter templates, and monorepo tools for the JavaScript ecosystem.</div>`
   html += `<button class="step-jump" data-jump="overall-resources">→ Deep dive: 📚 Learning Resources</button>`
+  html += `</div>`
+  html += `<div class="bonus-subpage">`
+  html += `<h3 class="bonus-subpage-title">✅ Publish Checklist</h3>`
+  html += `<div class="bonus-subpage-desc">Go through this before every npm publish — trust us, it saves headaches.</div>`
+  html += `<button class="step-jump" data-jump="checklist">→ Deep dive: ✅ Publish Checklist</button>`
+  html += `</div>`
+  html += `<div class="bonus-subpage">`
+  html += `<h3 class="bonus-subpage-title">🔗 Section References</h3>`
+  html += `<div class="bonus-subpage-desc">All the "Read More" links from the deep-dive sections, collected in one place for quick reference.</div>`
+  html += `<button class="step-jump" data-jump="section-links">→ Deep dive: 🔗 Section References</button>`
+  html += `</div>`
   html += `</div></div>`
 
   return (


### PR DESCRIPTION
Expand the Learning Resources bonus card on the Start Page to include sub-entries for Publish Checklist and Section References alongside the existing Learning Resources link. Also increase spacing between bonus sub-page items for better readability.

https://claude.ai/code/session_01EjoEnAVtGuD26oKLoKP9uz