### PR TITLE
Align sidebar sections with Start Page order and headers

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -37,11 +37,20 @@ export function Sidebar({ open, onClose }: SidebarProps) {
 
   const topItems = [
     { id: 'roadmap', title: '🚀 Start Here' },
-    { id: 'bigpicture', title: '🗺️ Big Picture' },
   ]
 
-  const conceptItems = sections.filter(s => s.group === 'concepts').map(s => ({ id: s.id, title: s.title }))
-  const comparisonItems = sections.filter(s => s.group !== 'concepts' && s.id !== 'bigpicture').map(s => ({ id: s.id, title: s.title }))
+  // Order matches the Start Page roadmap steps
+  const buildingPackageOrder = [
+    'bigpicture', 'monorepo', 'npm-vs-pnpm',
+    'build', 'tsconfig', 'deps', 'dist',
+    'packagejson', 'typescript', 'versioning', 'workflow',
+  ]
+  const buildingPackageItems = buildingPackageOrder
+    .map(id => {
+      const s = sections.find(s => s.id === id)
+      return s ? { id: s.id, title: s.title } : null
+    })
+    .filter((item): item is { id: string; title: string } => item !== null)
 
   const resourceItems = [
     { id: 'checklist', title: '✅ Publish Checklist' },
@@ -60,17 +69,12 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
         ))}
 
-        <div className="sidebar-group-label">Overall Concepts</div>
-        {conceptItems.map(item => (
+        <div className="sidebar-group-label">Building a Package: Step by Step</div>
+        {buildingPackageItems.map(item => (
           <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
         ))}
 
-        <div className="sidebar-group-label">Web App vs NPM Package</div>
-        {comparisonItems.map(item => (
-          <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
-        ))}
-
-        <div className="sidebar-group-label">CI Pipeline &amp; Checks</div>
+        <div className="sidebar-group-label">Bonus: CI Pipeline &amp; Checks</div>
         {ciPages.map(item => (
           <SidebarItem key={item.id} id={item.id} title={item.title} active={currentId === item.id} onClick={handleNav} />
         ))}
@@ -80,7 +84,7 @@ export function Sidebar({ open, onClose }: SidebarProps) {
           <SidebarItem key={item.id} id={item.id} title={item.title} active={currentId === item.id} onClick={handleNav} />
         ))}
 
-        <div className="sidebar-group-label">Resources</div>
+        <div className="sidebar-group-label">Bonus: Learning Resources</div>
         {resourceItems.map(item => (
           <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
         ))}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -3,9 +3,16 @@ import { ciPages, ciPageIds } from './ciPages'
 import { bonusSections, bonusIds } from './bonusSections'
 
 export function getNavOrder(): string[] {
-  const conceptIds = sections.filter(s => s.group === "concepts").map(s => s.id)
-  const comparisonIds = sections.filter(s => s.group !== "concepts" && s.id !== "bigpicture").map(s => s.id)
-  return ["roadmap", "bigpicture", ...conceptIds, ...comparisonIds, ...ciPageIds, ...bonusIds, "checklist", "overall-resources", "section-links"]
+  // Order matches the Start Page roadmap steps and sidebar sections
+  return [
+    "roadmap",
+    "bigpicture", "monorepo", "npm-vs-pnpm",
+    "build", "tsconfig", "deps", "dist",
+    "packagejson", "typescript", "versioning", "workflow",
+    ...ciPageIds,
+    ...bonusIds,
+    "checklist", "overall-resources", "section-links",
+  ]
 }
 
 export function getNavTitle(id: string): string {


### PR DESCRIPTION
- Merge "Overall Concepts" and "Web App vs NPM Package" sidebar groups into single "Building a Package: Step by Step" matching the Start Page
- Reorder sidebar items to follow the roadmap step sequence: bigpicture, monorepo, npm-vs-pnpm, build, tsconfig, deps, dist, packagejson, typescript, versioning, workflow
- Rename "CI Pipeline & Checks" to "Bonus: CI Pipeline & Checks"
- Rename "Resources" to "Bonus: Learning Resources"
- Update prev/next navigation order to match the new sidebar order

https://claude.ai/code/session_0189zGpdigbbr78BUF7E3g35