### PR TITLE
Add glossary section links and convert to interactive TanStack Table

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Educational single-page application (SPA) comparing web apps vs NPM packages, bu
 
 ## Tech Stack
 
-- **Framework:** React 19 + TanStack Router (hash-based routing for GitHub Pages)
+- **Framework:** React 19 + TanStack Router (hash-based routing for GitHub Pages) + TanStack Table (glossary)
 - **Language:** TypeScript (strict mode)
 - **Build Tool:** Vite 7
 - **Package Manager:** pnpm
@@ -37,6 +37,8 @@ Educational single-page application (SPA) comparing web apps vs NPM packages, bu
 - **HTML rendering:** Components use `HtmlContent` (wraps `dangerouslySetInnerHTML`) to render HTML strings from data files.
 - **Package manager context:** `usePM()` hook + `cmd()` helper handle npm/pnpm command display switching throughout the app.
 - **Functional components only:** No class components. Props typed with TypeScript interfaces.
+- **Glossary as interactive table:** The glossary page (`GlossaryPage.tsx`) uses TanStack Table for a sortable, filterable, searchable table. Each term has an optional `sectionId` in `glossaryTerms.ts` that links to the corresponding guide section.
+- **Start Page ordering:** The Bonus: Learning Resources card on the Start Page (`RoadmapPage.tsx`) lists items in the same order as the sidebar: Checklist, Learning Resources, Glossary, Section References.
 
 ## TypeScript Configuration
 

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@tanstack/react-router": "^1.159.5",
+    "@tanstack/react-table": "^8.21.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@tanstack/react-router':
         specifier: ^1.159.5
         version: 1.159.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@tanstack/react-table':
+        specifier: ^8.21.3
+        version: 8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: ^19.2.0
         version: 19.2.4
@@ -524,12 +527,23 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  '@tanstack/react-table@8.21.3':
+    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+
   '@tanstack/router-core@1.159.4':
     resolution: {integrity: sha512-MFzPH39ijNO83qJN3pe7x4iAlhZyqgao3sJIzv3SJ4Pnk12xMnzuDzIAQT/1WV6JolPQEcw0Wr4L5agF8yxoeg==}
     engines: {node: '>=12'}
 
   '@tanstack/store@0.8.0':
     resolution: {integrity: sha512-Om+BO0YfMZe//X2z0uLF2j+75nQga6TpTJgLJQBiq85aOyZNIhkCgleNcud2KQg4k4v9Y9l+Uhru3qWMPGTOzQ==}
+
+  '@tanstack/table-core@8.21.3':
+    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
+    engines: {node: '>=12'}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1523,6 +1537,12 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       use-sync-external-store: 1.6.0(react@19.2.4)
 
+  '@tanstack/react-table@8.21.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
+    dependencies:
+      '@tanstack/table-core': 8.21.3
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+
   '@tanstack/router-core@1.159.4':
     dependencies:
       '@tanstack/history': 1.154.14
@@ -1534,6 +1554,8 @@ snapshots:
       tiny-warning: 1.0.3
 
   '@tanstack/store@0.8.0': {}
+
+  '@tanstack/table-core@8.21.3': {}
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/src/App.css
+++ b/src/App.css
@@ -1029,35 +1029,137 @@
   .rb-interactive { background: #ccfbf1; color: #0f766e; }
 
   /* Glossary */
-  .glossary-list {
-    margin: 0 0 24px;
-    padding: 0;
+  /* Glossary controls */
+  .glossary-controls {
+    margin-bottom: 20px;
   }
 
-  .glossary-entry {
-    padding: 12px 0;
+  .glossary-search {
+    width: 100%;
+    padding: 10px 14px;
+    font-size: 14px;
+    font-family: inherit;
+    border: 1px solid var(--border);
+    border-radius: 8px;
+    background: var(--surface);
+    color: var(--ink);
+    outline: none;
+    margin-bottom: 12px;
+  }
+
+  .glossary-search:focus {
+    border-color: var(--indigo);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.12);
+  }
+
+  .glossary-search::placeholder {
+    color: var(--muted);
+  }
+
+  .glossary-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+  }
+
+  .glossary-filter-btn {
+    font-family: inherit;
+    font-size: 12px;
+    font-weight: 500;
+    padding: 5px 12px;
+    border: 1px solid var(--border);
+    border-radius: 16px;
+    background: var(--surface);
+    color: var(--body);
+    cursor: pointer;
+    transition: all 0.15s;
+  }
+
+  .glossary-filter-btn:hover {
+    border-color: var(--indigo);
+    color: var(--indigo);
+  }
+
+  .glossary-filter-btn.active {
+    background: var(--indigo);
+    border-color: var(--indigo);
+    color: #fff;
+  }
+
+  /* Glossary table */
+  .glossary-table-wrapper {
+    overflow-x: auto;
+    border: 1px solid var(--border-light);
+    border-radius: 10px;
+  }
+
+  .glossary-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 13.5px;
+    line-height: 1.6;
+  }
+
+  .glossary-table thead {
+    background: var(--pill-bg);
     border-bottom: 1px solid var(--border-light);
   }
 
-  .glossary-entry:last-child {
+  .glossary-table th {
+    text-align: left;
+    padding: 10px 14px;
+    font-size: 12px;
+    font-weight: 700;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.5px;
+    white-space: nowrap;
+    user-select: none;
+  }
+
+  .glossary-table th.sortable {
+    cursor: pointer;
+  }
+
+  .glossary-table th.sortable:hover {
+    color: var(--indigo);
+  }
+
+  .sort-indicator {
+    font-size: 11px;
+    color: var(--muted);
+  }
+
+  .glossary-table td {
+    padding: 12px 14px;
+    border-bottom: 1px solid var(--border-light);
+    color: var(--body);
+    vertical-align: top;
+  }
+
+  .glossary-table tbody tr:last-child td {
     border-bottom: none;
   }
 
-  .glossary-term {
+  .glossary-table tbody tr:hover {
+    background: var(--pill-bg);
+  }
+
+  .glossary-table td:first-child {
+    white-space: nowrap;
     font-size: 14px;
-    font-weight: 700;
     color: var(--ink);
-    margin-bottom: 4px;
+    width: 1%;
   }
 
-  .glossary-def {
-    font-size: 13.5px;
-    line-height: 1.65;
-    color: var(--body);
-    margin: 0;
+  .glossary-table td:last-child {
+    white-space: nowrap;
+    font-size: 12px;
+    color: var(--muted);
+    width: 1%;
   }
 
-  .glossary-def code {
+  .glossary-table td code {
     font-family: 'JetBrains Mono', monospace;
     font-size: 12px;
     background: var(--pill-bg);
@@ -1085,6 +1187,12 @@
   .glossary-link .external-link-icon {
     width: 11px;
     height: 11px;
+  }
+
+  .glossary-section-link {
+    margin-left: 4px;
+    font-size: 12px;
+    white-space: nowrap;
   }
 
   /* Links / Resources */
@@ -1769,8 +1877,39 @@
     border-bottom-color: var(--border);
   }
 
-  body.dark .glossary-entry {
+  body.dark .glossary-table-wrapper {
+    border-color: var(--border);
+  }
+
+  body.dark .glossary-table thead {
+    background: rgba(255, 255, 255, 0.04);
     border-bottom-color: var(--border);
+  }
+
+  body.dark .glossary-table td {
+    border-bottom-color: var(--border);
+  }
+
+  body.dark .glossary-table tbody tr:hover {
+    background: rgba(255, 255, 255, 0.04);
+  }
+
+  body.dark .glossary-search {
+    background: var(--surface);
+    border-color: var(--border);
+    color: var(--ink);
+  }
+
+  body.dark .glossary-filter-btn {
+    background: var(--surface);
+    border-color: var(--border);
+    color: var(--body);
+  }
+
+  body.dark .glossary-filter-btn.active {
+    background: var(--indigo);
+    border-color: var(--indigo);
+    color: #fff;
   }
 
   body.dark .links-section {

--- a/src/components/GlossaryPage.tsx
+++ b/src/components/GlossaryPage.tsx
@@ -1,42 +1,184 @@
+import { useState, useMemo } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import {
+  useReactTable,
+  getCoreRowModel,
+  getSortedRowModel,
+  getFilteredRowModel,
+  flexRender,
+  createColumnHelper,
+} from '@tanstack/react-table'
+import type { SortingState, ColumnFiltersState } from '@tanstack/react-table'
 import { glossaryTerms } from '../data/glossaryTerms'
-import { HtmlContent } from './HtmlContent'
+import type { GlossaryTerm } from '../data/glossaryTerms'
+import { getNavTitle } from '../data/navigation'
 import { PrevNextNav } from './PrevNextNav'
 
+interface FlatGlossaryRow extends GlossaryTerm {
+  category: string
+}
+
+const flatData: FlatGlossaryRow[] = glossaryTerms.flatMap(group =>
+  group.terms.map(t => ({ ...t, category: group.category }))
+)
+
+const categories = glossaryTerms.map(g => g.category)
+
+const columnHelper = createColumnHelper<FlatGlossaryRow>()
+
+const externalLinkIcon = `<svg class="external-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>`
+
 export function GlossaryPage() {
-  let html = `<h1 class="section-title">📖 Glossary</h1>`
-  html += `<p style="color: var(--muted); font-size: 14px; margin-bottom: 24px; line-height: 1.6;">Key terms you'll encounter when building and publishing npm packages. Each term includes a link to learn more.</p>`
+  const navigate = useNavigate()
+  const [sorting, setSorting] = useState<SortingState>([])
+  const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([])
+  const [globalFilter, setGlobalFilter] = useState('')
 
-  // Build TOC from categories
-  const tocEntries = glossaryTerms.map(g => ({
-    id: 'toc-glossary-' + g.category.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
-    label: g.category,
-  }))
+  const columns = useMemo(() => [
+    columnHelper.accessor('term', {
+      header: 'Term',
+      cell: info => <strong>{info.getValue()}</strong>,
+      sortingFn: 'alphanumeric',
+    }),
+    columnHelper.accessor('definition', {
+      header: 'Definition',
+      cell: info => {
+        const row = info.row.original
+        return (
+          <div>
+            <span dangerouslySetInnerHTML={{ __html: row.definition }} />
+            {' '}
+            <a
+              className="glossary-link"
+              href={row.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              dangerouslySetInnerHTML={{ __html: `${row.source} docs${externalLinkIcon}` }}
+            />
+            {row.sectionId && (
+              <>
+                {' '}
+                <button
+                  className="glossary-section-link inline-nav-link"
+                  onClick={() => {
+                    navigate({ to: '/$sectionId', params: { sectionId: row.sectionId! } })
+                    window.scrollTo({ top: 0, behavior: 'smooth' })
+                  }}
+                >
+                  → {getNavTitle(row.sectionId)}
+                </button>
+              </>
+            )}
+          </div>
+        )
+      },
+      enableSorting: false,
+    }),
+    columnHelper.accessor('category', {
+      header: 'Category',
+      sortingFn: 'alphanumeric',
+      filterFn: 'equals',
+    }),
+  ], [navigate])
 
-  if (tocEntries.length >= 3) {
-    html += `<div class="section-toc"><div class="section-toc-title">On this page</div>`
-    tocEntries.forEach(e => {
-      html += `<a class="toc-link" data-toc="${e.id}">${e.label}</a>`
-    })
-    html += `</div>`
-  }
-
-  glossaryTerms.forEach(group => {
-    const catId = 'toc-glossary-' + group.category.toLowerCase().replace(/[^a-z0-9]+/g, '-')
-    html += `<h2 class="section-subheading" id="${catId}">${group.category}</h2>`
-    html += `<dl class="glossary-list">`
-    group.terms.forEach(t => {
-      html += `<div class="glossary-entry">`
-      html += `<dt class="glossary-term">${t.term}</dt>`
-      html += `<dd class="glossary-def">${t.definition}`
-      html += ` <a class="glossary-link" href="${t.url}" target="_blank" rel="noopener noreferrer">${t.source} docs<svg class="external-link-icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg></a>`
-      html += `</dd></div>`
-    })
-    html += `</dl>`
+  const table = useReactTable({
+    data: flatData,
+    columns,
+    state: { sorting, columnFilters, globalFilter },
+    onSortingChange: setSorting,
+    onColumnFiltersChange: setColumnFilters,
+    onGlobalFilterChange: setGlobalFilter,
+    getCoreRowModel: getCoreRowModel(),
+    getSortedRowModel: getSortedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    globalFilterFn: (row, _columnId, filterValue: string) => {
+      const search = filterValue.toLowerCase()
+      const term = row.original.term.toLowerCase()
+      const def = row.original.definition.replace(/<[^>]*>/g, '').toLowerCase()
+      const cat = row.original.category.toLowerCase()
+      return term.includes(search) || def.includes(search) || cat.includes(search)
+    },
   })
+
+  const activeCategoryFilter = (columnFilters.find(f => f.id === 'category')?.value as string) || ''
 
   return (
     <>
-      <HtmlContent html={html} />
+      <h1 className="section-title">📖 Glossary</h1>
+      <p style={{ color: 'var(--muted)', fontSize: '14px', marginBottom: '16px', lineHeight: 1.6 }}>
+        Key terms you'll encounter when building and publishing npm packages. Each term includes links to learn more.
+      </p>
+
+      <div className="glossary-controls">
+        <input
+          className="glossary-search"
+          type="text"
+          placeholder="Search terms..."
+          value={globalFilter}
+          onChange={e => setGlobalFilter(e.target.value)}
+        />
+        <div className="glossary-filters">
+          <button
+            className={`glossary-filter-btn ${activeCategoryFilter === '' ? 'active' : ''}`}
+            onClick={() => setColumnFilters([])}
+          >
+            All
+          </button>
+          {categories.map(cat => (
+            <button
+              key={cat}
+              className={`glossary-filter-btn ${activeCategoryFilter === cat ? 'active' : ''}`}
+              onClick={() => setColumnFilters([{ id: 'category', value: cat }])}
+            >
+              {cat}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="glossary-table-wrapper">
+        <table className="glossary-table">
+          <thead>
+            {table.getHeaderGroups().map(headerGroup => (
+              <tr key={headerGroup.id}>
+                {headerGroup.headers.map(header => (
+                  <th
+                    key={header.id}
+                    className={header.column.getCanSort() ? 'sortable' : ''}
+                    onClick={header.column.getToggleSortingHandler()}
+                  >
+                    {flexRender(header.column.columnDef.header, header.getContext())}
+                    {header.column.getCanSort() && (
+                      <span className="sort-indicator">
+                        {{ asc: ' ▲', desc: ' ▼' }[header.column.getIsSorted() as string] ?? ' ⇅'}
+                      </span>
+                    )}
+                  </th>
+                ))}
+              </tr>
+            ))}
+          </thead>
+          <tbody>
+            {table.getRowModel().rows.map(row => (
+              <tr key={row.id}>
+                {row.getVisibleCells().map(cell => (
+                  <td key={cell.id}>
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))}
+            {table.getRowModel().rows.length === 0 && (
+              <tr>
+                <td colSpan={3} style={{ textAlign: 'center', color: 'var(--muted)', padding: '24px' }}>
+                  No terms match your search.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
       <PrevNextNav currentId="glossary" />
     </>
   )

--- a/src/components/RoadmapPage.tsx
+++ b/src/components/RoadmapPage.tsx
@@ -91,14 +91,19 @@ export function RoadmapPage() {
   html += `<div class="step-title">Bonus: Learning Resources</div>`
   html += `<div class="step-desc">Documentation, articles, courses, and tools to go deeper on frontend development, npm packages, and the JavaScript ecosystem.</div>`
   html += `<div class="bonus-subpage">`
+  html += `<h3 class="bonus-subpage-title">✅ Publish Checklist</h3>`
+  html += `<div class="bonus-subpage-desc">Go through this before every npm publish — trust us, it saves headaches.</div>`
+  html += `<button class="step-jump" data-jump="checklist">→ Deep dive: ✅ Publish Checklist</button>`
+  html += `</div>`
+  html += `<div class="bonus-subpage">`
   html += `<h3 class="bonus-subpage-title">📚 Learning Resources</h3>`
   html += `<div class="bonus-subpage-desc">Curated documentation, articles, free and paid courses, starter templates, and monorepo tools for the JavaScript ecosystem.</div>`
   html += `<button class="step-jump" data-jump="overall-resources">→ Deep dive: 📚 Learning Resources</button>`
   html += `</div>`
   html += `<div class="bonus-subpage">`
-  html += `<h3 class="bonus-subpage-title">✅ Publish Checklist</h3>`
-  html += `<div class="bonus-subpage-desc">Go through this before every npm publish — trust us, it saves headaches.</div>`
-  html += `<button class="step-jump" data-jump="checklist">→ Deep dive: ✅ Publish Checklist</button>`
+  html += `<h3 class="bonus-subpage-title">📖 Glossary</h3>`
+  html += `<div class="bonus-subpage-desc">Key terms you'll encounter when building and publishing npm packages, with links to the relevant sections in this guide.</div>`
+  html += `<button class="step-jump" data-jump="glossary">→ Deep dive: 📖 Glossary</button>`
   html += `</div>`
   html += `<div class="bonus-subpage">`
   html += `<h3 class="bonus-subpage-title">🔗 Section References</h3>`

--- a/src/data/glossaryTerms.ts
+++ b/src/data/glossaryTerms.ts
@@ -3,6 +3,7 @@ export interface GlossaryTerm {
   definition: string
   url: string
   source: string
+  sectionId?: string
 }
 
 export interface GlossaryCategory {
@@ -18,37 +19,43 @@ export const glossaryTerms: GlossaryCategory[] = [
         term: "npm",
         definition: "Node Package Manager — the default package manager for Node.js. Provides a CLI for installing, publishing, and managing JavaScript packages, and hosts the npm registry.",
         url: "https://docs.npmjs.com/about-npm",
-        source: "npm"
+        source: "npm",
+        sectionId: "npm-vs-pnpm"
       },
       {
         term: "pnpm",
         definition: "A fast, disk-space-efficient alternative to npm. Uses a content-addressable store and symlinks to avoid duplicating packages across projects.",
         url: "https://pnpm.io/motivation",
-        source: "pnpm"
+        source: "pnpm",
+        sectionId: "npm-vs-pnpm"
       },
       {
         term: "Registry",
         definition: "A public (or private) database of JavaScript packages. The npm registry at npmjs.com is the largest, where packages are published and downloaded from.",
         url: "https://docs.npmjs.com/about-the-public-npm-registry",
-        source: "npm"
+        source: "npm",
+        sectionId: "npm-vs-pnpm"
       },
       {
         term: "Lockfile",
         definition: "A file (<code>package-lock.json</code> for npm, <code>pnpm-lock.yaml</code> for pnpm) that records the exact versions of every installed dependency, ensuring reproducible installs across machines.",
         url: "https://docs.npmjs.com/cli/configuring-npm/package-lock-json",
-        source: "npm"
+        source: "npm",
+        sectionId: "npm-vs-pnpm"
       },
       {
         term: "node_modules",
         definition: "The directory where installed packages are stored locally. Each project has its own <code>node_modules</code> folder (though pnpm uses symlinks to a shared store for efficiency).",
         url: "https://docs.npmjs.com/cli/configuring-npm/folders",
-        source: "npm"
+        source: "npm",
+        sectionId: "npm-vs-pnpm"
       },
       {
         term: "Scope",
         definition: "A namespace for npm packages, prefixed with <code>@</code> (e.g., <code>@myorg/my-package</code>). Scopes group related packages together and help avoid naming collisions.",
         url: "https://docs.npmjs.com/about-scopes",
-        source: "npm"
+        source: "npm",
+        sectionId: "packagejson"
       },
     ]
   },
@@ -59,31 +66,36 @@ export const glossaryTerms: GlossaryCategory[] = [
         term: "dependency",
         definition: "A package required at runtime by consumers of your package. Listed in <code>dependencies</code> in <code>package.json</code> and installed automatically when someone installs your package.",
         url: "https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file",
-        source: "npm"
+        source: "npm",
+        sectionId: "deps"
       },
       {
         term: "devDependency",
         definition: "A package only needed during development (e.g., testing frameworks, build tools, linters). Listed in <code>devDependencies</code> and not installed by consumers of your package.",
         url: "https://docs.npmjs.com/specifying-dependencies-and-devdependencies-in-a-package-json-file",
-        source: "npm"
+        source: "npm",
+        sectionId: "deps"
       },
       {
         term: "Peer Dependency",
         definition: "A dependency your package expects the consumer to provide, rather than bundling it yourself. Common for plugins and UI component libraries (e.g., requiring React as a peer dependency).",
         url: "https://docs.npmjs.com/cli/configuring-npm/package-json#peerdependencies",
-        source: "npm"
+        source: "npm",
+        sectionId: "deps"
       },
       {
         term: "Semver",
         definition: "Semantic Versioning — a versioning scheme using <code>MAJOR.MINOR.PATCH</code>. Major = breaking changes, minor = new features (backward-compatible), patch = bug fixes.",
         url: "https://semver.org/",
-        source: "semver.org"
+        source: "semver.org",
+        sectionId: "versioning"
       },
       {
         term: "Range Specifier",
         definition: "A syntax in <code>package.json</code> to allow flexible version matching. <code>^1.2.3</code> allows minor and patch updates; <code>~1.2.3</code> allows only patch updates.",
         url: "https://docs.npmjs.com/about-semantic-versioning",
-        source: "npm"
+        source: "npm",
+        sectionId: "versioning"
       },
     ]
   },
@@ -94,43 +106,50 @@ export const glossaryTerms: GlossaryCategory[] = [
         term: "Bundler",
         definition: "A tool that combines multiple source files into optimized output files for distribution. Examples include Vite, webpack, Rollup, and esbuild.",
         url: "https://vite.dev/guide/why.html",
-        source: "Vite"
+        source: "Vite",
+        sectionId: "build"
       },
       {
         term: "Transpiler",
         definition: "A tool that converts source code from one language or version to another — e.g., TypeScript to JavaScript, or modern JS to older JS for browser compatibility. Babel and tsc are common transpilers.",
         url: "https://www.typescriptlang.org/docs/handbook/2/basic-types.html#tsc-the-typescript-compiler",
-        source: "TypeScript"
+        source: "TypeScript",
+        sectionId: "build"
       },
       {
         term: "Tree Shaking",
         definition: "A build optimization that removes unused code (dead code elimination). It relies on ES module <code>import</code>/<code>export</code> syntax to detect what's actually used.",
         url: "https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking",
-        source: "MDN"
+        source: "MDN",
+        sectionId: "build"
       },
       {
         term: "Minification",
         definition: "The process of removing whitespace, comments, and shortening variable names in production code to reduce file size without changing behavior.",
         url: "https://developer.mozilla.org/en-US/docs/Glossary/Minification",
-        source: "MDN"
+        source: "MDN",
+        sectionId: "build"
       },
       {
         term: "Source Map",
         definition: "A file that maps minified/bundled code back to the original source, enabling accurate debugging in browser dev tools. Usually a <code>.map</code> file alongside the output.",
         url: "https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Use_a_source_map",
-        source: "MDN"
+        source: "MDN",
+        sectionId: "build"
       },
       {
         term: "ESM (ES Modules)",
         definition: "The official JavaScript module system using <code>import</code> and <code>export</code> syntax. The modern standard that enables tree shaking and static analysis.",
         url: "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules",
-        source: "MDN"
+        source: "MDN",
+        sectionId: "build"
       },
       {
         term: "CJS (CommonJS)",
         definition: "The older module system used by Node.js, using <code>require()</code> and <code>module.exports</code>. Still widely used in Node.js but being gradually replaced by ESM.",
         url: "https://nodejs.org/docs/latest/api/modules.html",
-        source: "Node.js"
+        source: "Node.js",
+        sectionId: "build"
       },
     ]
   },
@@ -141,19 +160,22 @@ export const glossaryTerms: GlossaryCategory[] = [
         term: "tsconfig.json",
         definition: "The TypeScript configuration file that controls compiler options — target output, module format, strictness level, which files to include, and more.",
         url: "https://www.typescriptlang.org/docs/handbook/tsconfig-json.html",
-        source: "TypeScript"
+        source: "TypeScript",
+        sectionId: "tsconfig"
       },
       {
         term: "Declaration File (.d.ts)",
         definition: "A file containing only type information (no runtime code). Allows TypeScript users to get autocompletion and type checking when using your JavaScript package.",
         url: "https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html",
-        source: "TypeScript"
+        source: "TypeScript",
+        sectionId: "typescript"
       },
       {
         term: "Strict Mode",
         definition: "A TypeScript compiler setting (<code>\"strict\": true</code>) that enables a set of stricter type-checking rules, catching more potential bugs at compile time.",
         url: "https://www.typescriptlang.org/tsconfig/#strict",
-        source: "TypeScript"
+        source: "TypeScript",
+        sectionId: "tsconfig"
       },
     ]
   },
@@ -164,31 +186,36 @@ export const glossaryTerms: GlossaryCategory[] = [
         term: "package.json",
         definition: "The manifest file for any Node.js project or npm package. Declares the package name, version, dependencies, scripts, entry points, and metadata.",
         url: "https://docs.npmjs.com/cli/configuring-npm/package-json",
-        source: "npm"
+        source: "npm",
+        sectionId: "packagejson"
       },
       {
         term: "exports Field",
         definition: "A modern <code>package.json</code> field that defines the public entry points of your package. Allows conditional exports for ESM vs CJS, and controls which internal files consumers can import.",
         url: "https://nodejs.org/docs/latest/api/packages.html#exports",
-        source: "Node.js"
+        source: "Node.js",
+        sectionId: "packagejson"
       },
       {
         term: "main Field",
         definition: "The traditional <code>package.json</code> field specifying the primary entry point for your package (usually a CJS file). Being superseded by the <code>exports</code> field in modern packages.",
         url: "https://docs.npmjs.com/cli/configuring-npm/package-json#main",
-        source: "npm"
+        source: "npm",
+        sectionId: "packagejson"
       },
       {
         term: "dist (Distribution)",
         definition: "The compiled/built output of your package — the actual files that get published to npm and consumed by users. Typically contains JavaScript and declaration files, not source TypeScript.",
         url: "https://docs.npmjs.com/cli/configuring-npm/package-json#files",
-        source: "npm"
+        source: "npm",
+        sectionId: "dist"
       },
       {
         term: "files Field",
         definition: "A <code>package.json</code> field that specifies which files to include when publishing. Acts as an allowlist so only necessary files (like <code>dist/</code>) are included in the published package.",
         url: "https://docs.npmjs.com/cli/configuring-npm/package-json#files",
-        source: "npm"
+        source: "npm",
+        sectionId: "dist"
       },
     ]
   },
@@ -199,31 +226,36 @@ export const glossaryTerms: GlossaryCategory[] = [
         term: "Linting",
         definition: "Static analysis of code to find problems — style violations, potential bugs, unused variables, etc. ESLint is the standard JavaScript/TypeScript linter.",
         url: "https://eslint.org/docs/latest/use/getting-started",
-        source: "ESLint"
+        source: "ESLint",
+        sectionId: "ci-linting"
       },
       {
         term: "Monorepo",
         definition: "A single repository containing multiple related projects or packages. Tools like pnpm workspaces, Nx, or Turborepo help manage builds and dependencies across packages.",
         url: "https://pnpm.io/workspaces",
-        source: "pnpm"
+        source: "pnpm",
+        sectionId: "monorepo"
       },
       {
         term: "CI (Continuous Integration)",
         definition: "An automated process that runs tests, linting, and builds on every push or pull request. GitHub Actions is a common CI service for open-source packages.",
         url: "https://docs.github.com/en/actions/about-github-actions/understanding-github-actions",
-        source: "GitHub"
+        source: "GitHub",
+        sectionId: "ci-overview"
       },
       {
         term: "Git Hook",
         definition: "A script that runs automatically at specific points in the Git workflow (e.g., before commit or before push). Tools like Husky make it easy to add hooks for linting or testing.",
         url: "https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks",
-        source: "Git"
+        source: "Git",
+        sectionId: "workflow"
       },
       {
         term: "Storybook",
         definition: "A tool for developing and testing UI components in isolation, outside of your main application. Renders components with different props in a browsable catalog.",
         url: "https://storybook.js.org/docs/get-started",
-        source: "Storybook"
+        source: "Storybook",
+        sectionId: "storybook"
       },
     ]
   },


### PR DESCRIPTION
- Add sectionId to each glossary term linking to the corresponding guide section
- Convert GlossaryPage from static HTML to a sortable, filterable, searchable TanStack Table with category filter pills and a global search input
- Add glossary card to Start Page Learning Resources bonus section
- Reorder Start Page Learning Resources to match sidebar order
- Update CLAUDE.md with new patterns and TanStack Table dependency

https://claude.ai/code/session_0139gY9wtQVKzvmG5UPtPEPU