### PR TITLE
Separate External Resources tag filters into Type and Topic groups

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2128,11 +2128,33 @@
     color: var(--ink);
   }
 
+  .ref-filter-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    margin-bottom: 12px;
+  }
+
+  .ref-filter-group {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+
+  .ref-filter-label {
+    font-size: 11px;
+    font-weight: 600;
+    color: var(--muted);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    min-width: 42px;
+    flex-shrink: 0;
+  }
+
   .ref-badge-filters {
     display: flex;
     flex-wrap: wrap;
     gap: 6px;
-    margin-bottom: 12px;
     align-items: center;
   }
 

--- a/src/components/ExternalResourcesPage.tsx
+++ b/src/components/ExternalResourcesPage.tsx
@@ -9,7 +9,7 @@ import {
   type SortingState,
   type ColumnFiltersState,
 } from '@tanstack/react-table'
-import { overallResources, badgeMap } from '../data/overallResources'
+import { overallResources, badgeMap, typeTags, topicTags } from '../data/overallResources'
 import { sections } from '../data/sections'
 import { ciPages } from '../data/ciPages'
 import { bonusSections } from '../data/bonusSections'
@@ -114,11 +114,14 @@ export function ExternalResourcesPage() {
   const [globalFilter, setGlobalFilter] = useState('')
   const [tagFilter, setTagFilter] = useState<string[]>([])
 
-  // Collect all unique tags
-  const allTags = useMemo(() => {
+  // Collect unique tags split by category
+  const { typeTagList, topicTagList } = useMemo(() => {
     const set = new Set<string>()
     data.forEach(r => r.tags.forEach(b => set.add(b)))
-    return Array.from(set).sort()
+    return {
+      typeTagList: Array.from(set).filter(t => typeTags.has(t)).sort(),
+      topicTagList: Array.from(set).filter(t => topicTags.has(t)).sort(),
+    }
   }, [data])
 
   const columns = useMemo(() => [
@@ -230,21 +233,45 @@ export function ExternalResourcesPage() {
         </div>
 
         {/* Tag filters */}
-        <div className="ref-badge-filters">
-          {allTags.map(b => {
-            const badge = badgeMap[b]
-            if (!badge) return null
-            const isActive = tagFilter.includes(b)
-            return (
-              <button
-                key={b}
-                className={`ref-badge-btn resource-badge ${badge.cls} ${isActive ? 'ref-badge-active' : ''}`}
-                onClick={() => toggleTag(b)}
-              >
-                {badge.label}
-              </button>
-            )
-          })}
+        <div className="ref-filter-groups">
+          <div className="ref-filter-group">
+            <span className="ref-filter-label">Type</span>
+            <div className="ref-badge-filters">
+              {typeTagList.map(b => {
+                const badge = badgeMap[b]
+                if (!badge) return null
+                const isActive = tagFilter.includes(b)
+                return (
+                  <button
+                    key={b}
+                    className={`ref-badge-btn resource-badge ${badge.cls} ${isActive ? 'ref-badge-active' : ''}`}
+                    onClick={() => toggleTag(b)}
+                  >
+                    {badge.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
+          <div className="ref-filter-group">
+            <span className="ref-filter-label">Topic</span>
+            <div className="ref-badge-filters">
+              {topicTagList.map(b => {
+                const badge = badgeMap[b]
+                if (!badge) return null
+                const isActive = tagFilter.includes(b)
+                return (
+                  <button
+                    key={b}
+                    className={`ref-badge-btn resource-badge ${badge.cls} ${isActive ? 'ref-badge-active' : ''}`}
+                    onClick={() => toggleTag(b)}
+                  >
+                    {badge.label}
+                  </button>
+                )
+              })}
+            </div>
+          </div>
           {hasActiveFilters && (
             <button className="ref-clear-btn" onClick={clearFilters}>
               Clear filters

--- a/src/data/overallResources.ts
+++ b/src/data/overallResources.ts
@@ -70,14 +70,13 @@ export const overallResources: ResourceGroup[] = [
 ];
 
 export const badgeMap: Record<string, { cls: string; label: string }> = {
-  // Format
+  // Type
   docs: { cls: "rb-docs", label: "Docs" },
   article: { cls: "rb-article", label: "Article" },
   course: { cls: "rb-course", label: "Course" },
   video: { cls: "rb-video", label: "Video" },
   repo: { cls: "rb-repo", label: "Repo" },
   interactive: { cls: "rb-interactive", label: "Interactive" },
-  // Pricing
   free: { cls: "rb-free", label: "Free" },
   paid: { cls: "rb-paid", label: "Paid" },
   // Topic
@@ -92,3 +91,6 @@ export const badgeMap: Record<string, { cls: string; label: string }> = {
   testing: { cls: "rb-testing", label: "Testing" },
   linting: { cls: "rb-linting", label: "Linting" },
 };
+
+export const typeTags = new Set(["docs", "article", "course", "video", "repo", "interactive", "free", "paid"]);
+export const topicTags = new Set(["publishing", "typescript", "versioning", "ci-cd", "monorepo", "modules", "tooling", "bundling", "testing", "linting"]);


### PR DESCRIPTION
Split the flat tag filter bar into two labeled rows — "Type" (format
and pricing tags) and "Topic" (subject matter tags) — so users can
find resources more quickly by scanning the category they care about.

https://claude.ai/code/session_01FR2tKucVy3Pb332puLXjGV