### PR TITLE
Show Description column on mobile portrait for External Resources table

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -2235,6 +2235,4 @@
     .sidebar { width: 280px; }
     .header-section-name { font-size: 13px; }
     .ref-controls { flex-direction: column; }
-    .ref-table th:nth-child(2),
-    .ref-table td:nth-child(2) { display: none; }
   }


### PR DESCRIPTION
Remove the media query rule that hid the second table column (Description)
at viewport widths under 600px. The table wrapper already has overflow-x: auto,
so the full table remains scrollable on narrow screens.

https://claude.ai/code/session_01RWb5nVTo5f3kec1e5qaHjE