### PR TITLE
Add glossary term tooltips to content pages

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -287,6 +287,12 @@
     @apply flex items-center gap-3 py-3 border-b border-slate-100 dark:border-slate-800 text-sm flex-wrap;
   }
   .resource-row:last-child { @apply border-b-0; }
+
+  /* Glossary term inline annotation (used in enriched HTML strings) */
+  .glossary-term {
+    @apply border-b border-dashed border-current cursor-help transition-[border-bottom-style] duration-150;
+  }
+  .glossary-term:hover { border-bottom-style: solid; }
 }
 
 /* ── Badge variants (data-driven class names) ─────────────────────── */

--- a/src/components/BonusSectionPage.tsx
+++ b/src/components/BonusSectionPage.tsx
@@ -1,5 +1,6 @@
 import { bonusSections } from '../data/bonusSections'
 import { enrichFootnoteRefs } from '../helpers/renderFootnotes'
+import { enrichGlossaryTerms } from '../helpers/glossaryEnrich'
 import { HtmlContent } from './HtmlContent'
 import { Footnotes } from './Footnotes'
 import { PrevNextNav } from './PrevNextNav'
@@ -42,7 +43,7 @@ export function BonusSectionPage({ sectionId }: { sectionId: string }) {
       </div>`
   }
 
-  const enrichedHtml = enrichFootnoteRefs(html, section.links)
+  const enrichedHtml = enrichGlossaryTerms(enrichFootnoteRefs(html, section.links), sectionId)
 
   return (
     <>

--- a/src/components/CIPage.tsx
+++ b/src/components/CIPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useRef, useCallback } from 'react'
 import { ciPages } from '../data/ciPages'
 import { enrichFootnoteRefs } from '../helpers/renderFootnotes'
+import { enrichGlossaryTerms } from '../helpers/glossaryEnrich'
 import { HtmlContent } from './HtmlContent'
 import { Footnotes } from './Footnotes'
 import { PrevNextNav } from './PrevNextNav'
@@ -176,7 +177,7 @@ export function CIPage({ pageId }: { pageId: string }) {
     html += `<div class="ci-tip">${page.tip}</div>`
   }
 
-  const enrichedHtml = enrichFootnoteRefs(html, page.links)
+  const enrichedHtml = enrichGlossaryTerms(enrichFootnoteRefs(html, page.links), pageId)
 
   return (
     <div ref={contentRef} onClick={handleClick}>

--- a/src/components/GlossaryTooltip.tsx
+++ b/src/components/GlossaryTooltip.tsx
@@ -1,0 +1,153 @@
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { useNavigate } from '@tanstack/react-router'
+import clsx from 'clsx'
+import { getNavTitle } from '../data/navigation'
+
+interface TooltipData {
+  term: string
+  def: string
+  url: string
+  source: string
+  sectionId?: string
+  rect: DOMRect
+}
+
+const externalLinkSvg = `<svg class="w-3 h-3 align-middle shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/><polyline points="15 3 21 3 21 9"/><line x1="10" y1="14" x2="21" y2="3"/></svg>`
+
+export function GlossaryTooltip() {
+  const [data, setData] = useState<TooltipData | null>(null)
+  const [visible, setVisible] = useState(false)
+  const hideTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const tooltipRef = useRef<HTMLDivElement>(null)
+  const navigate = useNavigate()
+
+  const cancelHide = useCallback(() => {
+    if (hideTimer.current) {
+      clearTimeout(hideTimer.current)
+      hideTimer.current = null
+    }
+  }, [])
+
+  const scheduleHide = useCallback(() => {
+    cancelHide()
+    hideTimer.current = setTimeout(() => {
+      setVisible(false)
+      // Wait for fade-out transition before clearing data
+      setTimeout(() => setData(null), 150)
+    }, 150)
+  }, [cancelHide])
+
+  const hide = useCallback(() => {
+    cancelHide()
+    setVisible(false)
+    setTimeout(() => setData(null), 150)
+  }, [cancelHide])
+
+  useEffect(() => {
+    function onMouseOver(e: MouseEvent) {
+      const target = (e.target as HTMLElement).closest?.('.glossary-term') as HTMLElement | null
+      if (!target) return
+
+      cancelHide()
+
+      const rect = target.getBoundingClientRect()
+      setData({
+        term: target.dataset.glossaryTerm || '',
+        def: target.dataset.glossaryDef || '',
+        url: target.dataset.glossaryUrl || '',
+        source: target.dataset.glossarySource || '',
+        sectionId: target.dataset.glossarySection || undefined,
+        rect,
+      })
+      // Show after a microtask so the element is positioned before fading in
+      requestAnimationFrame(() => setVisible(true))
+    }
+
+    function onMouseOut(e: MouseEvent) {
+      const related = e.relatedTarget as HTMLElement | null
+      // If moving to the tooltip itself or another glossary-term, don't hide
+      if (related?.closest?.('.gt-tooltip') || related?.closest?.('.glossary-term')) return
+      scheduleHide()
+    }
+
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') hide()
+    }
+
+    function onScroll() {
+      hide()
+    }
+
+    document.addEventListener('mouseover', onMouseOver)
+    document.addEventListener('mouseout', onMouseOut)
+    document.addEventListener('keydown', onKeyDown)
+    window.addEventListener('scroll', onScroll, { passive: true })
+
+    return () => {
+      document.removeEventListener('mouseover', onMouseOver)
+      document.removeEventListener('mouseout', onMouseOut)
+      document.removeEventListener('keydown', onKeyDown)
+      window.removeEventListener('scroll', onScroll)
+      cancelHide()
+    }
+  }, [cancelHide, scheduleHide, hide])
+
+  if (!data) return null
+
+  // Position: below the term, centered horizontally
+  const { rect } = data
+  const tooltipWidth = 340
+  let left = rect.left + rect.width / 2 - tooltipWidth / 2
+  // Clamp to viewport
+  if (left < 8) left = 8
+  if (left + tooltipWidth > window.innerWidth - 8) left = window.innerWidth - 8 - tooltipWidth
+
+  // Show above if near bottom of viewport
+  const spaceBelow = window.innerHeight - rect.bottom
+  const showAbove = spaceBelow < 200
+  const top = showAbove ? rect.top + window.scrollY - 8 : rect.bottom + window.scrollY + 8
+
+  return (
+    <div
+      ref={tooltipRef}
+      className={clsx(
+        'gt-tooltip absolute z-[1200] bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg p-3 shadow-lg text-[13px] leading-relaxed text-slate-800 dark:text-slate-300 transition-[opacity,transform] duration-150',
+        visible
+          ? 'opacity-100 translate-y-0 pointer-events-auto'
+          : 'opacity-0 translate-y-1 pointer-events-none'
+      )}
+      style={{
+        left: `${left}px`,
+        top: `${top}px`,
+        width: `${tooltipWidth}px`,
+        transform: showAbove ? 'translateY(-100%)' : undefined,
+      }}
+      onMouseEnter={cancelHide}
+      onMouseLeave={scheduleHide}
+    >
+      <div className="font-semibold text-slate-900 dark:text-slate-100 mb-1">{data.term}</div>
+      <div className="text-slate-700 dark:text-slate-300 mb-2">{data.def}</div>
+      <div className="flex items-center gap-2.5 flex-wrap">
+        <a
+          className="inline-flex items-center gap-1 text-xs text-blue-500 dark:text-blue-400 no-underline font-medium hover:underline"
+          href={data.url}
+          target="_blank"
+          rel="noopener noreferrer"
+          dangerouslySetInnerHTML={{ __html: `${data.source} docs ${externalLinkSvg}` }}
+        />
+        {data.sectionId && (
+          <button
+            className="inline-flex items-center text-xs text-blue-500 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10 border-none rounded-full px-2.5 py-0.5 cursor-pointer font-medium whitespace-nowrap hover:bg-blue-500 hover:text-white dark:hover:bg-blue-500 dark:hover:text-white transition-colors duration-150"
+            onClick={() => {
+              hide()
+              navigate({ to: '/$sectionId', params: { sectionId: data.sectionId! } })
+              window.scrollTo({ top: 0, behavior: 'smooth' })
+            }}
+          >
+            → {getNavTitle(data.sectionId)}
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react'
 import { Outlet } from '@tanstack/react-router'
 import { FloatingHeader } from './FloatingHeader'
 import { Sidebar } from './Sidebar'
+import { GlossaryTooltip } from './GlossaryTooltip'
 
 export function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
@@ -42,6 +43,7 @@ export function Layout() {
         onClick={() => setSidebarOpen(false)}
       />
       <Sidebar open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      <GlossaryTooltip />
     </>
   )
 }

--- a/src/components/SectionPage.tsx
+++ b/src/components/SectionPage.tsx
@@ -1,6 +1,7 @@
 import { sections } from '../data/sections'
 import { codeExample } from '../data/codeExample'
 import { enrichFootnoteRefs } from '../helpers/renderFootnotes'
+import { enrichGlossaryTerms } from '../helpers/glossaryEnrich'
 import { HtmlContent } from './HtmlContent'
 import { Footnotes } from './Footnotes'
 import { PrevNextNav } from './PrevNextNav'
@@ -71,7 +72,7 @@ export function SectionPage({ sectionId }: { sectionId: string }) {
     html += `<div class="code-block">${codeExample}</div>`
   }
 
-  const enrichedHtml = enrichFootnoteRefs(html, s.links)
+  const enrichedHtml = enrichGlossaryTerms(enrichFootnoteRefs(html, s.links), sectionId)
 
   return (
     <>

--- a/src/helpers/glossaryEnrich.ts
+++ b/src/helpers/glossaryEnrich.ts
@@ -1,0 +1,156 @@
+import { glossaryTerms } from '../data/glossaryTerms'
+import type { GlossaryTerm } from '../data/glossaryTerms'
+
+interface FlatTerm extends GlossaryTerm {
+  category: string
+  /** Regex patterns to match this term in text */
+  patterns: RegExp[]
+}
+
+/** Strip HTML tags from a string (for data attributes) */
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]*>/g, '')
+}
+
+/** Escape special characters for use in HTML attribute values */
+function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
+}
+
+/**
+ * Build the flat list of terms with compiled regex patterns.
+ * Sorted by term length descending so longer terms match first
+ * (prevents "npm" matching before "npm registry").
+ */
+function buildTermList(): FlatTerm[] {
+  const flat: FlatTerm[] = glossaryTerms.flatMap(group =>
+    group.terms.map(t => {
+      const patterns: RegExp[] = []
+
+      // For terms like "ESM (ES Modules)" or "CI (Continuous Integration)",
+      // match both the full form and the abbreviation alone
+      const parenMatch = t.term.match(/^([^(]+)\s*\(/)
+      if (parenMatch) {
+        const abbrev = parenMatch[1].trim()
+        // Full term (escaped for regex)
+        patterns.push(new RegExp(`\\b${escapeRegex(t.term)}\\b`, 'i'))
+        // Just the abbreviation (case-sensitive for acronyms)
+        patterns.push(new RegExp(`\\b${escapeRegex(abbrev)}\\b`))
+      } else {
+        patterns.push(new RegExp(`\\b${escapeRegex(t.term)}\\b`, 'i'))
+      }
+
+      return { ...t, category: group.category, patterns }
+    })
+  )
+
+  // Sort longest first to prevent partial matches
+  flat.sort((a, b) => b.term.length - a.term.length)
+  return flat
+}
+
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+let cachedTerms: FlatTerm[] | null = null
+
+function getTerms(): FlatTerm[] {
+  if (!cachedTerms) cachedTerms = buildTermList()
+  return cachedTerms
+}
+
+/** Tags inside which we should NOT annotate terms */
+const SKIP_TAGS = new Set(['code', 'pre', 'a', 'button', 'h1', 'h2', 'h3'])
+
+/**
+ * Enrich HTML content by wrapping the first occurrence of each glossary term
+ * in a <span class="glossary-term" data-glossary-*> element.
+ *
+ * Skips terms inside <code>, <pre>, <a>, <button>, and heading elements.
+ * Only annotates the first match per term per call.
+ */
+export function enrichGlossaryTerms(html: string, currentSectionId?: string): string {
+  if (currentSectionId === 'glossary') return html
+
+  const terms = getTerms()
+  const matched = new Set<string>() // track which terms have been matched
+
+  // Split HTML into tags and text tokens
+  // Each token is either an HTML tag (starts with <) or a text node
+  const tokens = html.split(/(<[^>]*>)/)
+
+  // Track nesting of skip-tags
+  const skipStack: string[] = []
+
+  for (let i = 0; i < tokens.length; i++) {
+    const token = tokens[i]
+    if (!token) continue
+
+    // HTML tag
+    if (token.startsWith('<')) {
+      const closeMatch = token.match(/^<\/(\w+)/)
+      const openMatch = token.match(/^<(\w+)/)
+      if (closeMatch) {
+        const tag = closeMatch[1].toLowerCase()
+        // Pop from skip stack if it matches
+        if (skipStack.length > 0 && skipStack[skipStack.length - 1] === tag) {
+          skipStack.pop()
+        }
+      } else if (openMatch) {
+        const tag = openMatch[1].toLowerCase()
+        if (SKIP_TAGS.has(tag) && !token.endsWith('/>')) {
+          skipStack.push(tag)
+        }
+      }
+      continue
+    }
+
+    // Text node — skip if inside a skip-tag
+    if (skipStack.length > 0) continue
+
+    // Try to match glossary terms in this text
+    let text = token
+    let modified = false
+
+    for (const term of terms) {
+      if (matched.has(term.term)) continue
+
+      for (const pattern of term.patterns) {
+        const match = pattern.exec(text)
+        if (match) {
+          matched.add(term.term)
+          modified = true
+
+          const before = text.slice(0, match.index)
+          const matchedText = match[0]
+          const after = text.slice(match.index + matchedText.length)
+
+          const plainDef = escapeAttr(stripHtml(term.definition))
+          const sectionAttr =
+            term.sectionId && term.sectionId !== currentSectionId
+              ? ` data-glossary-section="${escapeAttr(term.sectionId)}"`
+              : ''
+
+          const span =
+            `<span class="glossary-term"` +
+            ` data-glossary-term="${escapeAttr(term.term)}"` +
+            ` data-glossary-def="${plainDef}"` +
+            ` data-glossary-url="${escapeAttr(term.url)}"` +
+            ` data-glossary-source="${escapeAttr(term.source)}"` +
+            sectionAttr +
+            `>${matchedText}</span>`
+
+          text = before + span + after
+          break // one pattern match is enough
+        }
+      }
+    }
+
+    if (modified) {
+      tokens[i] = text
+    }
+  }
+
+  return tokens.join('')
+}


### PR DESCRIPTION
Annotate the first occurrence of each glossary term on Section, CI, and Bonus pages with an interactive hover tooltip showing the definition, an external docs link, and an in-app navigation pill when the term links to a different page. Terms are matched longest-first to avoid partial matches and skipped inside code/pre/anchor/heading elements.

https://claude.ai/code/session_019c8NQNkUvkQ5L5MPXZjTQG