### PR TITLE
Remove toc-indent CSS class and its usage

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -56,7 +56,7 @@
     @apply block text-sm text-blue-500 dark:text-blue-400 no-underline py-0.5 cursor-pointer transition-colors duration-150;
   }
   .toc-link:hover { @apply text-slate-900 dark:text-slate-100; }
-  .toc-link.toc-indent { @apply pl-3 text-xs; }
+
   [id^="toc-"] { scroll-margin-top: 68px; }
 
   /* Columns layout */

--- a/src/components/BonusSectionPage.tsx
+++ b/src/components/BonusSectionPage.tsx
@@ -22,7 +22,7 @@ export function BonusSectionPage({ sectionId }: { sectionId: string }) {
 
   if (tocEntries.length >= 3) {
     html += `<div class="section-toc"><div class="section-toc-title">On this page</div>`
-    tocEntries.forEach(e => { html += `<a class="toc-link${e.level === 2 ? ' toc-indent' : ''}" data-toc="${e.id}">${e.label}</a>` })
+    tocEntries.forEach(e => { html += `<a class="toc-link" data-toc="${e.id}">${e.label}</a>` })
     html += `</div>`
   }
 

--- a/src/components/SectionPage.tsx
+++ b/src/components/SectionPage.tsx
@@ -34,7 +34,7 @@ export function SectionPage({ sectionId }: { sectionId: string }) {
   if (tocEntries.length >= 3) {
     html += `<div class="section-toc"><div class="section-toc-title">On this page</div>`
     tocEntries.forEach(e => {
-      html += `<a class="toc-link${e.level === 2 ? ' toc-indent' : ''}" data-toc="${e.id}">${e.label}</a>`
+      html += `<a class="toc-link" data-toc="${e.id}">${e.label}</a>`
     })
     html += `</div>`
   }


### PR DESCRIPTION
The toc-indent class added left padding and smaller font size to level-2 TOC entries. Remove the CSS rule from App.css and simplify the TOC link generation in SectionPage and BonusSectionPage to no longer conditionally apply the class.

https://claude.ai/code/session_01GKRW6V7NEMG2xvm8NCrq98