### PR TITLE
Add interactive tooltips for footnote references on hover

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -243,6 +243,23 @@
   }
   sup.fn-ref:hover { @apply bg-blue-700 dark:bg-blue-500; }
 
+  /* Footnote tooltip */
+  .fn-tooltip {
+    @apply absolute z-50 max-w-72 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg px-3.5 py-2.5 text-sm leading-normal;
+    animation: fadeIn 0.12s ease-out;
+  }
+  .fn-tooltip-link {
+    @apply text-blue-500 dark:text-blue-400 font-semibold no-underline inline-flex items-center gap-1;
+  }
+  .fn-tooltip-link:hover { @apply underline; }
+  .fn-tooltip-ext { @apply w-3 h-3 shrink-0 opacity-60; }
+  .fn-tooltip-source {
+    @apply text-xs font-semibold text-slate-600 dark:text-slate-400 bg-slate-100 dark:bg-slate-700 px-1.5 py-px rounded uppercase tracking-wide ml-1.5;
+  }
+  .fn-tooltip-note {
+    @apply text-xs text-slate-600 dark:text-slate-400 leading-relaxed mt-1.5 mb-0;
+  }
+
   .further-reading-item {
     @apply flex items-baseline gap-1.5 py-1 text-sm leading-normal;
   }

--- a/src/helpers/renderFootnotes.ts
+++ b/src/helpers/renderFootnotes.ts
@@ -54,9 +54,10 @@ export function enrichFootnoteRefs(html: string, links?: SectionLink[]): string 
     const idx = parseInt(num) - 1
     if (idx >= 0 && idx < links.length) {
       const link = links[idx]
-      const escapedLabel = link.label.replace(/"/g, '&quot;')
-      const escapedUrl = link.url.replace(/"/g, '&quot;')
-      return `data-fn="${num}" data-fn-url="${escapedUrl}" title="${escapedLabel}"`
+      const esc = (s: string) => s.replace(/"/g, '&quot;')
+      let attrs = `data-fn="${num}" data-fn-url="${esc(link.url)}" data-fn-label="${esc(link.label)}" data-fn-source="${esc(link.source)}"`
+      if (link.note) attrs += ` data-fn-note="${esc(link.note)}"`
+      return attrs
     }
     return _match
   })


### PR DESCRIPTION
## Summary
Enhanced the footnote reference interaction by adding interactive tooltips that appear on hover, displaying footnote metadata (label, source, and note) before the user clicks to navigate.

## Key Changes
- **Tooltip UI**: Added a styled tooltip component that displays above footnote references on hover, showing the footnote label as a clickable link with an external link icon, plus optional source and note information
- **Hover interactions**: Implemented `mouseenter` and `mouseleave` event listeners to show/hide tooltips with proper positioning logic that keeps tooltips within viewport bounds
- **Tooltip positioning**: Tooltips are positioned above the footnote reference with intelligent left-alignment to prevent overflow at screen edges
- **Enhanced data attributes**: Extended footnote reference data attributes to include `data-fn-label`, `data-fn-source`, and `data-fn-note` for tooltip content
- **Styling**: Added comprehensive CSS for tooltip appearance with dark mode support, including fade-in animation and proper spacing for nested elements
- **Click behavior**: Preserved existing click functionality to open footnote URLs in new tabs

## Implementation Details
- Tooltips are appended to `document.body` for proper z-index stacking and positioning context
- Active tooltip state is tracked to prevent multiple simultaneous tooltips and enable proper cleanup
- Mouse event handling includes cross-element tracking to keep tooltips visible when moving between the footnote reference and tooltip itself
- Tooltip content is safely escaped to prevent XSS vulnerabilities
- The solution maintains backward compatibility with existing footnote functionality

https://claude.ai/code/session_01YWyUZxvBqiYPcP48NdXttA