### PR TITLE
Fix superscript vertical alignment in dark mode

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,6 +14,9 @@
     -webkit-font-smoothing: antialiased;
     transition: background 0.2s ease, color 0.2s ease;
   }
+  sup {
+    top: 0;
+  }
 }
 
 /* ── @apply component classes for HTML template strings ───────────── */


### PR DESCRIPTION
## Summary
Added CSS styling to fix the vertical alignment of superscript (`<sup>`) elements within the dark mode theme.

## Changes
- Added `top: 0;` property to the `sup` selector within the dark mode media query to ensure superscript elements are properly positioned and aligned

## Details
This change addresses a visual alignment issue with superscript text in dark mode by explicitly setting the top position to 0, preventing any unwanted vertical offset that may have been caused by default browser styling or inherited properties.

https://claude.ai/code/session_01DmXux2QWtfBs7AVwGhHheY