### PR TITLE
Configure MDX provider import source for React

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,7 +8,10 @@ import remarkMdxFrontmatter from 'remark-mdx-frontmatter'
 export default defineConfig({
   plugins: [
     tailwindcss(),
-    mdx({ remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter] }),
+    mdx({
+      providerImportSource: '@mdx-js/react',
+      remarkPlugins: [remarkFrontmatter, remarkMdxFrontmatter],
+    }),
     react(),
   ],
   base: '/npm-package-guide/',


### PR DESCRIPTION
## Summary
Updated the MDX plugin configuration to explicitly specify the provider import source, enabling proper MDX context provider functionality with React.

## Changes
- Added `providerImportSource: '@mdx-js/react'` to the MDX plugin configuration in `vite.config.ts`
- This allows MDX components to access React context providers and improves compatibility with the MDX ecosystem

## Implementation Details
The `providerImportSource` option tells the MDX compiler where to import the provider component from. By setting it to `'@mdx-js/react'`, we enable the use of MDX's built-in React provider, which is necessary for features like custom component contexts and proper React integration in MDX documents.

https://claude.ai/code/session_01BFWJuecW6dZBuLHLHhASW6