### PR TITLE
Fix insertBefore null error in glossary DOM enrichment

### DIFF
--- a/src/helpers/glossaryEnrichDOM.ts
+++ b/src/helpers/glossaryEnrichDOM.ts
@@ -102,7 +102,8 @@ export function enrichGlossaryTermsDOM(container: HTMLElement, currentSectionId?
           }
           span.textContent = matchedText
 
-          const parent = textNode.parentNode!
+          const parent = textNode.parentNode
+          if (!parent) break
           if (before) parent.insertBefore(document.createTextNode(before), textNode)
           parent.insertBefore(span, textNode)
           if (after) parent.insertBefore(document.createTextNode(after), textNode)


### PR DESCRIPTION
When React re-renders during page navigation, text nodes collected by
the tree walker can become detached from the DOM, making parentNode
null. Replace the non-null assertion with a proper null guard so
detached nodes are safely skipped instead of crashing.

https://claude.ai/code/session_01Ljc4LLXsCvkoiwKsAS7s8c