### PR TITLE
Add guides index page and restructure routing

### DIFF
--- a/src/components/FloatingHeader.tsx
+++ b/src/components/FloatingHeader.tsx
@@ -1,8 +1,7 @@
-import { useParams } from '@tanstack/react-router'
+import { useParams, useNavigate } from '@tanstack/react-router'
 import clsx from 'clsx'
 import { PMDropdown } from './PMDropdown'
 import { useTheme } from '../hooks/useTheme'
-import { useNavigateToSection } from '../hooks/useNavigateToSection'
 
 interface FloatingHeaderProps {
   scrolled: boolean
@@ -10,14 +9,14 @@ interface FloatingHeaderProps {
 }
 
 export function FloatingHeader({ scrolled, onMenuToggle }: FloatingHeaderProps) {
-  const navigateToSection = useNavigateToSection()
+  const navigate = useNavigate()
   const params = useParams({ strict: false }) as { sectionId?: string }
-  const sectionId = params.sectionId || 'roadmap'
-  const isHome = sectionId === 'roadmap'
+  const isGuidesIndex = !params.sectionId
   const { theme, toggleTheme } = useTheme()
 
   const handleHomeClick = () => {
-    navigateToSection('roadmap')
+    navigate({ to: '/' })
+    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   return (
@@ -39,10 +38,10 @@ export function FloatingHeader({ scrolled, onMenuToggle }: FloatingHeaderProps) 
           </span>
         </button>
         <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 whitespace-nowrap overflow-hidden text-ellipsis min-w-0 max-sm:text-sm">
-          Web App vs. NPM Package Guide
+          {isGuidesIndex ? 'Frontend Guides' : 'Web App vs. NPM Package Guide'}
         </span>
         <div className="ml-auto relative shrink-0 flex items-center gap-2">
-          {!isHome && (
+          {!isGuidesIndex && (
             <button
               className="flex items-center gap-1.5 font-sans text-xs font-semibold h-9 px-2.5 rounded-lg bg-transparent text-gray-500 dark:text-slate-400 border border-slate-200 dark:border-slate-700 cursor-pointer transition-all duration-150 whitespace-nowrap hover:border-blue-500 dark:hover:border-blue-400 hover:text-blue-500 dark:hover:text-blue-400"
               onClick={handleHomeClick}
@@ -52,7 +51,7 @@ export function FloatingHeader({ scrolled, onMenuToggle }: FloatingHeaderProps) 
                 <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
                 <polyline points="9 22 9 12 15 12 15 22"/>
               </svg>
-              Start Here
+              All Guides
             </button>
           )}
           <button

--- a/src/components/GuidesIndexPage.tsx
+++ b/src/components/GuidesIndexPage.tsx
@@ -1,0 +1,66 @@
+import { useNavigate } from '@tanstack/react-router'
+
+interface GuideTile {
+  id: string
+  icon: string
+  title: string
+  description: string
+}
+
+const guides: GuideTile[] = [
+  {
+    id: 'npm-package',
+    icon: '\u{1F4E6}',
+    title: 'Web App vs. NPM Package',
+    description:
+      'Learn the differences between building a web app and an npm package, from project setup through CI/CD and publishing.',
+  },
+]
+
+export function GuidesIndexPage() {
+  const navigate = useNavigate()
+
+  return (
+    <div>
+      <div className="mb-7">
+        <h1 className="text-3xl font-bold tracking-tight mb-1">Frontend Guides</h1>
+        <p className="text-gray-500 dark:text-slate-400 text-sm">
+          Practical guides for backend engineers stepping into the frontend world.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-5 mt-8">
+        {guides.map((guide) => (
+          <button
+            key={guide.id}
+            className="flex flex-col items-start text-left p-6 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl cursor-pointer transition-all duration-150 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 hover:-translate-y-0.5"
+            onClick={() =>
+              navigate({
+                to: '/$sectionId',
+                params: { sectionId: 'roadmap' },
+              })
+            }
+          >
+            <span className="text-3xl mb-3">{guide.icon}</span>
+            <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100 mb-2">
+              {guide.title}
+            </h2>
+            <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+              {guide.description}
+            </p>
+          </button>
+        ))}
+
+        <div className="flex flex-col items-start text-left p-6 bg-slate-50 dark:bg-slate-800/50 border border-dashed border-slate-300 dark:border-slate-600 rounded-xl">
+          <span className="text-3xl mb-3">{'\u{1F6A7}'}</span>
+          <h2 className="text-lg font-bold text-slate-400 dark:text-slate-500 mb-2">
+            More to come...
+          </h2>
+          <p className="text-sm text-slate-400 dark:text-slate-500 leading-relaxed">
+            Additional guides are in the works. Stay tuned!
+          </p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { useParams } from '@tanstack/react-router'
+import { useParams, useNavigate } from '@tanstack/react-router'
 import clsx from 'clsx'
 import { contentPages } from '../content/registry'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
@@ -51,13 +51,20 @@ function resolveItems(ids: string[]) {
 }
 
 export function Sidebar({ open, onClose }: SidebarProps) {
+  const navigate = useNavigate()
   const navigateToSection = useNavigateToSection()
   const params = useParams({ strict: false }) as { sectionId?: string }
-  const currentId = params.sectionId || 'roadmap'
+  const currentId = params.sectionId || ''
 
   const handleNav = (id: string) => {
     onClose()
     navigateToSection(id)
+  }
+
+  const handleGuidesHome = () => {
+    onClose()
+    navigate({ to: '/' })
+    window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
   const topItems = [
@@ -92,6 +99,21 @@ export function Sidebar({ open, onClose }: SidebarProps) {
         </button>
       </div>
       <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-0.5">
+        <button
+          className={clsx(
+            'flex items-center w-full text-left px-3.5 py-2 text-sm rounded-lg border-none bg-transparent cursor-pointer transition-all duration-150',
+            !currentId
+              ? 'bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 font-semibold'
+              : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
+          )}
+          onClick={handleGuidesHome}
+          data-testid="sidebar-item-guides-home"
+        >
+          <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">All Guides</span>
+          <span className="ml-2 text-base leading-none opacity-70 shrink-0">{'\u{1F4CB}'}</span>
+        </button>
+
+        <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 uppercase tracking-wider mt-5 mb-1.5 px-3.5">Web App vs. NPM Package</div>
         {topItems.map(item => (
           <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
         ))}

--- a/src/hooks/useNavigateToSection.ts
+++ b/src/hooks/useNavigateToSection.ts
@@ -4,11 +4,7 @@ import { useNavigate } from '@tanstack/react-router'
 export function useNavigateToSection() {
   const navigate = useNavigate()
   return useCallback((id: string) => {
-    if (id === 'roadmap') {
-      navigate({ to: '/' })
-    } else {
-      navigate({ to: '/$sectionId', params: { sectionId: id } })
-    }
+    navigate({ to: '/$sectionId', params: { sectionId: id } })
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }, [navigate])
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,5 +1,6 @@
 import { createRouter, createRoute, createRootRoute, createHashHistory } from '@tanstack/react-router'
 import { Layout } from './components/Layout'
+import { GuidesIndexPage } from './components/GuidesIndexPage'
 import { RoadmapPage } from './components/RoadmapPage'
 import { ChecklistPage } from './components/ChecklistPage'
 import { ExternalResourcesPage } from './components/ExternalResourcesPage'
@@ -14,7 +15,7 @@ const rootRoute = createRootRoute({
 const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/',
-  component: RoadmapPage,
+  component: GuidesIndexPage,
 })
 
 // eslint-disable-next-line react-refresh/only-export-components


### PR DESCRIPTION
## Summary
This PR introduces a new guides index page that serves as the home/landing page for the application, replacing the previous direct navigation to the roadmap. The routing structure has been reorganized to support multiple guides with the roadmap becoming one of several available guides.

## Key Changes
- **New GuidesIndexPage component**: Created a new landing page that displays available guides in a grid layout with support for future guide additions. Currently features the "Web App vs. NPM Package" guide.
- **Updated routing**: Changed the root path (`/`) to render `GuidesIndexPage` instead of `RoadmapPage`, with the roadmap now accessible via `/$sectionId` parameter.
- **Sidebar navigation updates**: 
  - Added "All Guides" button at the top of the sidebar to navigate back to the guides index
  - Added section header for the current guide being viewed
  - Updated active state logic to reflect the new routing structure
- **FloatingHeader refinements**: 
  - Updated home button to navigate to guides index instead of roadmap
  - Changed header title to display "Frontend Guides" when on the index page
  - Updated button label from "Start Here" to "All Guides"
- **Navigation hook simplification**: Removed special-case handling for 'roadmap' in `useNavigateToSection` since all guides now use the same `/$sectionId` route pattern.

## Implementation Details
- The guides index page uses a responsive grid layout (1 column on mobile, 2 columns on tablet+) with hover effects and smooth transitions
- Includes a placeholder "More to come..." section to indicate future guide additions
- Navigation maintains scroll-to-top behavior for better UX when switching between guides
- Dark mode support is maintained throughout all new and modified components

https://claude.ai/code/session_01S1dBKiQ4fhmjnxh1TRaCp4