### PR TITLE
Refactor sidebar to icon rail + content panel layout

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -366,7 +366,3 @@ body.pnpm .cmd-npm { display: none; }
   to { opacity: 1; transform: translateY(0); }
 }
 
-/* ── Responsive ───────────────────────────────────────────────────── */
-@media (max-width: 600px) {
-  .sidebar { width: 280px !important; }
-}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -9,6 +9,82 @@ interface SidebarProps {
   onClose: () => void
 }
 
+// ── Guide data structure ──────────────────────────────────────────────
+
+interface GuideSection { label: string | null; ids: string[] }
+interface GuideDefinition { id: string; icon: string; title: string; sections: GuideSection[] }
+
+const buildingPackageOrder = [
+  'bigpicture', 'monorepo', 'npm-vs-pnpm',
+  'build', 'tsconfig', 'deps', 'dist',
+  'packagejson', 'typescript', 'versioning', 'workflow',
+]
+
+const ciOrder = [
+  'ci-overview', 'ci-linting', 'ci-build', 'ci-testing', 'ci-repo-maintenance',
+]
+
+const bonusOrder = ['storybook']
+
+const guides: GuideDefinition[] = [
+  {
+    id: 'npm-package',
+    icon: '\u{1F4E6}',        // 📦
+    title: 'Web App vs. NPM Package',
+    sections: [
+      { label: null, ids: ['roadmap'] },
+      { label: 'Building a Package', ids: buildingPackageOrder },
+      { label: 'CI Pipeline & Checks', ids: ciOrder },
+      { label: 'Developer Experience', ids: bonusOrder },
+      { label: 'Learning Resources', ids: ['checklist', 'external-resources', 'glossary'] },
+    ],
+  },
+  {
+    id: 'architecture',
+    icon: '\u{1F3D7}\uFE0F',  // 🏗️
+    title: 'Architecture Guide',
+    sections: [
+      { label: null, ids: ['architecture'] },
+    ],
+  },
+]
+
+const allGuidePageIds = new Map<string, string>()
+for (const guide of guides) {
+  for (const section of guide.sections) {
+    for (const id of section.ids) {
+      allGuidePageIds.set(id, guide.id)
+    }
+  }
+}
+
+function findGuideForPage(pageId: string): GuideDefinition | undefined {
+  const guideId = allGuidePageIds.get(pageId)
+  return guideId ? guides.find(g => g.id === guideId) : undefined
+}
+
+// ── Title resolution (special pages aren't in contentPages) ───────────
+
+const titleOverrides: Record<string, string> = {
+  'roadmap': '\u{1F680} Start Here',
+  'checklist': '\u2705 Publish Checklist',
+  'external-resources': '\u{1F4DA} External Resources',
+  'glossary': '\u{1F4D6} Glossary',
+  'architecture': '\u{1F3D7}\uFE0F Architecture Guide',
+}
+
+function resolveItems(ids: string[]) {
+  return ids
+    .map(id => {
+      if (titleOverrides[id]) return { id, title: titleOverrides[id] }
+      const page = contentPages.get(id)
+      return page ? { id: page.id, title: page.title } : null
+    })
+    .filter((item): item is { id: string; title: string } => item !== null)
+}
+
+// ── Sub-components ────────────────────────────────────────────────────
+
 function SidebarItem({ id, title, active, onClick }: { id: string; title: string; active: boolean; onClick: (id: string) => void }) {
   const match = title.match(/^(\S+)\s+(.+)$/)
   const icon = match ? match[1] : ''
@@ -30,34 +106,121 @@ function SidebarItem({ id, title, active, onClick }: { id: string; title: string
   )
 }
 
-const buildingPackageOrder = [
-  'bigpicture', 'monorepo', 'npm-vs-pnpm',
-  'build', 'tsconfig', 'deps', 'dist',
-  'packagejson', 'typescript', 'versioning', 'workflow',
-]
+function IconRail({
+  activeGuideId,
+  onSelectGuide,
+  onHomeClick,
+  currentId,
+}: {
+  activeGuideId: string | null
+  onSelectGuide: (guideId: string) => void
+  onHomeClick: () => void
+  currentId: string
+}) {
+  return (
+    <div className="flex flex-col items-center w-[52px] shrink-0 border-r border-slate-200 dark:border-slate-700 py-3 gap-1">
+      {/* Home button */}
+      <button
+        className={clsx(
+          'flex items-center justify-center w-10 h-10 rounded-lg border-none cursor-pointer transition-all duration-150',
+          !currentId
+            ? 'bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400'
+            : 'bg-transparent text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800'
+        )}
+        onClick={onHomeClick}
+        title="All Guides"
+        data-testid="sidebar-home-icon"
+      >
+        <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
+          <polyline points="9 22 9 12 15 12 15 22"/>
+        </svg>
+      </button>
 
-const ciOrder = [
-  'ci-overview', 'ci-linting', 'ci-build', 'ci-testing', 'ci-repo-maintenance',
-]
+      <div className="w-6 h-px bg-slate-200 dark:bg-slate-700 my-1.5" />
 
-const bonusOrder = ['storybook']
-
-const allNpmGuideIds = new Set([
-  'roadmap',
-  ...buildingPackageOrder,
-  ...ciOrder,
-  ...bonusOrder,
-  'checklist', 'external-resources', 'glossary',
-])
-
-function resolveItems(ids: string[]) {
-  return ids
-    .map(id => {
-      const page = contentPages.get(id)
-      return page ? { id: page.id, title: page.title } : null
-    })
-    .filter((item): item is { id: string; title: string } => item !== null)
+      {/* Guide icons */}
+      {guides.map(guide => (
+        <button
+          key={guide.id}
+          className={clsx(
+            'flex items-center justify-center w-10 h-10 rounded-lg border-none cursor-pointer transition-all duration-150',
+            activeGuideId === guide.id
+              ? 'bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400'
+              : 'bg-transparent text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800'
+          )}
+          onClick={() => onSelectGuide(guide.id)}
+          title={guide.title}
+          data-testid={`sidebar-guide-icon-${guide.id}`}
+        >
+          <span className="text-lg leading-none">{guide.icon}</span>
+        </button>
+      ))}
+    </div>
+  )
 }
+
+function ContentPanel({
+  guide,
+  currentId,
+  onNav,
+  onClose,
+}: {
+  guide: GuideDefinition | null
+  currentId: string
+  onNav: (id: string) => void
+  onClose: () => void
+}) {
+  return (
+    <div className="flex-1 flex flex-col min-w-0">
+      {/* Header */}
+      <div className="flex items-center justify-between px-4 h-13 border-b border-slate-200 dark:border-slate-700 shrink-0">
+        <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
+          {guide ? guide.title : 'Navigation'}
+        </span>
+        <button
+          className="flex items-center justify-center w-7 h-7 bg-transparent border-none cursor-pointer text-lg text-gray-400 dark:text-slate-500 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-600 dark:hover:text-slate-300 transition-colors duration-150"
+          onClick={onClose}
+          data-testid="sidebar-close"
+        >
+          &#x2715;
+        </button>
+      </div>
+
+      {/* Navigation links */}
+      {guide ? (
+        <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-0.5">
+          {guide.sections.map((section, idx) => (
+            <div key={idx}>
+              {section.label && (
+                <div className={clsx(
+                  'text-xs font-semibold text-gray-400 dark:text-slate-500 uppercase tracking-wider mb-1.5 px-3.5',
+                  idx === 0 ? 'mt-1' : 'mt-4'
+                )}>
+                  {section.label}
+                </div>
+              )}
+              {resolveItems(section.ids).map(item => (
+                <SidebarItem
+                  key={item.id}
+                  {...item}
+                  active={currentId === item.id}
+                  onClick={onNav}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div className="flex-1 flex items-center justify-center p-6">
+          <span className="text-sm text-slate-400 dark:text-slate-500">Select a guide</span>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Main Sidebar ──────────────────────────────────────────────────────
 
 export function Sidebar({ open, onClose }: SidebarProps) {
   const navigate = useNavigate()
@@ -65,10 +228,23 @@ export function Sidebar({ open, onClose }: SidebarProps) {
   const params = useParams({ strict: false }) as { sectionId?: string }
   const currentId = params.sectionId || ''
 
-  const isInNpmGuide = allNpmGuideIds.has(currentId)
-  const isInArchGuide = currentId === 'architecture'
-  const [npmExpanded, setNpmExpanded] = useState(isInNpmGuide)
-  const [archExpanded, setArchExpanded] = useState(isInArchGuide)
+  const [activeGuideId, setActiveGuideId] = useState<string | null>(() => {
+    return findGuideForPage(currentId)?.id ?? null
+  })
+
+  // Re-sync active guide when sidebar transitions from closed to open
+  const [prevOpen, setPrevOpen] = useState(false)
+  if (open !== prevOpen) {
+    setPrevOpen(open)
+    if (open) {
+      const expected = findGuideForPage(currentId)?.id ?? null
+      if (expected !== activeGuideId) {
+        setActiveGuideId(expected)
+      }
+    }
+  }
+
+  const activeGuide = guides.find(g => g.id === activeGuideId) ?? null
 
   const handleNav = (id: string) => {
     onClose()
@@ -81,147 +257,26 @@ export function Sidebar({ open, onClose }: SidebarProps) {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
-  const topItems = [
-    { id: 'roadmap', title: '\u{1F680} Start Here' },
-  ]
-
-  const buildingPackageItems = resolveItems(buildingPackageOrder)
-  const ciItems = resolveItems(ciOrder)
-  const bonusItems = resolveItems(bonusOrder)
-
-  const resourceItems = [
-    { id: 'checklist', title: '\u2705 Publish Checklist' },
-    { id: 'external-resources', title: '\u{1F4DA} External Resources' },
-    { id: 'glossary', title: '\u{1F4D6} Glossary' },
-  ]
-
   return (
     <div
       data-testid="sidebar"
       className={clsx(
-      'sidebar fixed top-0 left-0 bottom-0 w-80 max-sm:w-70 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 z-100 flex flex-col transition-transform duration-250 -translate-x-full',
-      open && 'translate-x-0'
-    )}>
-      <div className="flex items-center justify-between px-4 h-13 border-b border-slate-200 dark:border-slate-700 shrink-0">
-        <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">Navigation</span>
-        <button
-          className="flex items-center justify-center w-7 h-7 bg-transparent border-none cursor-pointer text-lg text-gray-400 dark:text-slate-500 rounded-md hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-600 dark:hover:text-slate-300 transition-colors duration-150"
-          onClick={onClose}
-          data-testid="sidebar-close"
-        >
-          &#x2715;
-        </button>
-      </div>
-      <div className="flex-1 overflow-y-auto p-3 flex flex-col gap-0.5">
-        {/* Level 1: Guides index */}
-        <button
-          className={clsx(
-            'flex items-center w-full text-left px-3.5 py-2 text-sm rounded-lg border-none bg-transparent cursor-pointer transition-all duration-150',
-            !currentId
-              ? 'bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 font-semibold'
-              : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
-          )}
-          onClick={handleGuidesHome}
-          data-testid="sidebar-item-guides-home"
-        >
-          <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">All Guides</span>
-          <span className="ml-2 text-base leading-none opacity-70 shrink-0">{'\u{1F4CB}'}</span>
-        </button>
-
-        {/* Level 1: Guide — Web App vs. NPM Package */}
-        <button
-          className={clsx(
-            'flex items-center w-full text-left px-3.5 py-2.5 text-sm font-semibold rounded-lg border-none bg-transparent cursor-pointer transition-all duration-150 mt-3',
-            isInNpmGuide
-              ? 'text-blue-600 dark:text-blue-400'
-              : 'text-slate-800 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800'
-          )}
-          onClick={() => setNpmExpanded(prev => !prev)}
-          data-testid="sidebar-guide-npm"
-        >
-          <span className="mr-2 text-base shrink-0">{'\u{1F4E6}'}</span>
-          <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">Web App vs. NPM Package</span>
-          <svg
-            className={clsx(
-              'w-3.5 h-3.5 shrink-0 ml-2 transition-transform duration-200',
-              npmExpanded && 'rotate-90'
-            )}
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <polyline points="9 18 15 12 9 6" />
-          </svg>
-        </button>
-
-        {/* Level 2: NPM guide sections */}
-        {npmExpanded && (
-          <div className="pl-3 flex flex-col gap-0.5">
-            {topItems.map(item => (
-              <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
-            ))}
-
-            <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 uppercase tracking-wider mt-4 mb-1.5 px-3.5">Building a Package</div>
-            {buildingPackageItems.map(item => (
-              <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
-            ))}
-
-            <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 uppercase tracking-wider mt-4 mb-1.5 px-3.5">CI Pipeline &amp; Checks</div>
-            {ciItems.map(item => (
-              <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
-            ))}
-
-            <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 uppercase tracking-wider mt-4 mb-1.5 px-3.5">Developer Experience</div>
-            {bonusItems.map(item => (
-              <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
-            ))}
-
-            <div className="text-xs font-semibold text-gray-400 dark:text-slate-500 uppercase tracking-wider mt-4 mb-1.5 px-3.5">Learning Resources</div>
-            {resourceItems.map(item => (
-              <SidebarItem key={item.id} {...item} active={currentId === item.id} onClick={handleNav} />
-            ))}
-          </div>
-        )}
-
-        {/* Level 1: Guide — Architecture Guide */}
-        <button
-          className={clsx(
-            'flex items-center w-full text-left px-3.5 py-2.5 text-sm font-semibold rounded-lg border-none bg-transparent cursor-pointer transition-all duration-150 mt-3',
-            isInArchGuide
-              ? 'text-blue-600 dark:text-blue-400'
-              : 'text-slate-800 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800'
-          )}
-          onClick={() => setArchExpanded(prev => !prev)}
-          data-testid="sidebar-guide-architecture"
-        >
-          <span className="mr-2 text-base shrink-0">{'\u{1F3D7}\uFE0F'}</span>
-          <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">Architecture Guide</span>
-          <svg
-            className={clsx(
-              'w-3.5 h-3.5 shrink-0 ml-2 transition-transform duration-200',
-              archExpanded && 'rotate-90'
-            )}
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <polyline points="9 18 15 12 9 6" />
-          </svg>
-        </button>
-
-        {/* Level 2: Architecture guide sections */}
-        {archExpanded && (
-          <div className="pl-3 flex flex-col gap-0.5">
-            <SidebarItem id="architecture" title={'\u{1F3D7}\uFE0F Architecture Guide'} active={currentId === 'architecture'} onClick={handleNav} />
-          </div>
-        )}
-      </div>
+        'sidebar fixed top-0 left-0 bottom-0 w-[360px] max-sm:w-[320px] bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 z-100 flex flex-row transition-transform duration-250 -translate-x-full',
+        open && 'translate-x-0'
+      )}
+    >
+      <IconRail
+        activeGuideId={activeGuideId}
+        onSelectGuide={setActiveGuideId}
+        onHomeClick={handleGuidesHome}
+        currentId={currentId}
+      />
+      <ContentPanel
+        guide={activeGuide}
+        currentId={currentId}
+        onNav={handleNav}
+        onClose={onClose}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
Restructured the sidebar navigation from a collapsible tree layout to a modern two-column design with an icon rail on the left and a content panel on the right. This improves visual hierarchy and makes guide selection more intuitive.

## Key Changes
- **New Layout Architecture**: Split sidebar into two components:
  - `IconRail`: Vertical icon buttons for guide selection (home + guide icons)
  - `ContentPanel`: Displays the selected guide's navigation structure
  
- **Guide Data Structure**: Introduced a declarative `GuideDefinition` interface to define guides with their sections and page IDs, replacing the previous implicit structure
  
- **State Management**: Replaced separate `npmExpanded` and `archExpanded` boolean states with a single `activeGuideId` state that tracks which guide is currently selected
  
- **Title Resolution**: Added `titleOverrides` map to handle special pages (roadmap, checklist, etc.) that aren't in `contentPages`, with a new `resolveItems()` function that checks both sources
  
- **Guide Lookup**: Implemented `findGuideForPage()` to determine which guide a page belongs to, enabling automatic guide selection when navigating to a page
  
- **Sidebar Sync**: Added logic to re-sync the active guide when the sidebar transitions from closed to open, ensuring the correct guide is displayed based on the current page

## Implementation Details
- The icon rail uses emoji icons (📦, 🏗️) for visual guide identification
- Guide sections can have optional labels; unlabeled sections appear without a header
- The layout uses flexbox with `flex-row` to position the icon rail and content panel side-by-side
- Responsive widths adjusted from `w-80` to `w-[360px]` for better consistency
- Removed the old media query for small screens as the new layout handles responsiveness differently

https://claude.ai/code/session_01UMvWVRRxZjc5ivhi9n4B6x