### PR TITLE
Add Full-Stack Frameworks section to Architecture Guide (#51)

### DIFF
--- a/src/components/ArchStartPage.tsx
+++ b/src/components/ArchStartPage.tsx
@@ -1,5 +1,5 @@
 import { contentPages } from '../content/registry'
-import { STACK_PAGES } from '../data/archData'
+import { STACK_PAGES, FRAMEWORK_PAGES } from '../data/archData'
 import { HtmlContent } from './HtmlContent'
 import { PrevNextNav } from './PrevNextNav'
 
@@ -10,6 +10,13 @@ const stackDescriptions: Record<string, string> = {
   lamp: 'The classic stack that powered the early internet — Linux, Apache, MySQL, PHP. Battle-tested for decades.',
   django: 'Python-powered with batteries included — PostgreSQL, Django, React/Vue, Python. Excellent for teams that know Python.',
   rails: 'Ruby-powered and famous for developer happiness — PostgreSQL, Ruby on Rails, Hotwire/React, Ruby.',
+}
+
+const frameworkDescriptions: Record<string, string> = {
+  nextjs: 'The most popular React framework by Vercel — server rendering, file-system routing, and built-in optimizations. The safe default for production React apps.',
+  'react-router': 'React Router v7\'s full-stack mode — built on web standards, progressive enhancement, and 10+ years of battle-tested routing.',
+  'tanstack-start': 'The newest entry with best-in-class TypeScript support — end-to-end type safety from the TanStack ecosystem.',
+  remix: 'The pioneering web-standards framework that merged into React Router v7. Its ideas shaped modern React frameworks.',
 }
 
 export function ArchStartPage() {
@@ -49,6 +56,31 @@ export function ArchStartPage() {
     html += `<h3 class="bonus-subpage-title">${title}</h3>`
     html += `<div class="bonus-subpage-desc">${desc}</div>`
     html += `<button class="step-jump" data-jump="${pageId}">→ Deep dive: ${title}</button>`
+    html += `</div>`
+  })
+
+  html += `</div></div>`
+
+  // Bonus: Full-Stack Frameworks
+  html += `<div class="step-card bonus-step">`
+  html += `<div class="step-number bonus-number">\u2605</div>`
+  html += `<div class="step-content">`
+  html += `<div class="step-title">Full-Stack Frameworks</div>`
+  html += `<div class="step-desc">Explore four React-based full-stack frameworks that handle server rendering, routing, and data fetching as a unified package.</div>`
+
+  const fwIntroPage = contentPages.get('arch-frameworks-intro')
+  const fwIntroLabel = fwIntroPage?.title ?? '\u{1F3E0} Full-Stack Frameworks'
+  html += `<button class="step-jump" data-jump="arch-frameworks-intro">\u2192 Overview: ${fwIntroLabel}</button>`
+
+  FRAMEWORK_PAGES.forEach(fw => {
+    const pageId = `arch-fw-${fw.id}`
+    const page = contentPages.get(pageId)
+    const title = page?.title ?? fw.name
+    const desc = frameworkDescriptions[fw.id] ?? fw.overview
+    html += `<div class="bonus-subpage">`
+    html += `<h3 class="bonus-subpage-title">${title}</h3>`
+    html += `<div class="bonus-subpage-desc">${desc}</div>`
+    html += `<button class="step-jump" data-jump="${pageId}">\u2192 Deep dive: ${title}</button>`
     html += `</div>`
   })
 

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -27,6 +27,10 @@ const archStackOrder = [
   'arch-stack-lamp', 'arch-stack-django', 'arch-stack-rails',
 ]
 
+const archFrameworkOrder = [
+  'arch-fw-nextjs', 'arch-fw-react-router', 'arch-fw-tanstack-start', 'arch-fw-remix',
+]
+
 function PageItem({ id, onSelect }: { id: string; onSelect: (id: string) => void }) {
   const title = getNavTitle(id)
   const match = title.match(/^(\S+)\s+(.+)$/)
@@ -109,6 +113,13 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
 
         <Command.Group heading="Stack Alternatives">
           {archStackOrder.map(id => (
+            <PageItem key={id} id={id} onSelect={handleSelect} />
+          ))}
+        </Command.Group>
+
+        <Command.Group heading="Full-Stack Frameworks">
+          <PageItem id="arch-frameworks-intro" onSelect={handleSelect} />
+          {archFrameworkOrder.map(id => (
             <PageItem key={id} id={id} onSelect={handleSelect} />
           ))}
         </Command.Group>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -31,6 +31,10 @@ const archStackOrder = [
   'arch-stack-lamp', 'arch-stack-django', 'arch-stack-rails',
 ]
 
+const archFrameworkOrder = [
+  'arch-fw-nextjs', 'arch-fw-react-router', 'arch-fw-tanstack-start', 'arch-fw-remix',
+]
+
 const guides: GuideDefinition[] = [
   {
     id: 'npm-package',
@@ -51,6 +55,7 @@ const guides: GuideDefinition[] = [
     sections: [
       { label: null, ids: ['arch-start', 'arch-what-is-a-stack'] },
       { label: 'Stack Alternatives', ids: archStackOrder },
+      { label: 'Full-Stack Frameworks', ids: ['arch-frameworks-intro', ...archFrameworkOrder] },
       { label: 'Putting It Together', ids: ['arch-how-it-connects'] },
     ],
   },

--- a/src/components/mdx/FrameworkExplorer.tsx
+++ b/src/components/mdx/FrameworkExplorer.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react'
+import { FRAMEWORK_PAGES } from '../../data/archData'
+import type { FrameworkCapability } from '../../data/archData'
+
+function CapabilityBar({ cap, color, accent, isActive, onClick }: { cap: FrameworkCapability; color: string; accent: string; isActive: boolean; onClick: () => void }) {
+  return (
+    <button
+      onClick={onClick}
+      style={{
+        width: "100%", padding: "0", background: "none", border: "none", cursor: "pointer",
+        display: "flex", alignItems: "stretch", borderRadius: "10px", overflow: "hidden",
+        transition: "all 0.2s ease",
+        transform: isActive ? "scale(1.02)" : "scale(1)",
+        boxShadow: isActive ? `0 3px 16px ${color}30` : "0 1px 4px #0001",
+      }}
+    >
+      <div style={{ width: "6px", minHeight: "100%", background: color, opacity: isActive ? 1 : 0.35, transition: "opacity 0.2s" }} />
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 16px", background: isActive ? accent : "#fff", transition: "background 0.2s" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
+          <span style={{ fontSize: "18px" }}>{cap.icon}</span>
+          <div style={{ textAlign: "left" }}>
+            <div style={{ fontSize: "14px", fontWeight: 700, color: isActive ? color : "#374151" }}>{cap.name}</div>
+          </div>
+        </div>
+        <span style={{ fontSize: "12px", color: "#94a3b8", transition: "transform 0.2s", transform: isActive ? "rotate(90deg)" : "rotate(0)" }}>{"\u25B6"}</span>
+      </div>
+    </button>
+  )
+}
+
+export function FrameworkExplorer({ frameworkId }: { frameworkId: string }) {
+  const fw = FRAMEWORK_PAGES.find(f => f.id === frameworkId)
+  const [activeId, setActiveId] = useState(fw?.capabilities[0]?.id ?? "")
+  const active = fw?.capabilities.find(c => c.id === activeId)
+
+  if (!fw) return <div>Framework not found: {frameworkId}</div>
+
+  return (
+    <div style={{ fontFamily: "'DM Sans', sans-serif", color: "#1e293b" }}>
+      <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700&display=swap" rel="stylesheet" />
+
+      {/* Capability bars */}
+      <div style={{ display: "flex", flexDirection: "column", gap: "6px", marginBottom: "28px" }}>
+        <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "2px", padding: "0 4px" }}>
+          <span style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>Built on: {fw.builtOn.join(" + ")}</span>
+          <div style={{ flex: 1, height: "1px", background: "#e2e8f0" }} />
+        </div>
+        {fw.capabilities.map(cap => (
+          <CapabilityBar key={cap.id} cap={cap} color={fw.color} accent={fw.accent} isActive={activeId === cap.id} onClick={() => setActiveId(cap.id)} />
+        ))}
+      </div>
+
+      {/* Detail panel */}
+      {active && (
+        <div key={active.id} style={{ display: "flex", flexDirection: "column", gap: "14px", animation: "fadeIn 0.3s ease" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: "10px", padding: "0 2px" }}>
+            <span style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1.2px", color: fw.color }}>
+              {active.icon} {active.name}
+            </span>
+            <div style={{ flex: 1, height: "1px", background: `${fw.color}25` }} />
+          </div>
+
+          {/* Description */}
+          <div style={{ background: "#fff", borderRadius: "12px", padding: "18px 20px", boxShadow: "0 1px 5px #0001", borderLeft: `4px solid ${fw.color}` }}>
+            <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: fw.color, marginBottom: "6px" }}>How it works</div>
+            <p style={{ margin: 0, lineHeight: 1.75, fontSize: "14.5px", color: "#374151" }}>{active.description}</p>
+          </div>
+
+          {/* Key points */}
+          <div style={{ background: "#fff", borderRadius: "12px", padding: "18px 20px", boxShadow: "0 1px 5px #0001" }}>
+            <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: fw.color, marginBottom: "10px" }}>
+              {"\u2705"} Key takeaways
+            </div>
+            <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
+              {active.keyPoints.map((item, i) => (
+                <div key={i} style={{ display: "flex", gap: "10px", alignItems: "flex-start", fontSize: "14px", lineHeight: 1.6, color: "#374151" }}>
+                  <span style={{ background: fw.color, color: "#fff", borderRadius: "50%", width: "20px", height: "20px", minWidth: "20px", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "10px", fontWeight: 700, marginTop: "2px" }}>{i + 1}</span>
+                  <span>{item}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      <style>{`
+        @keyframes fadeIn {
+          from { opacity: 0; transform: translateY(6px); }
+          to { opacity: 1; transform: translateY(0); }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/components/mdx/FrameworkProsCons.tsx
+++ b/src/components/mdx/FrameworkProsCons.tsx
@@ -1,0 +1,43 @@
+import { FRAMEWORK_PAGES } from '../../data/archData'
+
+export function FrameworkProsCons({ frameworkId }: { frameworkId: string }) {
+  const fw = FRAMEWORK_PAGES.find(f => f.id === frameworkId)
+  if (!fw) return null
+
+  return (
+    <div style={{ fontFamily: "'DM Sans', sans-serif", color: "#1e293b" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px", marginBottom: "20px" }}>
+        <div style={{ background: "#f0fdf4", borderRadius: "10px", padding: "14px" }}>
+          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#16a34a", marginBottom: "8px" }}>{"\u2705"} Strengths</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+            {fw.pros.map((pro, i) => (
+              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: "#374151", paddingLeft: "10px", borderLeft: "2px solid #bbf7d0" }}>{pro}</div>
+            ))}
+          </div>
+        </div>
+        <div style={{ background: "#fef2f2", borderRadius: "10px", padding: "14px" }}>
+          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#dc2626", marginBottom: "8px" }}>{"\u26A0\uFE0F"} Tradeoffs</div>
+          <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
+            {fw.cons.map((con, i) => (
+              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: "#374151", paddingLeft: "10px", borderLeft: "2px solid #fecaca" }}>{con}</div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Best For */}
+      <div style={{ background: `linear-gradient(135deg, ${fw.accent}, #fff)`, borderRadius: "12px", padding: "16px 18px", border: `1px solid ${fw.color}18` }}>
+        <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: fw.color, marginBottom: "6px" }}>{"\u{1F3AF}"} Best for</div>
+        <p style={{ margin: 0, lineHeight: 1.7, fontSize: "14px", color: "#374151" }}>{fw.bestFor}</p>
+      </div>
+
+      <style>{`
+        @media (max-width: 520px) {
+          div[style*="grid-template-columns: 1fr 1fr"] {
+            grid-template-columns: 1fr !important;
+          }
+        }
+      `}</style>
+    </div>
+  )
+}

--- a/src/components/mdx/index.ts
+++ b/src/components/mdx/index.ts
@@ -13,6 +13,8 @@ import { StackExplorer } from './StackExplorer'
 import { StackProsCons } from './StackProsCons'
 import { DataFlowDiagram } from './DataFlowDiagram'
 import { LayerDiagram } from './LayerDiagram'
+import { FrameworkExplorer } from './FrameworkExplorer'
+import { FrameworkProsCons } from './FrameworkProsCons'
 
 export const mdxComponents: MDXComponents = {
   Cmd,
@@ -43,4 +45,6 @@ export const mdxComponents: MDXComponents = {
   StackProsCons,
   DataFlowDiagram,
   LayerDiagram,
+  FrameworkExplorer,
+  FrameworkProsCons,
 }

--- a/src/content/architecture/arch-frameworks-intro.mdx
+++ b/src/content/architecture/arch-frameworks-intro.mdx
@@ -1,0 +1,56 @@
+---
+id: "arch-frameworks-intro"
+title: "🏠 Full-Stack Frameworks"
+---
+
+<h1 className="section-title">{frontmatter.title}</h1>
+
+<Toc>
+  <TocLink id="toc-what">What is a full-stack framework?</TocLink>
+  <TocLink id="toc-stacks-vs-frameworks">Stacks vs. frameworks</TocLink>
+  <TocLink id="toc-the-frameworks">The four frameworks</TocLink>
+  <TocLink id="toc-explainer">Backend analogy</TocLink>
+</Toc>
+
+<SectionIntro>
+Full-stack frameworks take a frontend library (like React) and add server rendering, routing, data fetching, and build optimization &mdash; creating a unified development experience. Instead of assembling independent pieces yourself, a framework makes these decisions for you.
+</SectionIntro>
+
+<h2 className="section-subheading" id="toc-what">{'\u{1F4CB}'} What is a full-stack framework?</h2>
+
+In the previous sections, you learned about **stacks** &mdash; collections of independent technologies at different layers (frontend, server, runtime, database). You choose each piece separately and wire them together.
+
+**Full-stack frameworks** take a different approach. They start with a frontend library (usually React) and add server-side capabilities on top:
+
+<div className="section-list">
+<ColItem>**Server rendering** &mdash; generate HTML on the server for faster initial loads and better SEO</ColItem>
+<ColItem>**File-system routing** &mdash; your file structure automatically becomes your URL structure</ColItem>
+<ColItem>**Data fetching** &mdash; load data on the server before sending pages to the browser</ColItem>
+<ColItem>**Build optimization** &mdash; automatic code splitting, bundling, and asset optimization</ColItem>
+</div>
+
+<h2 className="section-subheading" id="toc-stacks-vs-frameworks">{'\u{1F504}'} Stacks vs. frameworks</h2>
+
+The key difference is **who makes the integration decisions**:
+
+<div className="section-list">
+<ColItem>**Stacks** (MERN, LAMP, etc.) &mdash; you choose independent technologies at each layer and wire them together yourself. Maximum flexibility, but more decisions to make.</ColItem>
+<ColItem>**Frameworks** (Next.js, React Router, etc.) &mdash; the framework handles server rendering, routing, and data fetching as a unified package. Fewer decisions, but you follow the framework&apos;s patterns.</ColItem>
+</div>
+
+Frameworks don&apos;t replace stacks &mdash; they sit **on top** of them. Next.js still uses React (frontend) and Node.js (runtime). You still need a database. The framework handles the glue between layers so you don&apos;t have to.
+
+<h2 className="section-subheading" id="toc-the-frameworks">{'\u{1F3D7}\uFE0F'} The four frameworks</h2>
+
+<div className="section-list">
+<ColItem>**Next.js** &mdash; the most popular React framework, backed by Vercel. Multiple rendering strategies, massive ecosystem, and the safe default choice.</ColItem>
+<ColItem>**React Router Framework Mode** &mdash; React Router v7&apos;s full-stack mode. Built on web standards, progressive enhancement, and vendor independence.</ColItem>
+<ColItem>**TanStack Start** &mdash; the newest entry with best-in-class TypeScript support. End-to-end type safety from the TanStack ecosystem.</ColItem>
+<ColItem>**Remix** &mdash; the pioneering web-standards framework that merged into React Router v7. Its ideas live on, and understanding it helps you understand modern frameworks.</ColItem>
+</div>
+
+<StepJump to="arch-fw-nextjs" label="Start with Next.js" />
+
+<Explainer title="Full-stack frameworks &mdash; a backend analogy">
+If stacks are like building a microservice by choosing individual technologies (language, framework, database, message queue), full-stack frameworks are like choosing a platform (Spring Boot, ASP.NET, Rails) that makes the integration decisions for you. You trade some flexibility for a cohesive, well-tested development experience where the pieces are designed to work together.
+</Explainer>

--- a/src/content/architecture/arch-fw-nextjs.mdx
+++ b/src/content/architecture/arch-fw-nextjs.mdx
@@ -1,0 +1,39 @@
+---
+id: "arch-fw-nextjs"
+title: "▲ Next.js"
+---
+
+<h1 className="section-title">{frontmatter.title}</h1>
+
+<Toc>
+  <TocLink id="toc-overview">Overview</TocLink>
+  <TocLink id="toc-explore">Explore key capabilities</TocLink>
+  <TocLink id="toc-tradeoffs">Strengths & tradeoffs</TocLink>
+  <TocLink id="toc-explainer">Backend analogy</TocLink>
+</Toc>
+
+<SectionIntro>
+**Next.js** is the most popular React framework, developed by Vercel. It adds server-side rendering, file-system routing, API routes, and optimized builds on top of React &mdash; used in production by Netflix, TikTok, and Notion. It&apos;s the safe, well-documented default for most React projects.
+</SectionIntro>
+
+<h2 className="section-subheading" id="toc-overview">{'\u{1F4CB}'} Overview</h2>
+
+<div className="section-list">
+<ColItem>**Multiple rendering strategies** &mdash; Server-Side Rendering (SSR), Static Site Generation (SSG), and React Server Components (RSC) in a single app. Choose per-page.</ColItem>
+<ColItem>**File-system routing** &mdash; your folder structure automatically maps to URL paths. No manual route definitions needed.</ColItem>
+<ColItem>**Built-in optimizations** &mdash; automatic image optimization, font loading, code splitting, and bundle analysis out of the box.</ColItem>
+</div>
+
+<h2 className="section-subheading" id="toc-explore">{'\u{1F50D}'} Explore key capabilities</h2>
+
+Click any capability to learn how Next.js handles it.
+
+<FrameworkExplorer frameworkId="nextjs" />
+
+<h2 className="section-subheading" id="toc-tradeoffs">{'\u2696\uFE0F'} Strengths & tradeoffs</h2>
+
+<FrameworkProsCons frameworkId="nextjs" />
+
+<Explainer title="Next.js &mdash; a backend analogy">
+Next.js is like Spring Boot for React &mdash; it takes the core library and adds all the production infrastructure you&apos;d otherwise assemble yourself: routing, server rendering, build optimization, and deployment tooling. Like Spring Boot, it&apos;s opinionated but well-documented, and the ecosystem is massive.
+</Explainer>

--- a/src/content/architecture/arch-fw-react-router.mdx
+++ b/src/content/architecture/arch-fw-react-router.mdx
@@ -1,0 +1,39 @@
+---
+id: "arch-fw-react-router"
+title: "🔀 React Router Framework"
+---
+
+<h1 className="section-title">{frontmatter.title}</h1>
+
+<Toc>
+  <TocLink id="toc-overview">Overview</TocLink>
+  <TocLink id="toc-explore">Explore key capabilities</TocLink>
+  <TocLink id="toc-tradeoffs">Strengths & tradeoffs</TocLink>
+  <TocLink id="toc-explainer">Backend analogy</TocLink>
+</Toc>
+
+<SectionIntro>
+**React Router v7** introduced &ldquo;Framework Mode&rdquo; &mdash; transforming the most popular React routing library into a full-stack framework. It&apos;s the spiritual successor to Remix (which merged into React Router), built on web standards like the Fetch API, FormData, and HTTP caching. It&apos;s the web-standards-first alternative to Next.js.
+</SectionIntro>
+
+<h2 className="section-subheading" id="toc-overview">{'\u{1F4CB}'} Overview</h2>
+
+<div className="section-list">
+<ColItem>**Web standards first** &mdash; built on Fetch API Request/Response, FormData, and HTTP caching headers. Skills you learn transfer to the platform and other frameworks.</ColItem>
+<ColItem>**Progressive enhancement** &mdash; forms and navigation work without JavaScript by default, then enhance with JS for a richer experience.</ColItem>
+<ColItem>**Nested routing pioneer** &mdash; React Router has 10+ years of battle-testing. Each route segment gets its own data loader, action handler, and error boundary.</ColItem>
+</div>
+
+<h2 className="section-subheading" id="toc-explore">{'\u{1F50D}'} Explore key capabilities</h2>
+
+Click any capability to learn how React Router Framework Mode handles it.
+
+<FrameworkExplorer frameworkId="react-router" />
+
+<h2 className="section-subheading" id="toc-tradeoffs">{'\u2696\uFE0F'} Strengths & tradeoffs</h2>
+
+<FrameworkProsCons frameworkId="react-router" />
+
+<Explainer title="React Router Framework Mode &mdash; a backend analogy">
+React Router Framework Mode is like upgrading from Express to Fastify &mdash; you keep the same mental model (routes, middleware, request/response) but gain built-in validation, better performance, and modern patterns. It respects the platform rather than abstracting it away.
+</Explainer>

--- a/src/content/architecture/arch-fw-remix.mdx
+++ b/src/content/architecture/arch-fw-remix.mdx
@@ -1,0 +1,43 @@
+---
+id: "arch-fw-remix"
+title: "💿 Remix"
+---
+
+<h1 className="section-title">{frontmatter.title}</h1>
+
+<SectionNote>
+Remix merged into React Router v7 in 2024. New projects should use <NavLink to="arch-fw-react-router">React Router Framework Mode</NavLink> directly. This page covers Remix&apos;s contributions and ideas, which live on in React Router v7.
+</SectionNote>
+
+<Toc>
+  <TocLink id="toc-overview">Overview</TocLink>
+  <TocLink id="toc-explore">Explore key capabilities</TocLink>
+  <TocLink id="toc-tradeoffs">Strengths & tradeoffs</TocLink>
+  <TocLink id="toc-explainer">Backend analogy</TocLink>
+</Toc>
+
+<SectionIntro>
+**Remix** was a pioneering full-stack React framework created by the React Router team (Ryan Florence and Michael Jackson). It championed web standards, progressive enhancement, and nested routing. Its ideas now live on in React Router v7 Framework Mode &mdash; understanding Remix helps you understand the patterns behind modern React frameworks.
+</SectionIntro>
+
+<h2 className="section-subheading" id="toc-overview">{'\u{1F4CB}'} Overview</h2>
+
+<div className="section-list">
+<ColItem>**Web standards pioneer** &mdash; Remix built everything on Fetch API Request/Response, standard HTML forms, and HTTP caching. Skills learned transfer to any platform.</ColItem>
+<ColItem>**Loader/action pattern** &mdash; Remix pioneered co-located server-side data fetching (loaders) and mutation handling (actions) for React, with automatic revalidation.</ColItem>
+<ColItem>**Per-route error boundaries** &mdash; if a nested route crashes, only that section shows an error &mdash; the rest stays functional. This pattern was later adopted by Next.js and others.</ColItem>
+</div>
+
+<h2 className="section-subheading" id="toc-explore">{'\u{1F50D}'} Explore key capabilities</h2>
+
+Click any capability to learn how Remix approached it.
+
+<FrameworkExplorer frameworkId="remix" />
+
+<h2 className="section-subheading" id="toc-tradeoffs">{'\u2696\uFE0F'} Strengths & tradeoffs</h2>
+
+<FrameworkProsCons frameworkId="remix" />
+
+<Explainer title="Remix &mdash; a backend analogy">
+Remix is like the Unix philosophy applied to web frameworks &mdash; small, composable primitives built on the platform. It&apos;s like choosing POSIX-standard tools over vendor-specific CLI tools: you learn transferable skills that work everywhere, not just in one ecosystem.
+</Explainer>

--- a/src/content/architecture/arch-fw-tanstack-start.mdx
+++ b/src/content/architecture/arch-fw-tanstack-start.mdx
@@ -1,0 +1,39 @@
+---
+id: "arch-fw-tanstack-start"
+title: "🔥 TanStack Start"
+---
+
+<h1 className="section-title">{frontmatter.title}</h1>
+
+<Toc>
+  <TocLink id="toc-overview">Overview</TocLink>
+  <TocLink id="toc-explore">Explore key capabilities</TocLink>
+  <TocLink id="toc-tradeoffs">Strengths & tradeoffs</TocLink>
+  <TocLink id="toc-explainer">Backend analogy</TocLink>
+</Toc>
+
+<SectionIntro>
+**TanStack Start** is the newest full-stack React framework, built by Tanner Linsley (creator of TanStack Query, TanStack Router, and TanStack Table). It combines TanStack Router&apos;s type-safe routing with Vinxi (a Vite-based server framework) for best-in-class TypeScript support and end-to-end type safety.
+</SectionIntro>
+
+<h2 className="section-subheading" id="toc-overview">{'\u{1F4CB}'} Overview</h2>
+
+<div className="section-list">
+<ColItem>**End-to-end type safety** &mdash; route parameters, search params, loaders, and actions are all fully typed. No codegen required &mdash; types are inferred from your route definitions.</ColItem>
+<ColItem>**TanStack ecosystem** &mdash; built-in integration with TanStack Query for caching, TanStack Table for data grids, and more.</ColItem>
+<ColItem>**Vite-powered** &mdash; fast development experience with HMR and a smaller, focused API surface.</ColItem>
+</div>
+
+<h2 className="section-subheading" id="toc-explore">{'\u{1F50D}'} Explore key capabilities</h2>
+
+Click any capability to learn how TanStack Start handles it.
+
+<FrameworkExplorer frameworkId="tanstack-start" />
+
+<h2 className="section-subheading" id="toc-tradeoffs">{'\u2696\uFE0F'} Strengths & tradeoffs</h2>
+
+<FrameworkProsCons frameworkId="tanstack-start" />
+
+<Explainer title="TanStack Start &mdash; a backend analogy">
+TanStack Start is like building a service with gRPC instead of REST &mdash; you get stronger contracts, better tooling, and end-to-end type safety, but it&apos;s newer and has a smaller ecosystem. It trades community size for technical precision.
+</Explainer>

--- a/src/data/archData.ts
+++ b/src/data/archData.ts
@@ -38,6 +38,31 @@ export interface DataFlowItem {
   colorId: string
 }
 
+/* ───────────────────────── FRAMEWORK TYPES ───────────────────────── */
+
+export interface FrameworkCapability {
+  id: string
+  name: string
+  icon: string
+  description: string
+  keyPoints: string[]
+}
+
+export interface FrameworkPageData {
+  id: string
+  name: string
+  tagline: string
+  overview: string
+  color: string
+  accent: string
+  builtOn: string[]
+  capabilities: FrameworkCapability[]
+  pros: string[]
+  cons: string[]
+  bestFor: string
+  analogy: string
+}
+
 /* ───────────────────────── LAYER COLORS (shared) ───────────────────────── */
 
 export const LAYER_COLORS: Record<string, { color: string; accent: string }> = {
@@ -534,6 +559,310 @@ export const STACK_PAGES: StackPageData[] = [
   },
 ]
 
+/* ───────────────────────── FRAMEWORK DATA ───────────────────────── */
+
+export const FRAMEWORK_PAGES: FrameworkPageData[] = [
+  /* ── Next.js ─────────────────────────────────────── */
+  {
+    id: "nextjs",
+    name: "Next.js",
+    tagline: "The React meta-framework by Vercel",
+    overview: "Next.js is the most popular React framework. It adds server-side rendering, file-system routing, API routes, and optimized builds on top of React. Developed by Vercel, it\u2019s become the default way to build production React apps \u2014 used by Netflix, TikTok, and Notion.",
+    color: "#000000",
+    accent: "#f5f5f5",
+    builtOn: ["React", "Node.js"],
+    capabilities: [
+      {
+        id: "rendering",
+        name: "Rendering Strategies",
+        icon: "\u{1F5A5}\uFE0F",
+        description: "Next.js supports multiple rendering strategies in a single app: Server-Side Rendering (SSR) generates HTML on each request, Static Site Generation (SSG) pre-builds pages at build time, and the App Router introduces React Server Components (RSC) that render on the server without sending JavaScript to the client.",
+        keyPoints: [
+          "SSR \u2014 HTML generated per-request, great for dynamic content",
+          "SSG \u2014 HTML pre-built at build time, fastest possible load times",
+          "React Server Components \u2014 server-only rendering that reduces client JavaScript",
+          "Mix and match \u2014 different pages can use different strategies",
+        ],
+      },
+      {
+        id: "routing",
+        name: "File-System Routing",
+        icon: "\u{1F4C1}",
+        description: "Instead of manually defining routes, Next.js maps your file structure to URL paths. Create a file at app/dashboard/page.tsx and it automatically becomes /dashboard. Nested folders create nested routes, and special files (layout.tsx, loading.tsx, error.tsx) handle common patterns.",
+        keyPoints: [
+          "Zero-config routing \u2014 file structure = URL structure",
+          "Nested layouts \u2014 shared UI across route segments",
+          "Loading and error states \u2014 built-in per-route",
+          "Dynamic routes \u2014 [id] folder conventions for parameterized URLs",
+        ],
+      },
+      {
+        id: "data",
+        name: "Data Fetching",
+        icon: "\u{1F504}",
+        description: "Next.js provides server-side data fetching using async Server Components. You can fetch data directly inside components that run on the server, eliminating the need for separate API endpoints for your own frontend. Data is fetched before HTML is sent to the client.",
+        keyPoints: [
+          "Server Components fetch data directly \u2014 no useEffect or client-side loading spinners",
+          "Server Actions \u2014 call server-side functions from client components like RPC",
+          "Automatic request deduplication and caching",
+          "Streaming \u2014 send parts of the page as they become ready",
+        ],
+      },
+      {
+        id: "deployment",
+        name: "Deployment & Optimization",
+        icon: "\u{1F680}",
+        description: "Next.js includes built-in image optimization, font optimization, script loading strategies, and bundle analysis. It deploys seamlessly to Vercel\u2019s platform but also supports self-hosting on any Node.js server or via Docker.",
+        keyPoints: [
+          "Image component \u2014 automatic resizing, lazy loading, and format conversion",
+          "Vercel integration \u2014 zero-config deployment with edge functions",
+          "Self-hostable \u2014 works on any Node.js server or Docker container",
+          "Bundle optimization \u2014 automatic code splitting per route",
+        ],
+      },
+    ],
+    pros: [
+      "Most mature React framework \u2014 massive ecosystem, excellent documentation, huge community",
+      "Multiple rendering strategies (SSR, SSG, RSC) in one framework",
+      "Vercel provides seamless deployment with edge functions and analytics",
+      "Built-in optimizations for images, fonts, and scripts out of the box",
+    ],
+    cons: [
+      "Tight coupling with Vercel \u2014 some features work best (or only) on Vercel\u2019s platform",
+      "App Router complexity \u2014 React Server Components add a new mental model to learn",
+      "Caching behavior can be surprising and hard to debug",
+      "Frequent breaking changes between major versions",
+    ],
+    bestFor: "Production React applications that need SEO, fast initial loads, and a mature ecosystem. Next.js is the safe, well-documented choice for most React projects, especially if you\u2019re deploying to Vercel.",
+    analogy: "Next.js is like Spring Boot for React \u2014 it takes the core library and adds all the production infrastructure you\u2019d otherwise assemble yourself: routing, server rendering, build optimization, and deployment tooling.",
+  },
+
+  /* ── React Router Framework Mode ─────────────────── */
+  {
+    id: "react-router",
+    name: "React Router Framework Mode",
+    tagline: "Full-stack mode of React Router v7",
+    overview: "React Router v7 introduced \u2018Framework Mode\u2019 \u2014 transforming the most popular React routing library into a full-stack framework. It\u2019s the spiritual successor to Remix (which merged into React Router), built on web standards like the Fetch API, FormData, and HTTP caching. It\u2019s the web-standards-first alternative to Next.js.",
+    color: "#f44250",
+    accent: "#fff5f5",
+    builtOn: ["React", "Node.js"],
+    capabilities: [
+      {
+        id: "routing",
+        name: "Nested Routing",
+        icon: "\u{1F9E9}",
+        description: "React Router pioneered nested routing in the React ecosystem. In Framework Mode, each route segment can define its own data loader, action handler, and error boundary. The layout hierarchy is explicit, and multiple route segments can load data in parallel.",
+        keyPoints: [
+          "Nested routes with parallel data loading \u2014 no waterfalls",
+          "Each route segment has its own loader, action, and error boundary",
+          "URL-based state \u2014 the URL is the primary source of truth",
+          "Type-safe route definitions and parameters",
+        ],
+      },
+      {
+        id: "data",
+        name: "Loaders & Actions",
+        icon: "\u{1F504}",
+        description: "Data flows through loaders (GET requests) and actions (mutations). Loaders run on the server before rendering, and actions handle form submissions and mutations. This model mirrors how traditional web apps work \u2014 built on web standard Request/Response objects.",
+        keyPoints: [
+          "Loaders \u2014 server-side functions that provide data for each route",
+          "Actions \u2014 handle form submissions and mutations using web standard FormData",
+          "Automatic revalidation \u2014 after a mutation, affected loaders re-run automatically",
+          "Progressive enhancement \u2014 forms work without JavaScript by default",
+        ],
+      },
+      {
+        id: "standards",
+        name: "Web Standards",
+        icon: "\u{1F310}",
+        description: "React Router Framework Mode is built on web platform APIs: Fetch Request/Response, FormData, URL, Headers. Skills you learn transfer directly to other frameworks and to the platform itself. It avoids custom abstractions wherever a web standard exists.",
+        keyPoints: [
+          "Built on Fetch API Request/Response \u2014 not custom abstractions",
+          "FormData for mutations \u2014 standard HTML forms enhanced progressively",
+          "HTTP caching headers \u2014 leverage browser and CDN caching natively",
+          "Runs on any JavaScript runtime \u2014 Node.js, Deno, Cloudflare Workers",
+        ],
+      },
+      {
+        id: "rendering",
+        name: "Rendering Modes",
+        icon: "\u{1F5A5}\uFE0F",
+        description: "React Router supports SSR, static pre-rendering, and SPA mode. You can choose per-route whether to server-render or statically generate, and the SPA mode option lets you use it as a traditional client-side app without a server.",
+        keyPoints: [
+          "Server rendering \u2014 HTML on each request with hydration",
+          "Static pre-rendering \u2014 generate HTML at build time for specific routes",
+          "SPA mode \u2014 opt-out of server rendering entirely for traditional SPA deployment",
+          "Flexible deployment \u2014 adapters for Node, Cloudflare, Deno, Vercel, and more",
+        ],
+      },
+    ],
+    pros: [
+      "Web standards first \u2014 skills transfer to the platform and other frameworks",
+      "Progressive enhancement \u2014 forms and navigation work without JavaScript",
+      "Mature routing library \u2014 React Router has 10+ years of battle-testing",
+      "Flexible deployment \u2014 not tied to any specific hosting provider",
+    ],
+    cons: [
+      "Newer framework mode \u2014 smaller community and fewer tutorials than Next.js",
+      "Remix-to-React-Router migration caused community confusion",
+      "No built-in image optimization or static asset handling like Next.js",
+      "Less opinionated \u2014 requires more decisions about project structure",
+    ],
+    bestFor: "Teams that value web standards, progressive enhancement, and vendor independence. Great if you already use React Router for client-side routing and want to add server rendering without switching to an entirely different framework.",
+    analogy: "React Router Framework Mode is like upgrading from Express to Fastify \u2014 you keep the same mental model (routes, middleware, request/response) but gain built-in validation, better performance, and modern patterns. It respects the platform rather than abstracting it away.",
+  },
+
+  /* ── TanStack Start ──────────────────────────────── */
+  {
+    id: "tanstack-start",
+    name: "TanStack Start",
+    tagline: "Full-stack framework from the TanStack ecosystem",
+    overview: "TanStack Start is the newest entry, built by Tanner Linsley (creator of TanStack Query, TanStack Router, and TanStack Table). It combines TanStack Router\u2019s type-safe routing with Vinxi (a Vite-based server framework) to create a full-stack React framework with best-in-class TypeScript support.",
+    color: "#e8590c",
+    accent: "#fff4ed",
+    builtOn: ["React", "Vite/Vinxi", "Node.js"],
+    capabilities: [
+      {
+        id: "typesafety",
+        name: "End-to-End Type Safety",
+        icon: "\u{1F512}",
+        description: "TanStack Start provides type-safe routing where route parameters, search params, loaders, and actions are all fully typed. TypeScript errors surface at build time if you reference a route that doesn\u2019t exist or pass wrong parameters. No codegen required \u2014 types are inferred from your route definitions.",
+        keyPoints: [
+          "Route params and search params are fully typed without codegen",
+          "Loader return types flow into components automatically",
+          "Type-safe navigation \u2014 invalid links are caught at compile time",
+          "Leverages TanStack Router\u2019s industry-leading type inference",
+        ],
+      },
+      {
+        id: "data",
+        name: "Server Functions",
+        icon: "\u{1F504}",
+        description: "TanStack Start uses \u2018server functions\u2019 \u2014 functions that you write in your component files but execute on the server. They\u2019re similar to Next.js Server Actions but integrated with TanStack Query for caching, invalidation, and optimistic updates.",
+        keyPoints: [
+          "Server functions \u2014 define server-side logic alongside your components",
+          "Built-in TanStack Query integration for caching and state management",
+          "Automatic optimistic updates and cache invalidation",
+          "RPC-style calls \u2014 call server functions like regular async functions",
+        ],
+      },
+      {
+        id: "routing",
+        name: "File-Based Routing",
+        icon: "\u{1F4C1}",
+        description: "Routes are defined in a file-based system with TanStack Router under the hood. The route tree is generated automatically, with full support for nested layouts, parallel data loading, and search parameter validation.",
+        keyPoints: [
+          "File-based route definitions with automatic tree generation",
+          "Nested layouts with parallel data loading",
+          "Search parameter validation and serialization built-in",
+          "Powered by TanStack Router \u2014 the most type-safe React router",
+        ],
+      },
+      {
+        id: "ecosystem",
+        name: "TanStack Ecosystem",
+        icon: "\u{1F9F1}",
+        description: "TanStack Start is designed to work seamlessly with the rest of the TanStack ecosystem: Query for server state, Table for data grids, Form for form handling, and Virtual for large lists. Each library is independent but optimized to work together.",
+        keyPoints: [
+          "TanStack Query \u2014 built-in integration for server state management",
+          "TanStack Table, Form, Virtual \u2014 composable companion libraries",
+          "Framework-agnostic design \u2014 potential to support non-React frameworks in the future",
+          "Active development with rapid iteration",
+        ],
+      },
+    ],
+    pros: [
+      "Best-in-class TypeScript support \u2014 end-to-end type safety without codegen",
+      "Built on TanStack ecosystem \u2014 best-in-class data fetching, routing, and tables",
+      "Vite-powered \u2014 fast development experience with HMR",
+      "Smaller, focused API surface \u2014 less to learn compared to Next.js",
+    ],
+    cons: [
+      "Very new \u2014 still in early development, API may change",
+      "Smallest community and fewest learning resources of the four",
+      "Requires familiarity with TanStack Router and TanStack Query concepts",
+      "Production track record is limited compared to Next.js or React Router",
+    ],
+    bestFor: "TypeScript-heavy teams that want maximum type safety, projects already using TanStack Router or TanStack Query, and developers who want a modern Vite-native framework built from the ground up on current best practices.",
+    analogy: "TanStack Start is like building a service with gRPC instead of REST \u2014 you get stronger contracts, better tooling, and end-to-end type safety, but it\u2019s newer and has a smaller ecosystem. It trades community size for technical precision.",
+  },
+
+  /* ── Remix ───────────────────────────────────────── */
+  {
+    id: "remix",
+    name: "Remix",
+    tagline: "Web standards-focused framework (now part of React Router)",
+    overview: "Remix was a pioneering full-stack React framework created by the React Router team (Ryan Florence and Michael Jackson). It championed web standards, progressive enhancement, and nested routing. In 2024, Remix merged into React Router v7 as \u2018Framework Mode\u2019 \u2014 so Remix\u2019s ideas live on, but new projects should use React Router v7 directly.",
+    color: "#3992ff",
+    accent: "#f0f7ff",
+    builtOn: ["React", "Node.js"],
+    capabilities: [
+      {
+        id: "philosophy",
+        name: "Web Standards Philosophy",
+        icon: "\u{1F310}",
+        description: "Remix was built on a core belief: the web platform already has great APIs, and frameworks should use them rather than invent new ones. This means Fetch API Request/Response objects, standard HTML forms, HTTP caching, and browser-native navigation. Everything you learn transfers to the platform itself.",
+        keyPoints: [
+          "Built on web standard APIs \u2014 Request, Response, FormData, Headers",
+          "Progressive enhancement \u2014 apps work without JavaScript, then enhance",
+          "HTTP caching as a first-class optimization strategy",
+          "Skills transfer to any web platform or framework",
+        ],
+      },
+      {
+        id: "data",
+        name: "Loader/Action Pattern",
+        icon: "\u{1F504}",
+        description: "Remix pioneered the loader/action pattern for React apps: loaders run on the server to provide data for GET requests, and actions handle form submissions (POST/PUT/DELETE). After a mutation, all affected loaders automatically re-run to keep the UI in sync \u2014 no manual cache invalidation.",
+        keyPoints: [
+          "Loaders \u2014 co-located server-side data fetching for each route",
+          "Actions \u2014 handle mutations using standard form submissions",
+          "Automatic revalidation \u2014 loaders re-run after mutations",
+          "Parallel data loading \u2014 nested routes fetch simultaneously, preventing waterfalls",
+        ],
+      },
+      {
+        id: "errors",
+        name: "Error Handling",
+        icon: "\u{1F6E1}\uFE0F",
+        description: "Remix introduced per-route error boundaries: if a nested route crashes, only that section of the page shows an error \u2014 the rest stays functional. This is fundamentally better than full-page error screens and was later adopted by other frameworks.",
+        keyPoints: [
+          "Per-route error boundaries \u2014 errors are contained, not catastrophic",
+          "Graceful degradation \u2014 parent layouts stay functional when child routes fail",
+          "Expected errors vs. unexpected errors \u2014 different handling for each",
+          "Pattern later adopted by Next.js App Router and other frameworks",
+        ],
+      },
+      {
+        id: "legacy",
+        name: "Legacy & Migration",
+        icon: "\u{1F4E6}",
+        description: "Remix v2 was the final standalone release. The team merged Remix into React Router v7, making Framework Mode the official successor. Existing Remix v2 apps can migrate with minimal changes. New projects should start with React Router v7 Framework Mode directly.",
+        keyPoints: [
+          "Remix ideas live on in React Router v7 Framework Mode",
+          "Remix v2 \u2192 React Router v7 migration is mostly mechanical",
+          "Existing Remix apps continue to work but won\u2019t receive new features",
+          "Understanding Remix helps you understand React Router Framework Mode",
+        ],
+      },
+    ],
+    pros: [
+      "Pioneered patterns now adopted industry-wide (nested routing, loader/action, per-route errors)",
+      "Web standards focus means skills transfer to any framework or the platform",
+      "Progressive enhancement \u2014 apps work without JavaScript by default",
+      "Clean mental model \u2014 data in (loaders) and data out (actions)",
+    ],
+    cons: [
+      "Merged into React Router v7 \u2014 no longer a standalone framework for new projects",
+      "Community fragmented by the Remix \u2192 React Router transition",
+      "Fewer tutorials and resources compared to Next.js",
+      "Historical context needed \u2014 many Remix resources reference outdated APIs",
+    ],
+    bestFor: "Understanding the ideas behind modern React frameworks. Even though new projects should use React Router v7, studying Remix teaches you the loader/action pattern, progressive enhancement, and web-standards-first thinking that influenced the entire ecosystem.",
+    analogy: "Remix is like the Unix philosophy applied to web frameworks \u2014 small, composable primitives built on the platform. It\u2019s like choosing POSIX-standard tools over vendor-specific CLI tools: you learn transferable skills that work everywhere, not just in one ecosystem.",
+  },
+]
+
 /* ───────────────────────── NAVIGATION ───────────────────────── */
 
 export const ARCH_NAV_ORDER = [
@@ -545,6 +874,11 @@ export const ARCH_NAV_ORDER = [
   "arch-stack-lamp",
   "arch-stack-django",
   "arch-stack-rails",
+  "arch-frameworks-intro",
+  "arch-fw-nextjs",
+  "arch-fw-react-router",
+  "arch-fw-tanstack-start",
+  "arch-fw-remix",
   "arch-how-it-connects",
 ]
 

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -39,6 +39,11 @@ const staticTitles: Record<string, string> = {
   "arch-stack-lamp": "\u{1F4A1} LAMP Stack",
   "arch-stack-django": "\u{1F40D} Django Stack",
   "arch-stack-rails": "\u{1F6E4}\uFE0F Rails Stack",
+  "arch-frameworks-intro": "\u{1F3E0} Full-Stack Frameworks",
+  "arch-fw-nextjs": "\u25B2 Next.js",
+  "arch-fw-react-router": "\u{1F500} React Router Framework",
+  "arch-fw-tanstack-start": "\u{1F525} TanStack Start",
+  "arch-fw-remix": "\u{1F4BF} Remix",
   "arch-how-it-connects": "\u{1F504} How it all Connects",
 }
 


### PR DESCRIPTION
Add a new "Full-Stack Frameworks" section covering Next.js, React Router
Framework Mode, TanStack Start, and Remix. Each framework has its own
page with an interactive capability explorer, pros/cons, and backend
analogy, plus an intro page explaining stacks vs frameworks.

New files:
- FrameworkExplorer and FrameworkProsCons MDX components
- 5 MDX content pages (intro + 4 frameworks)

Updated navigation across all 4 sync points (archData, navigation,
Sidebar, CommandMenu) and the ArchStartPage.

https://claude.ai/code/session_015NkLDzUHkLsPHD3QAbrYYr