### PR TITLE
Add dark mode support to architecture guide components

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,9 @@ The site contains two independent guides, each with its own Start Here page, nav
 ### Architecture Guide
 - **Start page:** `arch-start` (`src/components/ArchStartPage.tsx`)
 - **Content pages:** MDX files in `src/content/architecture/`
-- **Data:** `src/data/archData.ts` (stack data, layer data, data flow)
-- **Interactive MDX components:** `src/components/mdx/StackExplorer.tsx`, `StackProsCons.tsx`, `DataFlowDiagram.tsx`, `LayerDiagram.tsx`
-- **Page IDs:** `arch-start`, `arch-what-is-a-stack`, `arch-stack-{mern,pfrn,mean,lamp,django,rails}`, `arch-how-it-connects`
+- **Data:** `src/data/archData.ts` (stack data, layer data, data flow, framework data)
+- **Interactive MDX components:** `src/components/mdx/StackExplorer.tsx`, `StackProsCons.tsx`, `DataFlowDiagram.tsx`, `LayerDiagram.tsx`, `FrameworkExplorer.tsx`, `FrameworkProsCons.tsx`
+- **Page IDs:** `arch-start`, `arch-what-is-a-stack`, `arch-stack-{mern,pfrn,mean,lamp,django,rails}`, `arch-frameworks-intro`, `arch-fw-{nextjs,react-router,tanstack-start,remix}`, `arch-how-it-connects`
 
 ## Tech Stack
 
@@ -61,6 +61,7 @@ The site contains two independent guides, each with its own Start Here page, nav
 - **Functional components only:** No class components. Props typed with TypeScript interfaces.
 - **Interactive tables:** The External Resources page (`ExternalResourcesPage.tsx`) and Glossary page (`GlossaryPage.tsx`) use TanStack Table for sortable, filterable, searchable tables.
 - **Styling:** Use inline Tailwind utility classes on JSX elements. Avoid defining component-level classes with `@apply` in `App.css`. CSS is only for things that genuinely require it: pseudo-elements (`::before`, `::after`), complex nested selectors, body-level toggles, animations/transitions, and third-party library attribute selectors (e.g., cmdk `[cmdk-input]`). Using `@apply` within those CSS-only rules is acceptable.
+- **Dark mode:** The app uses class-based dark mode via a `useTheme()` hook (`src/hooks/useTheme.tsx`) that toggles `.dark` on `<body>`. Tailwind's custom variant `@custom-variant dark (&:where(.dark, .dark *))` enables `dark:` utility classes. For components using Tailwind classes, use `dark:` variants directly (e.g., `dark:bg-slate-800 dark:text-slate-100`). For interactive components with dynamic inline styles (where colors come from data like `comp.color`), use the `useTheme()` hook + `ds()` helper from `src/helpers/darkStyle.ts` to select light/dark values. Standard dark palette: backgrounds `#1e293b` (slate-800), text `#e2e8f0` (slate-200), borders `#334155` (slate-700). All new interactive MDX components must support dark mode.
 
 ## Footnotes & References
 
@@ -151,6 +152,7 @@ Brief intro paragraph.
 - Only Start page components use `HtmlContent` / `dangerouslySetInnerHTML`. MDX pages use MDX components directly.
 - Export `NAV_ORDER` and `PAGE_IDS` from the data file so `navigation.ts` can import them.
 - Register any new interactive MDX components in `src/components/mdx/index.ts` or they won't be available in MDX files.
+- Interactive components with inline styles must support dark mode. Use `useTheme()` and `ds()` helper for theme-conditional values. Add `darkAccent` fields to data interfaces when components use dynamic accent colors.
 
 ## Pre-Push Checklist
 

--- a/src/components/ExternalResourcesPage.tsx
+++ b/src/components/ExternalResourcesPage.tsx
@@ -40,6 +40,19 @@ const sectionTopicMap: Record<string, string[]> = {
   'ci-testing': ['ci-cd', 'testing'],
   'ci-repo-maintenance': ['ci-cd', 'tooling'],
   storybook: ['tooling', 'testing'],
+  'arch-what-is-a-stack': ['architecture'],
+  'arch-stack-mern': ['architecture', 'databases'],
+  'arch-stack-pfrn': ['architecture', 'databases'],
+  'arch-stack-mean': ['architecture'],
+  'arch-stack-lamp': ['architecture', 'databases'],
+  'arch-stack-django': ['architecture', 'databases'],
+  'arch-stack-rails': ['architecture', 'databases'],
+  'arch-frameworks-intro': ['architecture', 'frameworks'],
+  'arch-fw-nextjs': ['frameworks'],
+  'arch-fw-react-router': ['frameworks'],
+  'arch-fw-tanstack-start': ['frameworks', 'typescript'],
+  'arch-fw-remix': ['frameworks'],
+  'arch-how-it-connects': ['architecture'],
 }
 
 // Generate short relevance descriptions for section references
@@ -61,6 +74,19 @@ const sectionDescMap: Record<string, string> = {
   'ci-testing': 'Automated testing for packages',
   'ci-repo-maintenance': 'Keeping dependencies and exports clean',
   storybook: 'Component documentation and visual testing',
+  'arch-what-is-a-stack': 'Understanding the concept and structure of web technology stacks',
+  'arch-stack-mern': 'MongoDB, Express, React, Node.js — the popular all-JavaScript stack',
+  'arch-stack-pfrn': 'PostgreSQL, Fastify, React, Node.js — the production-ready alternative',
+  'arch-stack-mean': 'MongoDB, Express, Angular, Node.js — enterprise-friendly with Angular',
+  'arch-stack-lamp': 'Linux, Apache, MySQL, PHP — the battle-tested classic',
+  'arch-stack-django': 'PostgreSQL, Django, React/Vue, Python — batteries included',
+  'arch-stack-rails': 'PostgreSQL, Ruby on Rails, Hotwire/React, Ruby — convention over configuration',
+  'arch-frameworks-intro': 'Introduction to full-stack React frameworks',
+  'arch-fw-nextjs': 'The most popular React meta-framework by Vercel',
+  'arch-fw-react-router': 'React Router v7 full-stack framework mode',
+  'arch-fw-tanstack-start': 'Type-safe full-stack framework from the TanStack ecosystem',
+  'arch-fw-remix': 'Pioneering web-standards framework merged into React Router',
+  'arch-how-it-connects': 'How data flows through a stack from browser to database',
 }
 
 function buildReferenceData(): ReferenceRow[] {

--- a/src/components/mdx/DataFlowDiagram.tsx
+++ b/src/components/mdx/DataFlowDiagram.tsx
@@ -1,29 +1,34 @@
 import { DATA_FLOW, LAYER_COLORS } from '../../data/archData'
+import { useTheme } from '../../hooks/useTheme'
+import { ds } from '../../helpers/darkStyle'
 
 export function DataFlowDiagram() {
+  const { theme } = useTheme()
+  const isDark = theme === 'dark'
+
   return (
-    <div style={{ fontFamily: "'DM Sans', sans-serif", color: "#1e293b" }}>
+    <div style={{ fontFamily: "'DM Sans', sans-serif", color: ds("#1e293b", "#f1f5f9", isDark) }}>
       <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
-      <div style={{ background: "#fff", borderRadius: "14px", padding: "22px", boxShadow: "0 1px 6px #0001" }}>
-        <div style={{ fontSize: "12px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#475569", marginBottom: "4px" }}>{"\u{1F501}"} Data flow through the stack</div>
-        <p style={{ fontSize: "13px", color: "#94a3b8", margin: "0 0 14px 0" }}>
+      <div style={{ background: ds("#fff", "#1e293b", isDark), borderRadius: "14px", padding: "22px", boxShadow: ds("0 1px 6px #0001", "0 1px 6px #0003", isDark) }}>
+        <div style={{ fontSize: "12px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: ds("#475569", "#94a3b8", isDark), marginBottom: "4px" }}>{"\u{1F501}"} Data flow through the stack</div>
+        <p style={{ fontSize: "13px", color: ds("#94a3b8", "#64748b", isDark), margin: "0 0 14px 0" }}>
           Every request follows this path regardless of which technology fills each layer.
         </p>
         <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
           {DATA_FLOW.map((item) => {
             const lc = LAYER_COLORS[item.colorId]
             return (
-              <div key={item.step} style={{ display: "flex", alignItems: "center", gap: "10px", padding: "9px 12px", borderRadius: "9px", background: "#f8fafc", fontSize: "13.5px" }}>
+              <div key={item.step} style={{ display: "flex", alignItems: "center", gap: "10px", padding: "9px 12px", borderRadius: "9px", background: ds("#f8fafc", "#0f172a", isDark), fontSize: "13.5px" }}>
                 <span style={{ background: lc?.color ?? "#94a3b8", color: "#fff", borderRadius: "50%", width: "24px", height: "24px", minWidth: "24px", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "11px", fontWeight: 700 }}>{item.step}</span>
-                <span style={{ flex: 1, color: "#374151" }}>{item.text}</span>
+                <span style={{ flex: 1, color: ds("#374151", "#e2e8f0", isDark) }}>{item.text}</span>
                 <span style={{ fontSize: "10px", fontWeight: 600, color: lc?.color ?? "#94a3b8", background: `${lc?.color ?? "#94a3b8"}10`, padding: "3px 7px", borderRadius: "5px", whiteSpace: "nowrap" }}>{item.tag}</span>
               </div>
             )
           })}
         </div>
-        <p style={{ fontSize: "12px", color: "#94a3b8", marginTop: "12px", marginBottom: 0, textAlign: "center" }}>
-          All server-side layers run on <strong style={{ color: "#ca8a04" }}>Node.js</strong> &mdash; the JavaScript engine that powers everything outside the browser.
+        <p style={{ fontSize: "12px", color: ds("#94a3b8", "#64748b", isDark), marginTop: "12px", marginBottom: 0, textAlign: "center" }}>
+          All server-side layers run on <strong style={{ color: ds("#ca8a04", "#facc15", isDark) }}>Node.js</strong> &mdash; the JavaScript engine that powers everything outside the browser.
         </p>
       </div>
     </div>

--- a/src/components/mdx/FrameworkExplorer.tsx
+++ b/src/components/mdx/FrameworkExplorer.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
 import { FRAMEWORK_PAGES } from '../../data/archData'
 import type { FrameworkCapability } from '../../data/archData'
+import { useTheme } from '../../hooks/useTheme'
+import { ds } from '../../helpers/darkStyle'
 
-function CapabilityBar({ cap, color, accent, isActive, onClick }: { cap: FrameworkCapability; color: string; accent: string; isActive: boolean; onClick: () => void }) {
+function CapabilityBar({ cap, color, accent, darkAccent, isActive, onClick, isDark }: { cap: FrameworkCapability; color: string; accent: string; darkAccent: string; isActive: boolean; onClick: () => void; isDark: boolean }) {
   return (
     <button
       onClick={onClick}
@@ -11,24 +13,26 @@ function CapabilityBar({ cap, color, accent, isActive, onClick }: { cap: Framewo
         display: "flex", alignItems: "stretch", borderRadius: "10px", overflow: "hidden",
         transition: "all 0.2s ease",
         transform: isActive ? "scale(1.02)" : "scale(1)",
-        boxShadow: isActive ? `0 3px 16px ${color}30` : "0 1px 4px #0001",
+        boxShadow: isActive ? `0 3px 16px ${color}30` : ds("0 1px 4px #0001", "0 1px 4px #0003", isDark),
       }}
     >
       <div style={{ width: "6px", minHeight: "100%", background: color, opacity: isActive ? 1 : 0.35, transition: "opacity 0.2s" }} />
-      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 16px", background: isActive ? accent : "#fff", transition: "background 0.2s" }}>
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 16px", background: isActive ? (isDark ? darkAccent : accent) : ds("#fff", "#1e293b", isDark), transition: "background 0.2s" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
           <span style={{ fontSize: "18px" }}>{cap.icon}</span>
           <div style={{ textAlign: "left" }}>
-            <div style={{ fontSize: "14px", fontWeight: 700, color: isActive ? color : "#374151" }}>{cap.name}</div>
+            <div style={{ fontSize: "14px", fontWeight: 700, color: isActive ? color : ds("#374151", "#e2e8f0", isDark) }}>{cap.name}</div>
           </div>
         </div>
-        <span style={{ fontSize: "12px", color: "#94a3b8", transition: "transform 0.2s", transform: isActive ? "rotate(90deg)" : "rotate(0)" }}>{"\u25B6"}</span>
+        <span style={{ fontSize: "12px", color: ds("#94a3b8", "#64748b", isDark), transition: "transform 0.2s", transform: isActive ? "rotate(90deg)" : "rotate(0)" }}>{"\u25B6"}</span>
       </div>
     </button>
   )
 }
 
 export function FrameworkExplorer({ frameworkId }: { frameworkId: string }) {
+  const { theme } = useTheme()
+  const isDark = theme === 'dark'
   const fw = FRAMEWORK_PAGES.find(f => f.id === frameworkId)
   const [activeId, setActiveId] = useState(fw?.capabilities[0]?.id ?? "")
   const active = fw?.capabilities.find(c => c.id === activeId)
@@ -36,17 +40,17 @@ export function FrameworkExplorer({ frameworkId }: { frameworkId: string }) {
   if (!fw) return <div>Framework not found: {frameworkId}</div>
 
   return (
-    <div style={{ fontFamily: "'DM Sans', sans-serif", color: "#1e293b" }}>
+    <div style={{ fontFamily: "'DM Sans', sans-serif", color: ds("#1e293b", "#f1f5f9", isDark) }}>
       <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700&display=swap" rel="stylesheet" />
 
       {/* Capability bars */}
       <div style={{ display: "flex", flexDirection: "column", gap: "6px", marginBottom: "28px" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "2px", padding: "0 4px" }}>
-          <span style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>Built on: {fw.builtOn.join(" + ")}</span>
-          <div style={{ flex: 1, height: "1px", background: "#e2e8f0" }} />
+          <span style={{ fontSize: "11px", color: ds("#94a3b8", "#64748b", isDark), fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>Built on: {fw.builtOn.join(" + ")}</span>
+          <div style={{ flex: 1, height: "1px", background: ds("#e2e8f0", "#334155", isDark) }} />
         </div>
         {fw.capabilities.map(cap => (
-          <CapabilityBar key={cap.id} cap={cap} color={fw.color} accent={fw.accent} isActive={activeId === cap.id} onClick={() => setActiveId(cap.id)} />
+          <CapabilityBar key={cap.id} cap={cap} color={fw.color} accent={fw.accent} darkAccent={fw.darkAccent} isActive={activeId === cap.id} onClick={() => setActiveId(cap.id)} isDark={isDark} />
         ))}
       </div>
 
@@ -61,19 +65,19 @@ export function FrameworkExplorer({ frameworkId }: { frameworkId: string }) {
           </div>
 
           {/* Description */}
-          <div style={{ background: "#fff", borderRadius: "12px", padding: "18px 20px", boxShadow: "0 1px 5px #0001", borderLeft: `4px solid ${fw.color}` }}>
+          <div style={{ background: ds("#fff", "#1e293b", isDark), borderRadius: "12px", padding: "18px 20px", boxShadow: ds("0 1px 5px #0001", "0 1px 5px #0003", isDark), borderLeft: `4px solid ${fw.color}` }}>
             <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: fw.color, marginBottom: "6px" }}>How it works</div>
-            <p style={{ margin: 0, lineHeight: 1.75, fontSize: "14.5px", color: "#374151" }}>{active.description}</p>
+            <p style={{ margin: 0, lineHeight: 1.75, fontSize: "14.5px", color: ds("#374151", "#e2e8f0", isDark) }}>{active.description}</p>
           </div>
 
           {/* Key points */}
-          <div style={{ background: "#fff", borderRadius: "12px", padding: "18px 20px", boxShadow: "0 1px 5px #0001" }}>
+          <div style={{ background: ds("#fff", "#1e293b", isDark), borderRadius: "12px", padding: "18px 20px", boxShadow: ds("0 1px 5px #0001", "0 1px 5px #0003", isDark) }}>
             <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: fw.color, marginBottom: "10px" }}>
               {"\u2705"} Key takeaways
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
               {active.keyPoints.map((item, i) => (
-                <div key={i} style={{ display: "flex", gap: "10px", alignItems: "flex-start", fontSize: "14px", lineHeight: 1.6, color: "#374151" }}>
+                <div key={i} style={{ display: "flex", gap: "10px", alignItems: "flex-start", fontSize: "14px", lineHeight: 1.6, color: ds("#374151", "#e2e8f0", isDark) }}>
                   <span style={{ background: fw.color, color: "#fff", borderRadius: "50%", width: "20px", height: "20px", minWidth: "20px", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "10px", fontWeight: 700, marginTop: "2px" }}>{i + 1}</span>
                   <span>{item}</span>
                 </div>

--- a/src/components/mdx/FrameworkProsCons.tsx
+++ b/src/components/mdx/FrameworkProsCons.tsx
@@ -1,34 +1,38 @@
 import { FRAMEWORK_PAGES } from '../../data/archData'
+import { useTheme } from '../../hooks/useTheme'
+import { ds } from '../../helpers/darkStyle'
 
 export function FrameworkProsCons({ frameworkId }: { frameworkId: string }) {
+  const { theme } = useTheme()
+  const isDark = theme === 'dark'
   const fw = FRAMEWORK_PAGES.find(f => f.id === frameworkId)
   if (!fw) return null
 
   return (
-    <div style={{ fontFamily: "'DM Sans', sans-serif", color: "#1e293b" }}>
+    <div style={{ fontFamily: "'DM Sans', sans-serif", color: ds("#1e293b", "#f1f5f9", isDark) }}>
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px", marginBottom: "20px" }}>
-        <div style={{ background: "#f0fdf4", borderRadius: "10px", padding: "14px" }}>
-          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#16a34a", marginBottom: "8px" }}>{"\u2705"} Strengths</div>
+        <div style={{ background: ds("#f0fdf4", "#052e16", isDark), borderRadius: "10px", padding: "14px" }}>
+          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: ds("#16a34a", "#4ade80", isDark), marginBottom: "8px" }}>{"\u2705"} Strengths</div>
           <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
             {fw.pros.map((pro, i) => (
-              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: "#374151", paddingLeft: "10px", borderLeft: "2px solid #bbf7d0" }}>{pro}</div>
+              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: ds("#374151", "#e2e8f0", isDark), paddingLeft: "10px", borderLeft: ds("2px solid #bbf7d0", "2px solid #166534", isDark) }}>{pro}</div>
             ))}
           </div>
         </div>
-        <div style={{ background: "#fef2f2", borderRadius: "10px", padding: "14px" }}>
-          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#dc2626", marginBottom: "8px" }}>{"\u26A0\uFE0F"} Tradeoffs</div>
+        <div style={{ background: ds("#fef2f2", "#450a0a", isDark), borderRadius: "10px", padding: "14px" }}>
+          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: ds("#dc2626", "#f87171", isDark), marginBottom: "8px" }}>{"\u26A0\uFE0F"} Tradeoffs</div>
           <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
             {fw.cons.map((con, i) => (
-              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: "#374151", paddingLeft: "10px", borderLeft: "2px solid #fecaca" }}>{con}</div>
+              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: ds("#374151", "#e2e8f0", isDark), paddingLeft: "10px", borderLeft: ds("2px solid #fecaca", "2px solid #991b1b", isDark) }}>{con}</div>
             ))}
           </div>
         </div>
       </div>
 
       {/* Best For */}
-      <div style={{ background: `linear-gradient(135deg, ${fw.accent}, #fff)`, borderRadius: "12px", padding: "16px 18px", border: `1px solid ${fw.color}18` }}>
+      <div style={{ background: `linear-gradient(135deg, ${isDark ? fw.darkAccent : fw.accent}, ${ds("#fff", "#1e293b", isDark)})`, borderRadius: "12px", padding: "16px 18px", border: `1px solid ${fw.color}18` }}>
         <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: fw.color, marginBottom: "6px" }}>{"\u{1F3AF}"} Best for</div>
-        <p style={{ margin: 0, lineHeight: 1.7, fontSize: "14px", color: "#374151" }}>{fw.bestFor}</p>
+        <p style={{ margin: 0, lineHeight: 1.7, fontSize: "14px", color: ds("#374151", "#e2e8f0", isDark) }}>{fw.bestFor}</p>
       </div>
 
       <style>{`

--- a/src/components/mdx/LayerDiagram.tsx
+++ b/src/components/mdx/LayerDiagram.tsx
@@ -1,4 +1,6 @@
 import { LAYER_COLORS } from '../../data/archData'
+import { useTheme } from '../../hooks/useTheme'
+import { ds } from '../../helpers/darkStyle'
 
 const LAYERS = [
   { id: "frontend", label: "Frontend", desc: "What users see & interact with", icon: "\u{1F3A8}", example: "React, Angular, Vue" },
@@ -8,14 +10,17 @@ const LAYERS = [
 ]
 
 export function LayerDiagram() {
+  const { theme } = useTheme()
+  const isDark = theme === 'dark'
+
   return (
-    <div style={{ fontFamily: "'DM Sans', sans-serif", color: "#1e293b" }}>
+    <div style={{ fontFamily: "'DM Sans', sans-serif", color: ds("#1e293b", "#f1f5f9", isDark) }}>
       <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
 
       <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "2px", padding: "0 4px" }}>
-          <span style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>User&apos;s Browser</span>
-          <div style={{ flex: 1, height: "1px", background: "#e2e8f0" }} />
+          <span style={{ fontSize: "11px", color: ds("#94a3b8", "#64748b", isDark), fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>User&apos;s Browser</span>
+          <div style={{ flex: 1, height: "1px", background: ds("#e2e8f0", "#334155", isDark) }} />
         </div>
 
         {LAYERS.map((layer) => {
@@ -23,18 +28,18 @@ export function LayerDiagram() {
           return (
             <div key={layer.id} style={{
               display: "flex", alignItems: "stretch", borderRadius: "10px", overflow: "hidden",
-              boxShadow: "0 1px 4px #0001",
+              boxShadow: ds("0 1px 4px #0001", "0 1px 4px #0003", isDark),
             }}>
               <div style={{ width: "6px", minHeight: "100%", background: lc?.color ?? "#94a3b8" }} />
-              <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 16px", background: "#fff" }}>
+              <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 16px", background: ds("#fff", "#1e293b", isDark) }}>
                 <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
                   <span style={{ fontSize: "18px" }}>{layer.icon}</span>
                   <div>
-                    <div style={{ fontSize: "14px", fontWeight: 700, color: lc?.color ?? "#374151" }}>{layer.label}</div>
-                    <div style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 500 }}>{layer.desc}</div>
+                    <div style={{ fontSize: "14px", fontWeight: 700, color: lc?.color ?? ds("#374151", "#e2e8f0", isDark) }}>{layer.label}</div>
+                    <div style={{ fontSize: "11px", color: ds("#94a3b8", "#64748b", isDark), fontWeight: 500 }}>{layer.desc}</div>
                   </div>
                 </div>
-                <div style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 500, textAlign: "right", maxWidth: "160px" }}>
+                <div style={{ fontSize: "11px", color: ds("#94a3b8", "#64748b", isDark), fontWeight: 500, textAlign: "right", maxWidth: "160px" }}>
                   {layer.example}
                 </div>
               </div>
@@ -43,8 +48,8 @@ export function LayerDiagram() {
         })}
 
         <div style={{ display: "flex", alignItems: "center", gap: "10px", marginTop: "2px", padding: "0 4px" }}>
-          <div style={{ flex: 1, height: "1px", background: "#e2e8f0" }} />
-          <span style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>Stored on Disk</span>
+          <div style={{ flex: 1, height: "1px", background: ds("#e2e8f0", "#334155", isDark) }} />
+          <span style={{ fontSize: "11px", color: ds("#94a3b8", "#64748b", isDark), fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>Stored on Disk</span>
         </div>
       </div>
     </div>

--- a/src/components/mdx/StackExplorer.tsx
+++ b/src/components/mdx/StackExplorer.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react'
 import { STACK_PAGES } from '../../data/archData'
 import type { StackComponent } from '../../data/archData'
+import { useTheme } from '../../hooks/useTheme'
+import { ds } from '../../helpers/darkStyle'
 
-function ComponentBar({ comp, isActive, onClick }: { comp: StackComponent; isActive: boolean; onClick: () => void }) {
+function ComponentBar({ comp, isActive, onClick, isDark }: { comp: StackComponent; isActive: boolean; onClick: () => void; isDark: boolean }) {
   return (
     <button
       onClick={onClick}
@@ -11,40 +13,40 @@ function ComponentBar({ comp, isActive, onClick }: { comp: StackComponent; isAct
         display: "flex", alignItems: "stretch", borderRadius: "10px", overflow: "hidden",
         transition: "all 0.2s ease",
         transform: isActive ? "scale(1.02)" : "scale(1)",
-        boxShadow: isActive ? `0 3px 16px ${comp.color}30` : "0 1px 4px #0001",
+        boxShadow: isActive ? `0 3px 16px ${comp.color}30` : ds("0 1px 4px #0001", "0 1px 4px #0003", isDark),
       }}
     >
       <div style={{ width: "6px", minHeight: "100%", background: comp.color, opacity: isActive ? 1 : 0.35, transition: "opacity 0.2s" }} />
-      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 16px", background: isActive ? comp.accent : "#fff", transition: "background 0.2s" }}>
+      <div style={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "space-between", padding: "14px 16px", background: isActive ? (isDark ? comp.darkAccent : comp.accent) : ds("#fff", "#1e293b", isDark), transition: "background 0.2s" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "10px" }}>
           <span style={{ fontSize: "18px" }}>{comp.icon}</span>
           <div style={{ textAlign: "left" }}>
-            <div style={{ fontSize: "14px", fontWeight: 700, color: isActive ? comp.color : "#374151" }}>{comp.name}</div>
-            <div style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 500 }}>{comp.role}</div>
+            <div style={{ fontSize: "14px", fontWeight: 700, color: isActive ? comp.color : ds("#374151", "#e2e8f0", isDark) }}>{comp.name}</div>
+            <div style={{ fontSize: "11px", color: ds("#94a3b8", "#64748b", isDark), fontWeight: 500 }}>{comp.role}</div>
           </div>
         </div>
         <div style={{ display: "flex", alignItems: "center", gap: "8px" }}>
           {comp.changed && (
             <span style={{ fontSize: "10px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.5px", background: `${comp.color}18`, color: comp.color, padding: "3px 8px", borderRadius: "5px" }}>Modified</span>
           )}
-          <span style={{ fontSize: "12px", color: "#94a3b8", transition: "transform 0.2s", transform: isActive ? "rotate(90deg)" : "rotate(0)" }}>{"\u25B6"}</span>
+          <span style={{ fontSize: "12px", color: ds("#94a3b8", "#64748b", isDark), transition: "transform 0.2s", transform: isActive ? "rotate(90deg)" : "rotate(0)" }}>{"\u25B6"}</span>
         </div>
       </div>
     </button>
   )
 }
 
-function ComparisonToggle({ comp }: { comp: StackComponent }) {
+function ComparisonToggle({ comp, isDark }: { comp: StackComponent; isDark: boolean }) {
   const [showModified, setShowModified] = useState(true)
   return (
-    <div style={{ background: "#fff", borderRadius: "12px", border: `1.5px solid ${comp.color}18`, overflow: "hidden" }}>
+    <div style={{ background: ds("#fff", "#1e293b", isDark), borderRadius: "12px", border: `1.5px solid ${comp.color}18`, overflow: "hidden" }}>
       <div style={{ display: "flex", borderBottom: `1px solid ${comp.color}12` }}>
         {[false, true].map((mod) => (
           <button key={String(mod)} onClick={() => setShowModified(mod)} style={{
             flex: 1, padding: "11px", border: "none", cursor: "pointer",
             fontFamily: "inherit", fontSize: "13px", fontWeight: 600,
-            background: showModified === mod ? comp.accent : "transparent",
-            color: showModified === mod ? comp.color : "#94a3b8",
+            background: showModified === mod ? (isDark ? comp.darkAccent : comp.accent) : "transparent",
+            color: showModified === mod ? comp.color : ds("#94a3b8", "#64748b", isDark),
             borderBottom: showModified === mod ? `3px solid ${comp.color}` : "3px solid transparent",
             transition: "all 0.2s",
           }}>
@@ -52,32 +54,34 @@ function ComparisonToggle({ comp }: { comp: StackComponent }) {
           </button>
         ))}
       </div>
-      <div style={{ padding: "16px 18px", fontSize: "14px", lineHeight: 1.75, color: "#374151" }}>
+      <div style={{ padding: "16px 18px", fontSize: "14px", lineHeight: 1.75, color: ds("#374151", "#e2e8f0", isDark) }}>
         {showModified ? comp.modifiedDesc : comp.traditionalDesc}
       </div>
     </div>
   )
 }
 
-function UnchangedExplanation({ comp }: { comp: StackComponent }) {
+function UnchangedExplanation({ comp, isDark }: { comp: StackComponent; isDark: boolean }) {
   return (
-    <div style={{ background: "#fff", borderRadius: "12px", border: `1.5px solid ${comp.color}18`, padding: "16px 18px" }}>
-      <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#94a3b8", marginBottom: "8px" }}>Same in both stacks &mdash; no changes here</div>
-      <p style={{ margin: 0, fontSize: "14px", lineHeight: 1.75, color: "#374151" }}>{comp.description}</p>
+    <div style={{ background: ds("#fff", "#1e293b", isDark), borderRadius: "12px", border: `1.5px solid ${comp.color}18`, padding: "16px 18px" }}>
+      <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: ds("#94a3b8", "#64748b", isDark), marginBottom: "8px" }}>Same in both stacks &mdash; no changes here</div>
+      <p style={{ margin: 0, fontSize: "14px", lineHeight: 1.75, color: ds("#374151", "#e2e8f0", isDark) }}>{comp.description}</p>
     </div>
   )
 }
 
-function PlainDescription({ comp }: { comp: StackComponent }) {
+function PlainDescription({ comp, isDark }: { comp: StackComponent; isDark: boolean }) {
   return (
-    <div style={{ background: "#fff", borderRadius: "12px", border: `1.5px solid ${comp.color}18`, padding: "16px 18px" }}>
-      <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#94a3b8", marginBottom: "8px" }}>About {comp.name}</div>
-      <p style={{ margin: 0, fontSize: "14px", lineHeight: 1.75, color: "#374151" }}>{comp.description}</p>
+    <div style={{ background: ds("#fff", "#1e293b", isDark), borderRadius: "12px", border: `1.5px solid ${comp.color}18`, padding: "16px 18px" }}>
+      <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: ds("#94a3b8", "#64748b", isDark), marginBottom: "8px" }}>About {comp.name}</div>
+      <p style={{ margin: 0, fontSize: "14px", lineHeight: 1.75, color: ds("#374151", "#e2e8f0", isDark) }}>{comp.description}</p>
     </div>
   )
 }
 
 export function StackExplorer({ stackId }: { stackId: string }) {
+  const { theme } = useTheme()
+  const isDark = theme === 'dark'
   const stack = STACK_PAGES.find(s => s.id === stackId)
   const [activeId, setActiveId] = useState(stack?.components[0]?.id ?? "")
   const active = stack?.components.find(c => c.id === activeId)
@@ -97,7 +101,7 @@ export function StackExplorer({ stackId }: { stackId: string }) {
   if (!stack) return <div>Stack not found: {stackId}</div>
 
   return (
-    <div style={{ fontFamily: "'DM Sans', sans-serif", color: "#1e293b" }}>
+    <div style={{ fontFamily: "'DM Sans', sans-serif", color: ds("#1e293b", "#f1f5f9", isDark) }}>
       <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,wght@0,400;0,500;0,600;0,700&family=DM+Serif+Display&display=swap" rel="stylesheet" />
 
       {/* Clickable letter header */}
@@ -118,7 +122,7 @@ export function StackExplorer({ stackId }: { stackId: string }) {
                 key={letter}
                 onClick={() => comp && setActiveId(comp.id)}
                 style={{
-                  color: comp && activeId === comp.id ? comp.color : "#cbd5e1",
+                  color: comp && activeId === comp.id ? comp.color : ds("#cbd5e1", "#475569", isDark),
                   cursor: "pointer",
                   transition: "color 0.25s",
                 }}
@@ -127,7 +131,7 @@ export function StackExplorer({ stackId }: { stackId: string }) {
               </span>
             ))}
             <span style={{
-              color: "#cbd5e1",
+              color: ds("#cbd5e1", "#475569", isDark),
               marginLeft: "6px",
               fontSize: "26px",
               alignSelf: "center",
@@ -139,15 +143,15 @@ export function StackExplorer({ stackId }: { stackId: string }) {
       {/* Component bars */}
       <div style={{ display: "flex", flexDirection: "column", gap: "6px", marginBottom: "28px" }}>
         <div style={{ display: "flex", alignItems: "center", gap: "10px", marginBottom: "2px", padding: "0 4px" }}>
-          <span style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>User&apos;s Browser</span>
-          <div style={{ flex: 1, height: "1px", background: "#e2e8f0" }} />
+          <span style={{ fontSize: "11px", color: ds("#94a3b8", "#64748b", isDark), fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>User&apos;s Browser</span>
+          <div style={{ flex: 1, height: "1px", background: ds("#e2e8f0", "#334155", isDark) }} />
         </div>
         {stack.components.map(comp => (
-          <ComponentBar key={comp.id} comp={comp} isActive={activeId === comp.id} onClick={() => setActiveId(comp.id)} />
+          <ComponentBar key={comp.id} comp={comp} isActive={activeId === comp.id} onClick={() => setActiveId(comp.id)} isDark={isDark} />
         ))}
         <div style={{ display: "flex", alignItems: "center", gap: "10px", marginTop: "2px", padding: "0 4px" }}>
-          <div style={{ flex: 1, height: "1px", background: "#e2e8f0" }} />
-          <span style={{ fontSize: "11px", color: "#94a3b8", fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>Infrastructure</span>
+          <div style={{ flex: 1, height: "1px", background: ds("#e2e8f0", "#334155", isDark) }} />
+          <span style={{ fontSize: "11px", color: ds("#94a3b8", "#64748b", isDark), fontWeight: 600, textTransform: "uppercase", letterSpacing: "1px" }}>Infrastructure</span>
         </div>
       </div>
 
@@ -162,33 +166,33 @@ export function StackExplorer({ stackId }: { stackId: string }) {
           </div>
 
           {/* Purpose */}
-          <div style={{ background: "#fff", borderRadius: "12px", padding: "18px 20px", boxShadow: "0 1px 5px #0001", borderLeft: `4px solid ${active.color}` }}>
+          <div style={{ background: ds("#fff", "#1e293b", isDark), borderRadius: "12px", padding: "18px 20px", boxShadow: ds("0 1px 5px #0001", "0 1px 5px #0003", isDark), borderLeft: `4px solid ${active.color}` }}>
             <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: active.color, marginBottom: "6px" }}>Why does this layer exist?</div>
-            <p style={{ margin: 0, lineHeight: 1.75, fontSize: "14.5px", color: "#374151" }}>{active.purpose}</p>
+            <p style={{ margin: 0, lineHeight: 1.75, fontSize: "14.5px", color: ds("#374151", "#e2e8f0", isDark) }}>{active.purpose}</p>
           </div>
 
           {/* Description / Comparison */}
           {isPfrn && active.changed
-            ? <ComparisonToggle comp={active} />
+            ? <ComparisonToggle comp={active} isDark={isDark} />
             : isPfrn && active.traditionalName !== undefined
-              ? <UnchangedExplanation comp={active} />
-              : <PlainDescription comp={active} />
+              ? <UnchangedExplanation comp={active} isDark={isDark} />
+              : <PlainDescription comp={active} isDark={isDark} />
           }
 
           {/* Analogy */}
-          <div style={{ background: `linear-gradient(135deg, ${active.accent}, #fff)`, borderRadius: "12px", padding: "16px 18px", border: `1px solid ${active.color}18` }}>
+          <div style={{ background: `linear-gradient(135deg, ${isDark ? active.darkAccent : active.accent}, ${ds("#fff", "#1e293b", isDark)})`, borderRadius: "12px", padding: "16px 18px", border: `1px solid ${active.color}18` }}>
             <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: active.color, marginBottom: "6px" }}>{"\u{1F4A1}"} Analogy</div>
-            <p style={{ margin: 0, lineHeight: 1.7, fontSize: "14px", color: "#374151", fontStyle: "italic" }}>{active.analogy}</p>
+            <p style={{ margin: 0, lineHeight: 1.7, fontSize: "14px", color: ds("#374151", "#e2e8f0", isDark), fontStyle: "italic" }}>{active.analogy}</p>
           </div>
 
           {/* Key features */}
-          <div style={{ background: "#fff", borderRadius: "12px", padding: "18px 20px", boxShadow: "0 1px 5px #0001" }}>
+          <div style={{ background: ds("#fff", "#1e293b", isDark), borderRadius: "12px", padding: "18px 20px", boxShadow: ds("0 1px 5px #0001", "0 1px 5px #0003", isDark) }}>
             <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: active.color, marginBottom: "10px" }}>
               {active.changed ? `\u{1F504} What changes with ${active.name}?` : "\u2705 Key takeaways"}
             </div>
             <div style={{ display: "flex", flexDirection: "column", gap: "8px" }}>
               {active.keyFeatures.map((item, i) => (
-                <div key={i} style={{ display: "flex", gap: "10px", alignItems: "flex-start", fontSize: "14px", lineHeight: 1.6, color: "#374151" }}>
+                <div key={i} style={{ display: "flex", gap: "10px", alignItems: "flex-start", fontSize: "14px", lineHeight: 1.6, color: ds("#374151", "#e2e8f0", isDark) }}>
                   <span style={{ background: active.color, color: "#fff", borderRadius: "50%", width: "20px", height: "20px", minWidth: "20px", display: "flex", alignItems: "center", justifyContent: "center", fontSize: "10px", fontWeight: 700, marginTop: "2px" }}>{i + 1}</span>
                   <span>{item}</span>
                 </div>

--- a/src/components/mdx/StackProsCons.tsx
+++ b/src/components/mdx/StackProsCons.tsx
@@ -1,34 +1,38 @@
 import { STACK_PAGES } from '../../data/archData'
+import { useTheme } from '../../hooks/useTheme'
+import { ds } from '../../helpers/darkStyle'
 
 export function StackProsCons({ stackId }: { stackId: string }) {
+  const { theme } = useTheme()
+  const isDark = theme === 'dark'
   const stack = STACK_PAGES.find(s => s.id === stackId)
   if (!stack) return null
 
   return (
-    <div style={{ fontFamily: "'DM Sans', sans-serif", color: "#1e293b" }}>
+    <div style={{ fontFamily: "'DM Sans', sans-serif", color: ds("#1e293b", "#f1f5f9", isDark) }}>
       <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: "12px", marginBottom: "20px" }}>
-        <div style={{ background: "#f0fdf4", borderRadius: "10px", padding: "14px" }}>
-          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#16a34a", marginBottom: "8px" }}>{"\u2705"} Strengths</div>
+        <div style={{ background: ds("#f0fdf4", "#052e16", isDark), borderRadius: "10px", padding: "14px" }}>
+          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: ds("#16a34a", "#4ade80", isDark), marginBottom: "8px" }}>{"\u2705"} Strengths</div>
           <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
             {stack.pros.map((pro, i) => (
-              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: "#374151", paddingLeft: "10px", borderLeft: "2px solid #bbf7d0" }}>{pro}</div>
+              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: ds("#374151", "#e2e8f0", isDark), paddingLeft: "10px", borderLeft: ds("2px solid #bbf7d0", "2px solid #166534", isDark) }}>{pro}</div>
             ))}
           </div>
         </div>
-        <div style={{ background: "#fef2f2", borderRadius: "10px", padding: "14px" }}>
-          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: "#dc2626", marginBottom: "8px" }}>{"\u26A0\uFE0F"} Tradeoffs</div>
+        <div style={{ background: ds("#fef2f2", "#450a0a", isDark), borderRadius: "10px", padding: "14px" }}>
+          <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: ds("#dc2626", "#f87171", isDark), marginBottom: "8px" }}>{"\u26A0\uFE0F"} Tradeoffs</div>
           <div style={{ display: "flex", flexDirection: "column", gap: "6px" }}>
             {stack.cons.map((con, i) => (
-              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: "#374151", paddingLeft: "10px", borderLeft: "2px solid #fecaca" }}>{con}</div>
+              <div key={i} style={{ fontSize: "12.5px", lineHeight: 1.55, color: ds("#374151", "#e2e8f0", isDark), paddingLeft: "10px", borderLeft: ds("2px solid #fecaca", "2px solid #991b1b", isDark) }}>{con}</div>
             ))}
           </div>
         </div>
       </div>
 
       {/* Best For */}
-      <div style={{ background: `linear-gradient(135deg, ${stack.accent}, #fff)`, borderRadius: "12px", padding: "16px 18px", border: `1px solid ${stack.color}18` }}>
+      <div style={{ background: `linear-gradient(135deg, ${isDark ? stack.darkAccent : stack.accent}, ${ds("#fff", "#1e293b", isDark)})`, borderRadius: "12px", padding: "16px 18px", border: `1px solid ${stack.color}18` }}>
         <div style={{ fontSize: "11px", fontWeight: 700, textTransform: "uppercase", letterSpacing: "1px", color: stack.color, marginBottom: "6px" }}>{"\u{1F3AF}"} Best for</div>
-        <p style={{ margin: 0, lineHeight: 1.7, fontSize: "14px", color: "#374151" }}>{stack.bestFor}</p>
+        <p style={{ margin: 0, lineHeight: 1.7, fontSize: "14px", color: ds("#374151", "#e2e8f0", isDark) }}>{stack.bestFor}</p>
       </div>
 
       <style>{`

--- a/src/content/architecture/arch-frameworks-intro.mdx
+++ b/src/content/architecture/arch-frameworks-intro.mdx
@@ -1,6 +1,18 @@
 ---
 id: "arch-frameworks-intro"
 title: "🏠 Full-Stack Frameworks"
+usedFootnotes: [2]
+links:
+  - label: "React documentation"
+    url: "https://react.dev/learn"
+    source: "React"
+  - label: "Rendering on the Web"
+    url: "https://web.dev/articles/rendering-on-the-web"
+    source: "web.dev"
+    note: "Comprehensive guide to rendering strategies: SSR, CSR, SSG, and hybrid approaches"
+  - label: "Server-side rendering vs client-side rendering"
+    url: "https://web.dev/articles/rendering-on-the-web#server-rendering"
+    source: "web.dev"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -23,7 +35,7 @@ In the previous sections, you learned about **stacks** &mdash; collections of in
 **Full-stack frameworks** take a different approach. They start with a frontend library (usually React) and add server-side capabilities on top:
 
 <SectionList>
-<ColItem>**Server rendering** &mdash; generate HTML on the server for faster initial loads and better SEO</ColItem>
+<ColItem>**Server rendering** &mdash; generate HTML on the server for faster initial loads and better SEO<FnRef n={2} /></ColItem>
 <ColItem>**File-system routing** &mdash; your file structure automatically becomes your URL structure</ColItem>
 <ColItem>**Data fetching** &mdash; load data on the server before sending pages to the browser</ColItem>
 <ColItem>**Build optimization** &mdash; automatic code splitting, bundling, and asset optimization</ColItem>

--- a/src/content/architecture/arch-fw-nextjs.mdx
+++ b/src/content/architecture/arch-fw-nextjs.mdx
@@ -1,6 +1,21 @@
 ---
 id: "arch-fw-nextjs"
 title: "▲ Next.js"
+usedFootnotes: [1, 2]
+links:
+  - label: "Next.js documentation"
+    url: "https://nextjs.org/docs"
+    source: "Next.js"
+  - label: "React Server Components"
+    url: "https://react.dev/reference/rsc/server-components"
+    source: "React"
+    note: "Official React documentation explaining how Server Components work and when to use them"
+  - label: "Next.js App Router"
+    url: "https://nextjs.org/docs/app"
+    source: "Next.js"
+  - label: "Vercel platform documentation"
+    url: "https://vercel.com/docs"
+    source: "Vercel"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -13,13 +28,13 @@ title: "▲ Next.js"
 </Toc>
 
 <SectionIntro>
-**Next.js** is the most popular React framework, developed by Vercel. It adds server-side rendering, file-system routing, API routes, and optimized builds on top of React &mdash; used in production by Netflix, TikTok, and Notion. It&apos;s the safe, well-documented default for most React projects.
+**Next.js** is the most popular React framework, developed by Vercel.<FnRef n={1} /> It adds server-side rendering, file-system routing, API routes, and optimized builds on top of React &mdash; used in production by Netflix, TikTok, and Notion. It&apos;s the safe, well-documented default for most React projects.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>
 
 <SectionList>
-<ColItem>**Multiple rendering strategies** &mdash; Server-Side Rendering (SSR), Static Site Generation (SSG), and React Server Components (RSC) in a single app. Choose per-page.</ColItem>
+<ColItem>**Multiple rendering strategies** &mdash; Server-Side Rendering (SSR), Static Site Generation (SSG), and React Server Components (RSC)<FnRef n={2} /> in a single app. Choose per-page.</ColItem>
 <ColItem>**File-system routing** &mdash; your folder structure automatically maps to URL paths. No manual route definitions needed.</ColItem>
 <ColItem>**Built-in optimizations** &mdash; automatic image optimization, font loading, code splitting, and bundle analysis out of the box.</ColItem>
 </SectionList>

--- a/src/content/architecture/arch-fw-react-router.mdx
+++ b/src/content/architecture/arch-fw-react-router.mdx
@@ -1,6 +1,17 @@
 ---
 id: "arch-fw-react-router"
 title: "🔀 React Router Framework"
+usedFootnotes: [1, 2]
+links:
+  - label: "React Router documentation"
+    url: "https://reactrouter.com/start/framework/installation"
+    source: "React Router"
+  - label: "MDN — Fetch API"
+    url: "https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API"
+    source: "MDN"
+  - label: "MDN — Progressive enhancement"
+    url: "https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement"
+    source: "MDN"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -13,13 +24,13 @@ title: "🔀 React Router Framework"
 </Toc>
 
 <SectionIntro>
-**React Router v7** introduced &ldquo;Framework Mode&rdquo; &mdash; transforming the most popular React routing library into a full-stack framework. It&apos;s the spiritual successor to Remix (which merged into React Router), built on web standards like the Fetch API, FormData, and HTTP caching. It&apos;s the web-standards-first alternative to Next.js.
+**React Router v7** introduced &ldquo;Framework Mode&rdquo;<FnRef n={1} /> &mdash; transforming the most popular React routing library into a full-stack framework. It&apos;s the spiritual successor to Remix (which merged into React Router), built on web standards like the Fetch API, FormData, and HTTP caching. It&apos;s the web-standards-first alternative to Next.js.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>
 
 <SectionList>
-<ColItem>**Web standards first** &mdash; built on Fetch API Request/Response, FormData, and HTTP caching headers. Skills you learn transfer to the platform and other frameworks.</ColItem>
+<ColItem>**Web standards first** &mdash; built on Fetch API<FnRef n={2} /> Request/Response, FormData, and HTTP caching headers. Skills you learn transfer to the platform and other frameworks.</ColItem>
 <ColItem>**Progressive enhancement** &mdash; forms and navigation work without JavaScript by default, then enhance with JS for a richer experience.</ColItem>
 <ColItem>**Nested routing pioneer** &mdash; React Router has 10+ years of battle-testing. Each route segment gets its own data loader, action handler, and error boundary.</ColItem>
 </SectionList>

--- a/src/content/architecture/arch-fw-remix.mdx
+++ b/src/content/architecture/arch-fw-remix.mdx
@@ -1,12 +1,24 @@
 ---
 id: "arch-fw-remix"
 title: "💿 Remix"
+usedFootnotes: [1, 2]
+links:
+  - label: "React Router v7 documentation"
+    url: "https://reactrouter.com/"
+    source: "React Router"
+  - label: "Remixing React Router"
+    url: "https://remix.run/blog/merging-remix-and-react-router"
+    source: "Remix"
+    note: "Official blog post explaining the merger of Remix into React Router v7"
+  - label: "MDN — Web standards"
+    url: "https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Web_standards"
+    source: "MDN"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
 <SectionNote>
-Remix merged into React Router v7 in 2024. New projects should use <NavLink to="arch-fw-react-router">React Router Framework Mode</NavLink> directly. This page covers Remix&apos;s contributions and ideas, which live on in React Router v7.
+Remix merged into React Router v7 in 2024.<FnRef n={1} /> New projects should use <NavLink to="arch-fw-react-router">React Router Framework Mode</NavLink> directly. This page covers Remix&apos;s contributions and ideas, which live on in React Router v7.
 </SectionNote>
 
 <Toc>
@@ -17,7 +29,7 @@ Remix merged into React Router v7 in 2024. New projects should use <NavLink to="
 </Toc>
 
 <SectionIntro>
-**Remix** was a pioneering full-stack React framework created by the React Router team (Ryan Florence and Michael Jackson). It championed web standards, progressive enhancement, and nested routing. Its ideas now live on in React Router v7 Framework Mode &mdash; understanding Remix helps you understand the patterns behind modern React frameworks.
+**Remix** was a pioneering full-stack React framework created by the React Router team (Ryan Florence and Michael Jackson).<FnRef n={2} /> It championed web standards, progressive enhancement, and nested routing. Its ideas now live on in React Router v7 Framework Mode &mdash; understanding Remix helps you understand the patterns behind modern React frameworks.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>

--- a/src/content/architecture/arch-fw-tanstack-start.mdx
+++ b/src/content/architecture/arch-fw-tanstack-start.mdx
@@ -1,6 +1,17 @@
 ---
 id: "arch-fw-tanstack-start"
 title: "🔥 TanStack Start"
+usedFootnotes: [1, 2]
+links:
+  - label: "TanStack Start documentation"
+    url: "https://tanstack.com/start/latest"
+    source: "TanStack"
+  - label: "TanStack Router documentation"
+    url: "https://tanstack.com/router/latest"
+    source: "TanStack"
+  - label: "TanStack Query documentation"
+    url: "https://tanstack.com/query/latest"
+    source: "TanStack"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -13,13 +24,13 @@ title: "🔥 TanStack Start"
 </Toc>
 
 <SectionIntro>
-**TanStack Start** is the newest full-stack React framework, built by Tanner Linsley (creator of TanStack Query, TanStack Router, and TanStack Table). It combines TanStack Router&apos;s type-safe routing with Vinxi (a Vite-based server framework) for best-in-class TypeScript support and end-to-end type safety.
+**TanStack Start**<FnRef n={1} /> is the newest full-stack React framework, built by Tanner Linsley (creator of TanStack Query, TanStack Router, and TanStack Table). It combines TanStack Router&apos;s type-safe routing with Vinxi (a Vite-based server framework) for best-in-class TypeScript support and end-to-end type safety.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>
 
 <SectionList>
-<ColItem>**End-to-end type safety** &mdash; route parameters, search params, loaders, and actions are all fully typed. No codegen required &mdash; types are inferred from your route definitions.</ColItem>
+<ColItem>**End-to-end type safety** &mdash; route parameters, search params, loaders, and actions are all fully typed.<FnRef n={2} /> No codegen required &mdash; types are inferred from your route definitions.</ColItem>
 <ColItem>**TanStack ecosystem** &mdash; built-in integration with TanStack Query for caching, TanStack Table for data grids, and more.</ColItem>
 <ColItem>**Vite-powered** &mdash; fast development experience with HMR and a smaller, focused API surface.</ColItem>
 </SectionList>

--- a/src/content/architecture/arch-how-it-connects.mdx
+++ b/src/content/architecture/arch-how-it-connects.mdx
@@ -1,6 +1,18 @@
 ---
 id: "arch-how-it-connects"
 title: "🔄 How it all Connects"
+usedFootnotes: [1]
+links:
+  - label: "MDN — An overview of HTTP"
+    url: "https://developer.mozilla.org/en-US/docs/Web/HTTP/Overview"
+    source: "MDN"
+  - label: "MDN — How the web works"
+    url: "https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Web_standards/How_the_web_works"
+    source: "MDN"
+  - label: "REST API design best practices"
+    url: "https://learn.microsoft.com/en-us/azure/architecture/best-practices/api-design"
+    source: "Microsoft"
+    note: "Comprehensive guide to designing web APIs that are consistent, discoverable, and maintainable"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -19,7 +31,7 @@ Understanding how data flows through a stack is just as important as understandi
 <SectionSubheading id="toc-cycle">{'\u{1F501}'} The request-response cycle</SectionSubheading>
 
 <SectionList>
-<ColItem>Every web interaction follows the same basic pattern: the **frontend** sends a request, the **server** processes it (often querying the **database**), and a response flows back to update the screen.</ColItem>
+<ColItem>Every web interaction follows the same basic pattern:<FnRef n={1} /> the **frontend** sends a request, the **server** processes it (often querying the **database**), and a response flows back to update the screen.</ColItem>
 <ColItem>This pattern is **the same regardless of which stack you use**. Whether it's React talking to Fastify, Angular talking to Express, or PHP rendering HTML directly &mdash; the fundamental flow doesn't change.</ColItem>
 <ColItem>The stack determines **how** each step happens (JSON API vs. server-rendered HTML, SQL vs. NoSQL queries), but the **order** and **purpose** of each step stays constant.</ColItem>
 </SectionList>

--- a/src/content/architecture/arch-stack-django.mdx
+++ b/src/content/architecture/arch-stack-django.mdx
@@ -1,6 +1,17 @@
 ---
 id: "arch-stack-django"
 title: "🐍 Django Stack"
+usedFootnotes: [1]
+links:
+  - label: "Django documentation"
+    url: "https://docs.djangoproject.com/en/5.1/"
+    source: "Django"
+  - label: "Django REST framework"
+    url: "https://www.django-rest-framework.org/"
+    source: "Django REST"
+  - label: "Python documentation"
+    url: "https://docs.python.org/3/"
+    source: "Python"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -13,7 +24,7 @@ title: "🐍 Django Stack"
 </Toc>
 
 <SectionIntro>
-The **Django stack** pairs Python's most popular web framework with a modern JavaScript frontend. Django follows the "batteries included" philosophy &mdash; it comes with an admin panel, ORM, authentication, and security protections built in. If you know Python, Django gets you from zero to production faster than almost anything else.
+The **Django stack** pairs Python's most popular web framework with a modern JavaScript frontend. Django follows the "batteries included" philosophy<FnRef n={1} /> &mdash; it comes with an admin panel, ORM, authentication, and security protections built in. If you know Python, Django gets you from zero to production faster than almost anything else.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>

--- a/src/content/architecture/arch-stack-lamp.mdx
+++ b/src/content/architecture/arch-stack-lamp.mdx
@@ -1,6 +1,21 @@
 ---
 id: "arch-stack-lamp"
 title: "💡 LAMP Stack"
+usedFootnotes: [4]
+links:
+  - label: "PHP documentation"
+    url: "https://www.php.net/manual/en/"
+    source: "PHP"
+  - label: "Apache HTTP Server documentation"
+    url: "https://httpd.apache.org/docs/current/"
+    source: "Apache"
+  - label: "MySQL documentation"
+    url: "https://dev.mysql.com/doc/refman/en/"
+    source: "MySQL"
+  - label: "W3Techs — Usage of server-side languages"
+    url: "https://w3techs.com/technologies/overview/programming_language"
+    source: "W3Techs"
+    note: "PHP powers approximately 75% of all websites whose server-side language is known"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -13,7 +28,7 @@ title: "💡 LAMP Stack"
 </Toc>
 
 <SectionIntro>
-The **LAMP** stack &mdash; **Linux**, **Apache**, **MySQL**, **PHP** &mdash; powered most of the early internet and remains one of the most deployed stacks worldwide. WordPress (43% of all websites), Facebook (originally), and Wikipedia all run on it. Unlike JavaScript stacks, LAMP uses PHP on the server and renders HTML directly &mdash; no separate frontend framework needed.
+The **LAMP** stack &mdash; **Linux**, **Apache**, **MySQL**, **PHP** &mdash; powered most of the early internet and remains one of the most deployed stacks worldwide. WordPress (43% of all websites)<FnRef n={4} />, Facebook (originally), and Wikipedia all run on it. Unlike JavaScript stacks, LAMP uses PHP on the server and renders HTML directly &mdash; no separate frontend framework needed.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>

--- a/src/content/architecture/arch-stack-mean.mdx
+++ b/src/content/architecture/arch-stack-mean.mdx
@@ -1,6 +1,17 @@
 ---
 id: "arch-stack-mean"
 title: "🔷 MEAN Stack"
+usedFootnotes: [1]
+links:
+  - label: "Angular documentation"
+    url: "https://angular.dev/overview"
+    source: "Angular"
+  - label: "Angular CLI overview"
+    url: "https://angular.dev/tools/cli"
+    source: "Angular"
+  - label: "TypeScript and Angular"
+    url: "https://angular.dev/tools/cli/template-typecheck"
+    source: "Angular"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -13,7 +24,7 @@ title: "🔷 MEAN Stack"
 </Toc>
 
 <SectionIntro>
-The **MEAN** stack &mdash; **MongoDB**, **Express**, **Angular**, **Node.js** &mdash; is like MERN but swaps React for Angular. While React is a library that lets you choose your own tools, Angular is a full framework with routing, forms, HTTP, and more built in. Everything else stays the same.
+The **MEAN** stack &mdash; **MongoDB**, **Express**, **Angular**, **Node.js** &mdash; is like MERN but swaps React for Angular. While React is a library that lets you choose your own tools, Angular<FnRef n={1} /> is a full framework with routing, forms, HTTP, and more built in. Everything else stays the same.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>

--- a/src/content/architecture/arch-stack-mern.mdx
+++ b/src/content/architecture/arch-stack-mern.mdx
@@ -1,6 +1,20 @@
 ---
 id: "arch-stack-mern"
 title: "🔗 MERN Stack"
+usedFootnotes: [1, 2]
+links:
+  - label: "MongoDB documentation"
+    url: "https://www.mongodb.com/docs/manual/"
+    source: "MongoDB"
+  - label: "Express.js guide"
+    url: "https://expressjs.com/en/guide/routing.html"
+    source: "Express"
+  - label: "React documentation"
+    url: "https://react.dev/learn"
+    source: "React"
+  - label: "Node.js documentation"
+    url: "https://nodejs.org/en/learn/getting-started/introduction-to-nodejs"
+    source: "Node.js"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -19,9 +33,9 @@ The **MERN** stack &mdash; **MongoDB**, **Express**, **React**, **Node.js** &mda
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>
 
 <SectionList>
-<ColItem>**One language everywhere** &mdash; JavaScript runs on the frontend (React), the server (Express on Node.js), and even database queries (MongoDB uses JSON-like documents).</ColItem>
+<ColItem>**One language everywhere** &mdash; JavaScript runs on the frontend (React), the server (Express on Node.js)<FnRef n={2} />, and even database queries (MongoDB uses JSON-like documents).</ColItem>
 <ColItem>**Massive community** &mdash; More tutorials, Stack Overflow answers, and npm packages exist for this combination than any other stack.</ColItem>
-<ColItem>**Rapid prototyping** &mdash; MongoDB's flexible schema means you can start building without designing database tables upfront.</ColItem>
+<ColItem>**Rapid prototyping** &mdash; MongoDB's flexible schema<FnRef n={1} /> means you can start building without designing database tables upfront.</ColItem>
 </SectionList>
 
 <SectionSubheading id="toc-explore">{'\u{1F50D}'} Explore each component</SectionSubheading>

--- a/src/content/architecture/arch-stack-pfrn.mdx
+++ b/src/content/architecture/arch-stack-pfrn.mdx
@@ -1,6 +1,18 @@
 ---
 id: "arch-stack-pfrn"
 title: "⚡ PFRN Stack (This Guide)"
+usedFootnotes: [1, 3]
+links:
+  - label: "PostgreSQL documentation"
+    url: "https://www.postgresql.org/docs/current/"
+    source: "PostgreSQL"
+  - label: "Fastify documentation"
+    url: "https://fastify.dev/docs/latest/"
+    source: "Fastify"
+  - label: "Fastify benchmarks"
+    url: "https://fastify.dev/benchmarks/"
+    source: "Fastify"
+    note: "Fastify consistently outperforms Express in independent benchmarks"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -19,8 +31,8 @@ The **PFRN** stack is a modified version of MERN that swaps MongoDB for **Postgr
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>
 
 <SectionList>
-<ColItem>**Stronger data layer** &mdash; PostgreSQL enforces data integrity through schemas, constraints, and relationships. Much harder to save bad data compared to MongoDB.</ColItem>
-<ColItem>**Faster server** &mdash; Fastify handles significantly more requests per second than Express, with built-in schema validation and a cleaner plugin architecture.</ColItem>
+<ColItem>**Stronger data layer** &mdash; PostgreSQL<FnRef n={1} /> enforces data integrity through schemas, constraints, and relationships. Much harder to save bad data compared to MongoDB.</ColItem>
+<ColItem>**Faster server** &mdash; Fastify handles significantly more requests per second than Express<FnRef n={3} />, with built-in schema validation and a cleaner plugin architecture.</ColItem>
 <ColItem>**Same JavaScript ecosystem** &mdash; React and Node.js stay the same, so you keep the one-language benefit of MERN while upgrading the backend.</ColItem>
 </SectionList>
 

--- a/src/content/architecture/arch-stack-rails.mdx
+++ b/src/content/architecture/arch-stack-rails.mdx
@@ -1,6 +1,18 @@
 ---
 id: "arch-stack-rails"
 title: "🛤️ Rails Stack"
+usedFootnotes: [1, 2]
+links:
+  - label: "Ruby on Rails guides"
+    url: "https://guides.rubyonrails.org/"
+    source: "Rails"
+  - label: "Hotwire documentation"
+    url: "https://hotwired.dev/"
+    source: "Hotwired"
+  - label: "The Rails Doctrine"
+    url: "https://rubyonrails.org/doctrine"
+    source: "Rails"
+    note: "Core principles behind Rails' design philosophy, including Convention over Configuration"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -13,7 +25,7 @@ title: "🛤️ Rails Stack"
 </Toc>
 
 <SectionIntro>
-The **Rails stack** is built around Ruby on Rails &mdash; a framework famous for "convention over configuration" and developer happiness. GitHub, Shopify, and Basecamp were built with it. Rails makes hundreds of decisions for you so you can focus on building features instead of setting up boilerplate.
+The **Rails stack** is built around Ruby on Rails &mdash; a framework famous for "convention over configuration"<FnRef n={1} /> and developer happiness. GitHub, Shopify, and Basecamp were built with it. Rails makes hundreds of decisions for you so you can focus on building features instead of setting up boilerplate.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">{'\u{1F4CB}'} Overview</SectionSubheading>
@@ -21,7 +33,7 @@ The **Rails stack** is built around Ruby on Rails &mdash; a framework famous for
 <SectionList>
 <ColItem>**Convention over configuration** &mdash; Rails decides how to organize files, name database tables, and structure routes. Follow the conventions and things just work.</ColItem>
 <ColItem>**Ship fast** &mdash; Rails can scaffold entire features (models, views, controllers, database migrations) with a single command. Rapid development is a core philosophy.</ColItem>
-<ColItem>**Hotwire for modern frontends** &mdash; Rails' Hotwire approach (Turbo + Stimulus) delivers interactive UIs with minimal JavaScript, or you can integrate React for complex frontends.</ColItem>
+<ColItem>**Hotwire for modern frontends** &mdash; Rails' Hotwire<FnRef n={2} /> approach (Turbo + Stimulus) delivers interactive UIs with minimal JavaScript, or you can integrate React for complex frontends.</ColItem>
 </SectionList>
 
 <SectionSubheading id="toc-explore">{'\u{1F50D}'} Explore each component</SectionSubheading>

--- a/src/content/architecture/arch-what-is-a-stack.mdx
+++ b/src/content/architecture/arch-what-is-a-stack.mdx
@@ -1,6 +1,17 @@
 ---
 id: "arch-what-is-a-stack"
 title: "📚 What is a Stack?"
+usedFootnotes: [1, 2]
+links:
+  - label: "How the web works"
+    url: "https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Web_standards/How_the_web_works"
+    source: "MDN"
+  - label: "Introduction to the server side"
+    url: "https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Server-side/First_steps/Introduction"
+    source: "MDN"
+  - label: "What is a web server?"
+    url: "https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Web_mechanics/What_is_a_web_server"
+    source: "MDN"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
@@ -27,13 +38,13 @@ A **tech stack** is the combination of technologies used to build a web applicat
 
 <SectionSubheading id="toc-layers">{'\u{1F5C2}\uFE0F'} The four essential layers</SectionSubheading>
 
-Every web application stack has four essential layers. Each layer has a specific job, and together they handle the full lifecycle of a user interaction &mdash; from clicking a button to seeing updated data on the screen.
+Every web application stack has four essential layers. Each layer has a specific job, and together they handle the full lifecycle of a user interaction<FnRef n={1} /> &mdash; from clicking a button to seeing updated data on the screen.
 
 <LayerDiagram />
 
 <SectionList>
 <ColItem>**Frontend** &mdash; Builds the user interface. This is what people see and interact with in the browser: buttons, forms, pages, animations.</ColItem>
-<ColItem>**Server Framework** &mdash; Handles HTTP requests, processes business logic, and sends responses. It's the traffic controller between the frontend and the database.</ColItem>
+<ColItem>**Server Framework** &mdash; Handles HTTP requests<FnRef n={2} />, processes business logic, and sends responses. It's the traffic controller between the frontend and the database.</ColItem>
 <ColItem>**Runtime / Platform** &mdash; The engine that executes your server-side code. Node.js runs JavaScript, Python runs Django, Ruby runs Rails.</ColItem>
 <ColItem>**Database** &mdash; Stores data permanently so it survives server restarts. Users, posts, orders &mdash; anything your app needs to remember.</ColItem>
 </SectionList>

--- a/src/data/archData.ts
+++ b/src/data/archData.ts
@@ -7,6 +7,7 @@ export interface StackComponent {
   icon: string
   color: string
   accent: string
+  darkAccent: string
   purpose: string
   description: string
   keyFeatures: string[]
@@ -25,6 +26,7 @@ export interface StackPageData {
   overview: string
   color: string
   accent: string
+  darkAccent: string
   components: StackComponent[]
   pros: string[]
   cons: string[]
@@ -55,6 +57,7 @@ export interface FrameworkPageData {
   overview: string
   color: string
   accent: string
+  darkAccent: string
   builtOn: string[]
   capabilities: FrameworkCapability[]
   pros: string[]
@@ -65,11 +68,11 @@ export interface FrameworkPageData {
 
 /* ───────────────────────── LAYER COLORS (shared) ───────────────────────── */
 
-export const LAYER_COLORS: Record<string, { color: string; accent: string }> = {
-  frontend: { color: "#7c3aed", accent: "#ede9fe" },
-  server:   { color: "#059669", accent: "#d1fae5" },
-  runtime:  { color: "#ca8a04", accent: "#fef9c3" },
-  database: { color: "#2563eb", accent: "#dbeafe" },
+export const LAYER_COLORS: Record<string, { color: string; accent: string; darkAccent: string }> = {
+  frontend: { color: "#7c3aed", accent: "#ede9fe", darkAccent: "#2e1065" },
+  server:   { color: "#059669", accent: "#d1fae5", darkAccent: "#022c22" },
+  runtime:  { color: "#ca8a04", accent: "#fef9c3", darkAccent: "#422006" },
+  database: { color: "#2563eb", accent: "#dbeafe", darkAccent: "#172554" },
 }
 
 /* ───────────────────────── DATA FLOW ───────────────────────── */
@@ -94,10 +97,11 @@ export const STACK_PAGES: StackPageData[] = [
     overview: "The MERN stack \u2014 MongoDB, Express, React, and Node.js \u2014 is the most popular all-JavaScript full-stack combination. Every layer uses JavaScript, meaning you only need one language for the entire application. It\u2019s the go-to choice for tutorials, bootcamps, and rapid prototyping.",
     color: "#e11d48",
     accent: "#fff1f2",
+    darkAccent: "#4c0519",
     components: [
       {
         id: "frontend", name: "React", role: "Frontend",
-        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe",
+        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe", darkAccent: "#2e1065",
         purpose: "The frontend library builds everything the user sees and interacts with \u2014 buttons, forms, pages, animations. It takes raw data from the server and turns it into a visual, interactive experience in the browser.",
         description: "React (by Meta) lets you build UIs out of reusable \u2018components\u2019 \u2014 small building blocks like a search bar, a card, or a navigation menu. You compose these together like LEGO bricks to build complex interfaces. React uses a \u2018virtual DOM\u2019 to efficiently update only the parts of the page that change, making it fast even for complex UIs.",
         keyFeatures: [
@@ -110,7 +114,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "server", name: "Express", role: "Server Framework",
-        icon: "\u26A1", color: "#059669", accent: "#d1fae5",
+        icon: "\u26A1", color: "#059669", accent: "#d1fae5", darkAccent: "#022c22",
         purpose: "The server framework handles incoming requests from the browser, processes them, and sends back responses. It\u2019s the traffic controller between your frontend and your database.",
         description: "Express is the most popular Node.js server framework. Created in 2010, it\u2019s minimal and unopinionated \u2014 it gives you the basics (routing, middleware) and lets you add whatever else you need via plugins. Think of it as a blank canvas: flexible, but you need to set up everything yourself.",
         keyFeatures: [
@@ -123,7 +127,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "runtime", name: "Node.js", role: "Runtime",
-        icon: "\u{1F527}", color: "#ca8a04", accent: "#fef9c3",
+        icon: "\u{1F527}", color: "#ca8a04", accent: "#fef9c3", darkAccent: "#422006",
         purpose: "The runtime is the engine that executes your server-side code. Without it, JavaScript could only run in a browser \u2014 Node.js lets you run JavaScript on a server.",
         description: "Node.js is a JavaScript runtime built on Chrome\u2019s V8 engine. It\u2019s event-driven and non-blocking, meaning it can handle many simultaneous connections efficiently \u2014 perfect for real-time apps like chat. Node.js is what makes the \u2018all JavaScript, all the time\u2019 dream possible: one language for frontend, backend, and tooling.",
         keyFeatures: [
@@ -136,7 +140,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "database", name: "MongoDB", role: "Database",
-        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe",
+        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe", darkAccent: "#172554",
         purpose: "The database stores all your application\u2019s data \u2014 users, posts, orders \u2014 so it persists even when the server restarts. Without a database, everything vanishes when you close the app.",
         description: "MongoDB is a NoSQL database that stores data as flexible JSON-like documents \u2014 think of it like tossing papers into labeled folders. You don\u2019t need to define a rigid structure (schema) upfront, making it perfect for rapid prototyping and projects where the data shape evolves frequently.",
         keyFeatures: [
@@ -171,10 +175,11 @@ export const STACK_PAGES: StackPageData[] = [
     overview: "The PFRN stack is a modified version of MERN that swaps MongoDB for PostgreSQL (a more structured database) and Express for Fastify (a faster server framework), while keeping React and Node.js the same. This shows a key architecture principle: you can swap individual layers without rewriting everything else.",
     color: "#7c3aed",
     accent: "#f5f3ff",
+    darkAccent: "#1e1b4b",
     components: [
       {
         id: "frontend", name: "React", role: "Frontend",
-        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe",
+        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe", darkAccent: "#2e1065",
         purpose: "The frontend library builds everything the user actually sees and interacts with \u2014 buttons, forms, pages, animations. It takes raw data from the server and turns it into a visual, interactive experience in the browser.",
         description: "React (by Meta) lets you build UIs out of reusable \u2018components\u2019 \u2014 small building blocks like a search bar, a card, or a navigation menu. You compose these together like LEGO bricks to build complex interfaces. It uses a \u2018virtual DOM\u2019 to efficiently update only the parts of the page that change. React stays the same in both the traditional and modified stack \u2014 it\u2019s backend-agnostic. Your React components don\u2019t care if data comes from MongoDB or PostgreSQL, or whether the server runs Express or Fastify. The API contract (the shape of data exchanged) is what matters.",
         keyFeatures: [
@@ -188,7 +193,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "server", name: "Fastify", role: "Server Framework",
-        icon: "\u26A1", color: "#059669", accent: "#d1fae5",
+        icon: "\u26A1", color: "#059669", accent: "#d1fae5", darkAccent: "#022c22",
         purpose: "The server framework is the \u2018traffic controller\u2019 of your app. When someone visits a URL or submits a form, the server decides what to do: fetch data from the database, process it, and send back a response. It\u2019s the bridge between your frontend and your database.",
         description: "Fastify is a newer, faster alternative to Express. It\u2019s built for performance and comes with more built-in features like request validation (checking that incoming data looks right) and automatic API documentation. Think of it like a modern kitchen that comes pre-equipped with high-end appliances.",
         keyFeatures: [
@@ -205,7 +210,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "runtime", name: "Node.js", role: "Runtime",
-        icon: "\u{1F527}", color: "#ca8a04", accent: "#fef9c3",
+        icon: "\u{1F527}", color: "#ca8a04", accent: "#fef9c3", darkAccent: "#422006",
         purpose: "The runtime is the engine that makes everything else possible. JavaScript was originally built only for browsers. Node.js lets you run JavaScript on a server \u2014 meaning you can use one language for your entire application, frontend and backend.",
         description: "Node.js is a JavaScript runtime built on Chrome\u2019s V8 engine. It\u2019s event-driven and non-blocking, which means it can handle many simultaneous connections efficiently \u2014 great for real-time apps like chat. It\u2019s the foundation that both Express and Fastify run on. Swapping Express for Fastify doesn\u2019t change this layer at all, because both are Node.js frameworks. Node.js is what unifies the entire stack under one language.",
         keyFeatures: [
@@ -219,7 +224,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "database", name: "PostgreSQL", role: "Database",
-        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe",
+        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe", darkAccent: "#172554",
         purpose: "The database is your app\u2019s long-term memory. It stores all your data \u2014 users, posts, orders, anything \u2014 so it persists even when the server restarts. Without it, every piece of information would vanish the moment you close the app.",
         description: "PostgreSQL is a relational (SQL) database. It stores data in structured tables with rows and columns \u2014 like a spreadsheet. You define the shape of your data upfront (a \u2018schema\u2019). This makes relationships between data very clean and enforces data integrity, meaning it\u2019s much harder to accidentally save bad data.",
         keyFeatures: [
@@ -258,10 +263,11 @@ export const STACK_PAGES: StackPageData[] = [
     overview: "The MEAN stack swaps React for Angular \u2014 Google\u2019s full-featured frontend framework. While React is a library that lets you choose your own tools, Angular is an all-in-one framework with routing, forms, HTTP, and more built in. Everything else stays the same as MERN.",
     color: "#dc2626",
     accent: "#fef2f2",
+    darkAccent: "#450a0a",
     components: [
       {
         id: "frontend", name: "Angular", role: "Frontend",
-        icon: "\u{1F3A8}", color: "#dc2626", accent: "#fef2f2",
+        icon: "\u{1F3A8}", color: "#dc2626", accent: "#fef2f2", darkAccent: "#450a0a",
         purpose: "The frontend framework builds the user interface. Unlike React (a library), Angular is a complete framework with routing, forms, HTTP client, and more built in \u2014 no need to choose and install separate packages.",
         description: "Angular (by Google) is a full-featured frontend framework written in TypeScript. While React gives you building blocks and lets you choose your own tools, Angular is an all-in-one solution \u2014 it includes routing, form handling, an HTTP client, dependency injection, and more out of the box. This makes it opinionated but consistent across teams.",
         keyFeatures: [
@@ -274,7 +280,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "server", name: "Express", role: "Server Framework",
-        icon: "\u26A1", color: "#059669", accent: "#d1fae5",
+        icon: "\u26A1", color: "#059669", accent: "#d1fae5", darkAccent: "#022c22",
         purpose: "The server framework handles incoming requests from the browser, processes them, and sends back responses. It\u2019s the traffic controller between your frontend and your database.",
         description: "Express is the most popular Node.js server framework. Created in 2010, it\u2019s minimal and unopinionated \u2014 it gives you the basics (routing, middleware) and lets you add whatever else you need via plugins. Think of it as a blank canvas: flexible, but you need to set up everything yourself.",
         keyFeatures: [
@@ -287,7 +293,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "runtime", name: "Node.js", role: "Runtime",
-        icon: "\u{1F527}", color: "#ca8a04", accent: "#fef9c3",
+        icon: "\u{1F527}", color: "#ca8a04", accent: "#fef9c3", darkAccent: "#422006",
         purpose: "The runtime is the engine that executes your server-side code. Without it, JavaScript could only run in a browser \u2014 Node.js lets you run JavaScript on a server.",
         description: "Node.js is a JavaScript runtime built on Chrome\u2019s V8 engine. It\u2019s event-driven and non-blocking, meaning it can handle many simultaneous connections efficiently \u2014 perfect for real-time apps like chat. Node.js is what makes the \u2018all JavaScript, all the time\u2019 dream possible.",
         keyFeatures: [
@@ -300,7 +306,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "database", name: "MongoDB", role: "Database",
-        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe",
+        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe", darkAccent: "#172554",
         purpose: "The database stores all your application\u2019s data so it persists even when the server restarts. MongoDB\u2019s flexible document model pairs well with JavaScript\u2019s object-based data format.",
         description: "MongoDB is a NoSQL database that stores data as flexible JSON-like documents. You don\u2019t need to define a rigid structure (schema) upfront, making it quick to get started. The data format naturally matches JavaScript objects, so there\u2019s minimal translation between your code and your database.",
         keyFeatures: [
@@ -335,10 +341,11 @@ export const STACK_PAGES: StackPageData[] = [
     overview: "The LAMP stack powered most of the early internet and remains one of the most deployed stacks worldwide. WordPress (43% of all websites), Facebook (originally), and Wikipedia all run on it. Unlike JavaScript stacks, LAMP uses PHP on the server and renders HTML directly \u2014 no separate frontend framework needed.",
     color: "#ea580c",
     accent: "#fff7ed",
+    darkAccent: "#431407",
     components: [
       {
         id: "frontend", name: "PHP Templates", role: "Frontend (Server-Rendered)",
-        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe",
+        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe", darkAccent: "#2e1065",
         purpose: "PHP generates HTML on the server and sends complete pages to the browser. There\u2019s no separate frontend framework \u2014 the server builds the entire page before the user sees it.",
         description: "In a LAMP stack, the \u2018frontend\u2019 is server-rendered HTML generated by PHP. When a user requests a page, PHP executes on the server, queries the database, builds the HTML, and sends the finished page to the browser. This is fundamentally different from React/Angular where the browser builds the page. PHP can be embedded directly in HTML files, mixing presentation and logic in one place.",
         keyFeatures: [
@@ -351,7 +358,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "server", name: "Apache", role: "Web Server",
-        icon: "\u{1F310}", color: "#059669", accent: "#d1fae5",
+        icon: "\u{1F310}", color: "#059669", accent: "#d1fae5", darkAccent: "#022c22",
         purpose: "The web server listens for HTTP requests, decides how to handle them, and sends responses back. Apache serves static files directly and passes dynamic requests to PHP for processing.",
         description: "Apache HTTP Server is one of the oldest and most popular web servers, powering a huge portion of the internet since 1995. It uses a module-based architecture and supports .htaccess files for per-directory configuration, making it flexible for shared hosting environments where you can\u2019t edit the main server config.",
         keyFeatures: [
@@ -364,7 +371,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "database", name: "MySQL", role: "Database",
-        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe",
+        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe", darkAccent: "#172554",
         purpose: "The relational database stores all your application\u2019s data in structured tables with rows and columns, enforcing consistency through a defined schema.",
         description: "MySQL is the world\u2019s most popular open-source relational database. It stores data in structured tables with defined columns and data types. Unlike MongoDB\u2019s flexible documents, MySQL requires you to define your data structure upfront \u2014 but this means your data is always consistent and valid.",
         keyFeatures: [
@@ -377,7 +384,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "runtime", name: "Linux", role: "Operating System",
-        icon: "\u{1F427}", color: "#ca8a04", accent: "#fef9c3",
+        icon: "\u{1F427}", color: "#ca8a04", accent: "#fef9c3", darkAccent: "#422006",
         purpose: "The operating system is the foundation that runs everything else. Linux provides the file system, networking, process management, and security that Apache, MySQL, and PHP all depend on.",
         description: "Linux is the open-source operating system that runs the majority of web servers worldwide. It\u2019s free, stable, highly configurable, and available everywhere from tiny embedded devices to massive cloud servers. In the LAMP stack, Linux is the foundation layer that all other components run on.",
         keyFeatures: [
@@ -412,10 +419,11 @@ export const STACK_PAGES: StackPageData[] = [
     overview: "The Django stack pairs Python\u2019s most popular web framework with a modern JavaScript frontend. Django follows the \u2018batteries included\u2019 philosophy \u2014 it comes with an admin panel, ORM, authentication, and security protections built in. If you know Python, Django gets you from zero to production faster than almost anything else.",
     color: "#16a34a",
     accent: "#f0fdf4",
+    darkAccent: "#052e16",
     components: [
       {
         id: "frontend", name: "React / Vue", role: "Frontend",
-        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe",
+        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe", darkAccent: "#2e1065",
         purpose: "The frontend framework builds the user interface as a single-page application (SPA) that communicates with the Django backend through a REST or GraphQL API.",
         description: "In a Django stack, the frontend is typically a separate React or Vue.js application. Django serves as a pure API backend, and the frontend makes HTTP requests to fetch and send data. This separation gives you the full power of a modern JavaScript UI framework while keeping Python on the backend.",
         keyFeatures: [
@@ -428,7 +436,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "server", name: "Django", role: "Server Framework",
-        icon: "\u26A1", color: "#059669", accent: "#d1fae5",
+        icon: "\u26A1", color: "#059669", accent: "#d1fae5", darkAccent: "#022c22",
         purpose: "The \u2018batteries included\u2019 web framework handles routing, database queries, authentication, and admin interfaces \u2014 with most features built in rather than bolted on.",
         description: "Django is a high-level Python web framework that follows the \u2018batteries included\u2019 philosophy. It comes with a built-in admin panel, ORM (database abstraction), authentication system, form handling, and security protections. Django encourages rapid development by providing sensible defaults for everything.",
         keyFeatures: [
@@ -441,7 +449,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "runtime", name: "Python", role: "Language & Runtime",
-        icon: "\u{1F40D}", color: "#ca8a04", accent: "#fef9c3",
+        icon: "\u{1F40D}", color: "#ca8a04", accent: "#fef9c3", darkAccent: "#422006",
         purpose: "The programming language that powers the server. Python\u2019s clean syntax, vast standard library, and dominance in data science make it an excellent choice for backend development.",
         description: "Python is a general-purpose programming language known for its readable, clean syntax. It\u2019s the most popular language for data science, machine learning, and automation \u2014 and Django makes it equally powerful for web development. Unlike JavaScript stacks, Python backends require a separate language for the frontend.",
         keyFeatures: [
@@ -454,7 +462,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "database", name: "PostgreSQL", role: "Database",
-        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe",
+        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe", darkAccent: "#172554",
         purpose: "The relational database stores all your application data in structured tables, enforcing data integrity through schemas, constraints, and relationships.",
         description: "PostgreSQL is an advanced open-source relational database known for its reliability, feature richness, and standards compliance. It supports complex queries, full-text search, JSON data, and advanced features like window functions and CTEs. Django\u2019s ORM works especially well with PostgreSQL.",
         keyFeatures: [
@@ -489,10 +497,11 @@ export const STACK_PAGES: StackPageData[] = [
     overview: "The Rails stack is built around Ruby on Rails \u2014 a framework famous for \u2018convention over configuration\u2019 and developer happiness. GitHub, Shopify, and Basecamp were built with it. Rails makes hundreds of decisions for you so you can focus on building features instead of setting up boilerplate.",
     color: "#b91c1c",
     accent: "#fef2f2",
+    darkAccent: "#450a0a",
     components: [
       {
         id: "frontend", name: "Hotwire / React", role: "Frontend",
-        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe",
+        icon: "\u{1F3A8}", color: "#7c3aed", accent: "#ede9fe", darkAccent: "#2e1065",
         purpose: "The frontend approach handles what the user sees and interacts with. Rails offers Hotwire for server-driven interactivity or React for rich client-side applications.",
         description: "Rails offers two frontend approaches: Hotwire (Turbo + Stimulus) sends HTML from the server and uses minimal JavaScript for interactivity \u2014 great for CRUD apps and content sites. For complex UIs, React can be integrated as a separate SPA that talks to Rails as an API backend.",
         keyFeatures: [
@@ -505,7 +514,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "server", name: "Ruby on Rails", role: "Server Framework",
-        icon: "\u26A1", color: "#b91c1c", accent: "#fef2f2",
+        icon: "\u26A1", color: "#b91c1c", accent: "#fef2f2", darkAccent: "#450a0a",
         purpose: "The \u2018convention over configuration\u2019 framework makes hundreds of decisions for you, so you can focus on building features instead of setting up boilerplate.",
         description: "Ruby on Rails (or just \u2018Rails\u2019) is a web framework famous for developer productivity and happiness. It follows \u2018convention over configuration\u2019 \u2014 if you follow Rails\u2019 conventions, most things just work without explicit setup. Rails includes an ORM (ActiveRecord), routing, testing framework, email handling, and more.",
         keyFeatures: [
@@ -518,7 +527,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "runtime", name: "Ruby", role: "Language & Runtime",
-        icon: "\u{1F48E}", color: "#ca8a04", accent: "#fef9c3",
+        icon: "\u{1F48E}", color: "#ca8a04", accent: "#fef9c3", darkAccent: "#422006",
         purpose: "The programming language designed for developer happiness. Ruby\u2019s elegant, readable syntax and powerful metaprogramming make it uniquely expressive.",
         description: "Ruby is a dynamic programming language designed by Yukihiro \u2018Matz\u2019 Matsumoto with a focus on simplicity and productivity. It has an elegant syntax that reads naturally and is often described as \u2018a joy to write.\u2019 Ruby\u2019s metaprogramming capabilities power much of Rails\u2019 \u2018magic\u2019 \u2014 the convention-based behavior that makes things work automatically.",
         keyFeatures: [
@@ -531,7 +540,7 @@ export const STACK_PAGES: StackPageData[] = [
       },
       {
         id: "database", name: "PostgreSQL", role: "Database",
-        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe",
+        icon: "\u{1F5C4}\uFE0F", color: "#2563eb", accent: "#dbeafe", darkAccent: "#172554",
         purpose: "The relational database stores all your application data. Rails\u2019 ActiveRecord ORM makes PostgreSQL feel natural to use from Ruby code.",
         description: "PostgreSQL is the default and recommended database for Rails applications. Rails\u2019 ActiveRecord ORM maps Ruby objects to database tables, so you rarely write raw SQL. PostgreSQL\u2019s advanced features like JSONB columns, full-text search, and array types are all accessible through ActiveRecord.",
         keyFeatures: [
@@ -570,6 +579,7 @@ export const FRAMEWORK_PAGES: FrameworkPageData[] = [
     overview: "Next.js is the most popular React framework. It adds server-side rendering, file-system routing, API routes, and optimized builds on top of React. Developed by Vercel, it\u2019s become the default way to build production React apps \u2014 used by Netflix, TikTok, and Notion.",
     color: "#000000",
     accent: "#f5f5f5",
+    darkAccent: "#171717",
     builtOn: ["React", "Node.js"],
     capabilities: [
       {
@@ -645,6 +655,7 @@ export const FRAMEWORK_PAGES: FrameworkPageData[] = [
     overview: "React Router v7 introduced \u2018Framework Mode\u2019 \u2014 transforming the most popular React routing library into a full-stack framework. It\u2019s the spiritual successor to Remix (which merged into React Router), built on web standards like the Fetch API, FormData, and HTTP caching. It\u2019s the web-standards-first alternative to Next.js.",
     color: "#f44250",
     accent: "#fff5f5",
+    darkAccent: "#450a0a",
     builtOn: ["React", "Node.js"],
     capabilities: [
       {
@@ -720,6 +731,7 @@ export const FRAMEWORK_PAGES: FrameworkPageData[] = [
     overview: "TanStack Start is the newest entry, built by Tanner Linsley (creator of TanStack Query, TanStack Router, and TanStack Table). It combines TanStack Router\u2019s type-safe routing with Vinxi (a Vite-based server framework) to create a full-stack React framework with best-in-class TypeScript support.",
     color: "#e8590c",
     accent: "#fff4ed",
+    darkAccent: "#431407",
     builtOn: ["React", "Vite/Vinxi", "Node.js"],
     capabilities: [
       {
@@ -795,6 +807,7 @@ export const FRAMEWORK_PAGES: FrameworkPageData[] = [
     overview: "Remix was a pioneering full-stack React framework created by the React Router team (Ryan Florence and Michael Jackson). It championed web standards, progressive enhancement, and nested routing. In 2024, Remix merged into React Router v7 as \u2018Framework Mode\u2019 \u2014 so Remix\u2019s ideas live on, but new projects should use React Router v7 directly.",
     color: "#3992ff",
     accent: "#f0f7ff",
+    darkAccent: "#172554",
     builtOn: ["React", "Node.js"],
     capabilities: [
       {

--- a/src/data/glossaryTerms.ts
+++ b/src/data/glossaryTerms.ts
@@ -259,4 +259,117 @@ export const glossaryTerms: GlossaryCategory[] = [
       },
     ]
   },
+  {
+    category: "Web Architecture",
+    terms: [
+      {
+        term: "Tech Stack",
+        definition: "A combination of technologies (frontend, server framework, runtime, database) used together to build a web application. Common examples include MERN, LAMP, and Django stacks.",
+        url: "https://developer.mozilla.org/en-US/docs/Learn_web_development/Getting_started/Web_standards/How_the_web_works",
+        source: "MDN",
+        sectionId: "arch-what-is-a-stack"
+      },
+      {
+        term: "Server Framework",
+        definition: "A library that handles HTTP requests, routing, and business logic on the server. Examples include Express, Fastify, Django, and Rails.",
+        url: "https://developer.mozilla.org/en-US/docs/Learn_web_development/Extensions/Server-side/First_steps/Web_frameworks",
+        source: "MDN",
+        sectionId: "arch-what-is-a-stack"
+      },
+      {
+        term: "ORM",
+        definition: "Object-Relational Mapping — a technique that lets you query and manipulate a database using objects in your programming language instead of raw SQL. Examples include Django's ORM, Rails' ActiveRecord, and Prisma.",
+        url: "https://docs.djangoproject.com/en/5.1/topics/db/models/",
+        source: "Django",
+        sectionId: "arch-stack-django"
+      },
+      {
+        term: "Server-Side Rendering",
+        definition: "Generating HTML on the server for each request, then sending the complete page to the browser. Improves initial load time and SEO compared to client-side rendering.",
+        url: "https://nextjs.org/docs/app/building-your-application/rendering/server-components",
+        source: "Next.js",
+        sectionId: "arch-fw-nextjs"
+      },
+      {
+        term: "Static Site Generation",
+        definition: "Pre-building HTML pages at build time rather than on each request. The fastest delivery method since pages are served as static files from a CDN.",
+        url: "https://nextjs.org/docs/pages/building-your-application/rendering/static-site-generation",
+        source: "Next.js",
+        sectionId: "arch-fw-nextjs"
+      },
+      {
+        term: "Progressive Enhancement",
+        definition: "A design approach where the core functionality works without JavaScript, then JavaScript adds richer interactivity. Forms submit normally, then JS enhances them with instant feedback.",
+        url: "https://developer.mozilla.org/en-US/docs/Glossary/Progressive_Enhancement",
+        source: "MDN",
+        sectionId: "arch-fw-react-router"
+      },
+    ]
+  },
+  {
+    category: "Databases",
+    terms: [
+      {
+        term: "SQL",
+        definition: "Structured Query Language — the standard language for querying and managing relational databases like PostgreSQL, MySQL, and SQLite.",
+        url: "https://www.postgresql.org/docs/current/sql.html",
+        source: "PostgreSQL",
+        sectionId: "arch-stack-pfrn"
+      },
+      {
+        term: "NoSQL",
+        definition: "A category of databases that don't use traditional SQL tables. Document stores (MongoDB), key-value stores (Redis), and graph databases (Neo4j) are all NoSQL.",
+        url: "https://www.mongodb.com/resources/basics/databases/nosql-explained",
+        source: "MongoDB",
+        sectionId: "arch-stack-mern"
+      },
+      {
+        term: "Schema",
+        definition: "The structure definition of a database — what tables exist, what columns they have, and what data types are allowed. Relational databases enforce schemas; NoSQL databases often don't.",
+        url: "https://www.postgresql.org/docs/current/ddl.html",
+        source: "PostgreSQL",
+        sectionId: "arch-stack-pfrn"
+      },
+      {
+        term: "ACID",
+        definition: "Atomicity, Consistency, Isolation, Durability — properties that guarantee database transactions are processed reliably. Relational databases like PostgreSQL are fully ACID-compliant.",
+        url: "https://www.postgresql.org/docs/current/transaction-iso.html",
+        source: "PostgreSQL",
+        sectionId: "arch-stack-lamp"
+      },
+    ]
+  },
+  {
+    category: "Full-Stack Frameworks",
+    terms: [
+      {
+        term: "React Server Components",
+        definition: "A React feature that renders components entirely on the server, sending only the HTML result to the browser. Reduces client-side JavaScript and enables direct database access from components.",
+        url: "https://react.dev/reference/rsc/server-components",
+        source: "React",
+        sectionId: "arch-fw-nextjs"
+      },
+      {
+        term: "File-System Routing",
+        definition: "A convention where a framework maps your project's file and folder structure directly to URL routes, eliminating the need for manual route configuration.",
+        url: "https://nextjs.org/docs/app/building-your-application/routing",
+        source: "Next.js",
+        sectionId: "arch-fw-nextjs"
+      },
+      {
+        term: "Loader/Action Pattern",
+        definition: "A data fetching pattern where loaders provide data for GET requests and actions handle mutations (POST/PUT/DELETE). After a mutation, affected loaders automatically re-run.",
+        url: "https://reactrouter.com/start/framework/data-loading",
+        source: "React Router",
+        sectionId: "arch-fw-react-router"
+      },
+      {
+        term: "Hotwire",
+        definition: "A Rails frontend approach combining Turbo (fast page navigation via HTML-over-the-wire) and Stimulus (lightweight JavaScript behaviors), minimizing the need for heavy JS frameworks.",
+        url: "https://hotwired.dev/",
+        source: "Hotwired",
+        sectionId: "arch-stack-rails"
+      },
+    ]
+  },
 ]

--- a/src/data/overallResources.ts
+++ b/src/data/overallResources.ts
@@ -92,7 +92,10 @@ export const badgeMap: Record<string, { cls: string; label: string }> = {
   bundling: { cls: "bg-orange-50 text-orange-800 dark:bg-orange-500/15 dark:text-orange-300", label: "Bundling" },
   testing: { cls: "bg-green-50 text-green-800 dark:bg-green-500/15 dark:text-green-300", label: "Testing" },
   linting: { cls: "bg-fuchsia-50 text-fuchsia-800 dark:bg-fuchsia-500/15 dark:text-fuchsia-300", label: "Linting" },
+  architecture: { cls: "bg-cyan-100 text-cyan-800 dark:bg-cyan-500/15 dark:text-cyan-300", label: "Architecture" },
+  frameworks: { cls: "bg-rose-100 text-rose-800 dark:bg-rose-500/15 dark:text-rose-300", label: "Frameworks" },
+  databases: { cls: "bg-emerald-50 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300", label: "Databases" },
 };
 
 export const typeTags = new Set(["docs", "article", "course", "video", "repo", "interactive", "free", "paid"]);
-export const topicTags = new Set(["publishing", "typescript", "versioning", "ci-cd", "monorepo", "modules", "tooling", "bundling", "testing", "linting"]);
+export const topicTags = new Set(["publishing", "typescript", "versioning", "ci-cd", "monorepo", "modules", "tooling", "bundling", "testing", "linting", "architecture", "frameworks", "databases"]);

--- a/src/helpers/darkStyle.ts
+++ b/src/helpers/darkStyle.ts
@@ -1,0 +1,4 @@
+/** Return light or dark value based on current theme */
+export function ds(light: string, dark: string, isDark: boolean): string {
+  return isDark ? dark : light
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive dark mode support to the architecture guide, including new glossary terms and dark theme styling for all interactive components.

## Key Changes

### Dark Mode Styling
- Created new `ds()` helper function in `src/helpers/darkStyle.ts` for consistent light/dark value switching
- Updated all architecture guide components to use the theme hook and apply dark mode colors:
  - `StackExplorer.tsx`: Dark backgrounds, text colors, and shadows for component bars and comparison toggles
  - `FrameworkExplorer.tsx`: Dark styling for capability bars and framework descriptions
  - `LayerDiagram.tsx`: Dark mode colors for layer visualization
  - `DataFlowDiagram.tsx`: Dark backgrounds and text for data flow diagram
  - `StackProsCons.tsx` and `FrameworkProsCons.tsx`: Dark mode for pros/cons sections
- Added `darkAccent` color property to `LAYER_COLORS` and all stack/framework data structures for proper dark mode accent backgrounds

### New Glossary Content
- Added three new glossary categories with 15 new terms:
  - **Web Architecture**: Tech Stack, Server Framework, ORM, Server-Side Rendering, Static Site Generation, Progressive Enhancement
  - **Databases**: SQL, NoSQL, Schema, ACID
  - **Full-Stack Frameworks**: React Server Components, File-System Routing, Loader/Action Pattern, Hotwire

### Documentation Enhancements
- Added `links` and `usedFootnotes` frontmatter to architecture guide pages:
  - `arch-what-is-a-stack.mdx`
  - `arch-stack-mern.mdx`
  - `arch-stack-pfrn.mdx`
  - `arch-stack-lamp.mdx`
  - `arch-stack-django.mdx`
  - `arch-stack-rails.mdx`
  - `arch-stack-mean.mdx`
  - `arch-fw-nextjs.mdx`
  - `arch-fw-react-router.mdx`
  - `arch-fw-tanstack-start.mdx`
  - `arch-fw-remix.mdx`
  - `arch-how-it-connects.mdx`
  - `arch-frameworks-intro.mdx`
- Updated `ExternalResourcesPage.tsx` with section-to-topic mappings and descriptions for all architecture sections

### Data Structure Updates
- Extended `StackComponent` and `FrameworkPageData` interfaces with `darkAccent` property
- Updated `LAYER_COLORS` constant to include dark accent colors for each layer (frontend, server, runtime, database)

## Implementation Details
- Dark mode detection uses existing `useTheme()` hook throughout components
- Color scheme maintains visual hierarchy and accessibility in both light and dark modes
- All interactive elements (buttons, toggles, cards) have consistent dark mode styling
- Glossary terms include proper source attribution and section IDs for cross-referencing

https://claude.ai/code/session_01GFahrqpBZ6QCV7CeoJLA4E