### PR TITLE
Add guide filtering to Glossary and External Resources pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Educational single-page application (SPA) with multiple guides for backend engin
 
 ## Guides
 
-The site contains two independent guides, each with its own Start Here page, navigation order, and Previous/Next links:
+The site contains two independent guides, each with its own Start Here page, navigation order, and Previous/Next links, plus top-level resource pages shared across all guides:
 
 ### NPM Package Guide (`Web App vs. NPM Package`)
 - **Start page:** `roadmap` (`src/components/RoadmapPage.tsx`)
@@ -19,6 +19,12 @@ The site contains two independent guides, each with its own Start Here page, nav
 - **Data:** `src/data/archData.ts` (stack data, layer data, data flow, framework data)
 - **Interactive MDX components:** `src/components/mdx/StackExplorer.tsx`, `StackProsCons.tsx`, `DataFlowDiagram.tsx`, `LayerDiagram.tsx`, `FrameworkExplorer.tsx`, `FrameworkProsCons.tsx`
 - **Page IDs:** `arch-start`, `arch-what-is-a-stack`, `arch-stack-{mern,pfrn,mean,lamp,django,rails}`, `arch-frameworks-intro`, `arch-fw-{nextjs,react-router,tanstack-start,remix}`, `arch-how-it-connects`
+
+### Top-Level Resources
+- **External Resources** (`src/components/ExternalResourcesPage.tsx`) — searchable, filterable table of documentation, articles, courses, and tools. Tagged with Guide, Type, and Topic filters. Data in `src/data/overallResources.ts`.
+- **Glossary** (`src/components/GlossaryPage.tsx`) — searchable glossary with Guide and Category filters. Data in `src/data/glossaryTerms.ts`.
+- Both pages support a `?guide=` URL search param to pre-select a guide filter (e.g., `/#/glossary?guide=npm-package`). Links from within guides use this param to show guide-relevant content by default.
+- These pages appear in the sidebar under a dedicated "Resources" icon, in the command menu under a "Resources" group, and on the home page in a "Resources" section.
 
 ## Tech Stack
 
@@ -99,6 +105,8 @@ Each guide has its own independent navigation order. Pages must appear in the sa
 4. **Command menu** (`src/components/CommandMenu.tsx`) — the `buildingPackageOrder`, `ciOrder`, `bonusOrder`, and `resourceIds` arrays that populate the Cmd+K palette
 
 The `getNavOrder(currentId)` function returns the correct guide's order based on the current page ID. NPM Package Guide pages use the default order; Architecture Guide pages (matching `ARCH_PAGE_IDS` from `src/data/archData.ts`) use the architecture order.
+
+**Top-level resource pages** (`external-resources`, `glossary`) are NOT part of any guide's navigation order. They appear in the sidebar under a dedicated "Resources" icon, in the command menu under a "Resources" group, and on the home page. They do not have Previous/Next navigation.
 
 When adding, removing, or reordering pages, update all four locations for the affected guide to stay in sync.
 

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -20,7 +20,9 @@ const ciOrder = [
 
 const bonusOrder = ['storybook']
 
-const resourceIds = ['checklist', 'external-resources', 'glossary']
+const resourceIds = ['checklist']
+
+const topLevelResourceIds = ['external-resources', 'glossary']
 
 const archStackOrder = [
   'arch-stack-mern', 'arch-stack-pfrn', 'arch-stack-mean',
@@ -126,6 +128,12 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
 
         <Command.Group heading="Putting It Together">
           <PageItem id="arch-how-it-connects" onSelect={handleSelect} />
+        </Command.Group>
+
+        <Command.Group heading="Resources">
+          {topLevelResourceIds.map(id => (
+            <PageItem key={id} id={id} onSelect={handleSelect} />
+          ))}
         </Command.Group>
       </Command.List>
     </Command.Dialog>

--- a/src/components/GuidesIndexPage.tsx
+++ b/src/components/GuidesIndexPage.tsx
@@ -8,6 +8,30 @@ interface GuideTile {
   description: string
 }
 
+interface ResourceTile {
+  sectionId: string
+  icon: string
+  title: string
+  description: string
+}
+
+const resources: ResourceTile[] = [
+  {
+    sectionId: 'external-resources',
+    icon: '\u{1F4DA}',
+    title: 'External Resources',
+    description:
+      'Curated documentation, articles, courses, tools, and section references — all in one searchable, filterable table.',
+  },
+  {
+    sectionId: 'glossary',
+    icon: '\u{1F4D6}',
+    title: 'Glossary',
+    description:
+      'Key terms you\'ll encounter across all guides, with links to relevant sections and external documentation.',
+  },
+]
+
 const guides: GuideTile[] = [
   {
     id: 'npm-package',
@@ -69,6 +93,36 @@ export function GuidesIndexPage() {
           <p className="text-sm text-slate-400 dark:text-slate-500 leading-relaxed">
             Additional guides are in the works. Stay tuned!
           </p>
+        </div>
+      </div>
+
+      {/* Resources section */}
+      <div className="mt-12">
+        <h2 className="text-xl font-bold tracking-tight mb-1 text-slate-900 dark:text-slate-100">Resources</h2>
+        <p className="text-gray-500 dark:text-slate-400 text-sm mb-5">
+          Cross-guide references and learning materials.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {resources.map((resource) => (
+            <button
+              key={resource.sectionId}
+              className="flex flex-col items-start text-left p-5 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl cursor-pointer transition-all duration-150 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 hover:-translate-y-0.5"
+              onClick={() =>
+                navigate({
+                  to: '/$sectionId',
+                  params: { sectionId: resource.sectionId },
+                })
+              }
+            >
+              <span className="text-2xl mb-2">{resource.icon}</span>
+              <h3 className="text-base font-bold text-slate-900 dark:text-slate-100 mb-1">
+                {resource.title}
+              </h3>
+              <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                {resource.description}
+              </p>
+            </button>
+          ))}
         </div>
       </div>
     </div>

--- a/src/components/RoadmapPage.tsx
+++ b/src/components/RoadmapPage.tsx
@@ -1,3 +1,4 @@
+import { useNavigate } from '@tanstack/react-router'
 import { roadmapSteps } from '../data/roadmapSteps'
 import { contentPages } from '../content/registry'
 import { findNavItem } from '../helpers/findNavItem'
@@ -26,9 +27,24 @@ const bonusDescriptions: Record<string, string> = {
 const jumpBtnCls = 'inline-flex items-center gap-1.5 text-sm font-bold text-white cursor-pointer bg-blue-500 dark:bg-blue-400 dark:text-slate-900 border-none font-sans py-2 px-3.5 rounded-lg transition-all duration-150 mt-1 shadow-md shadow-blue-500/25 hover:bg-blue-600 dark:hover:bg-blue-500 hover:-translate-y-px hover:shadow-lg hover:shadow-blue-500/30'
 
 function JumpButton({ jumpTo, children, style }: { jumpTo: string; children: React.ReactNode; style?: React.CSSProperties }) {
-  const navigate = useNavigateToSection()
+  const navigateToSection = useNavigateToSection()
   return (
-    <button className={jumpBtnCls} style={style} onClick={() => navigate(jumpTo)}>
+    <button className={jumpBtnCls} style={style} onClick={() => navigateToSection(jumpTo)}>
+      {children}
+    </button>
+  )
+}
+
+function GuideJumpButton({ sectionId, guide, children }: { sectionId: string; guide: string; children: React.ReactNode }) {
+  const navigate = useNavigate()
+  return (
+    <button
+      className={jumpBtnCls}
+      onClick={() => {
+        navigate({ to: '/$sectionId', params: { sectionId }, search: { guide } })
+        window.scrollTo({ top: 0, behavior: 'smooth' })
+      }}
+    >
       {children}
     </button>
   )
@@ -130,8 +146,16 @@ export function RoadmapPage() {
 
         <BonusCard title="Bonus: Learning Resources" desc="Documentation, articles, courses, and tools to go deeper on frontend development, npm packages, and the JavaScript ecosystem.">
           <BonusSubpage title={'\u2705 Publish Checklist'} desc="Go through this before every npm publish — trust us, it saves headaches." jumpTo="checklist" jumpLabel={'\u2705 Publish Checklist'} />
-          <BonusSubpage title={'\u{1F4DA} External Resources'} desc="Curated documentation, articles, courses, tools, and section references — all in one searchable, sortable table." jumpTo="external-resources" jumpLabel={'\u{1F4DA} External Resources'} />
-          <BonusSubpage title={'\u{1F4D6} Glossary'} desc="Key terms you'll encounter when building and publishing npm packages, with links to the relevant sections in this guide." jumpTo="glossary" jumpLabel={'\u{1F4D6} Glossary'} />
+          <div className="mt-4.5 py-2 pl-3.5 border-l-2 border-slate-200 dark:border-slate-700">
+            <h3 className="text-sm font-bold text-slate-900 dark:text-slate-100 m-0 mb-0.5">{'\u{1F4DA}'} External Resources</h3>
+            <div className="text-sm text-slate-800 dark:text-slate-300 leading-normal mb-1">Curated documentation, articles, courses, tools, and section references — all in one searchable, sortable table.</div>
+            <GuideJumpButton sectionId="external-resources" guide="npm-package">{'\u2192'} View with NPM Package filter</GuideJumpButton>
+          </div>
+          <div className="mt-4.5 py-2 pl-3.5 border-l-2 border-slate-200 dark:border-slate-700">
+            <h3 className="text-sm font-bold text-slate-900 dark:text-slate-100 m-0 mb-0.5">{'\u{1F4D6}'} Glossary</h3>
+            <div className="text-sm text-slate-800 dark:text-slate-300 leading-normal mb-1">Key terms you'll encounter when building and publishing npm packages, with links to the relevant sections in this guide.</div>
+            <GuideJumpButton sectionId="glossary" guide="npm-package">{'\u2192'} View with NPM Package filter</GuideJumpButton>
+          </div>
         </BonusCard>
       </div>
       <PrevNextNav currentId="roadmap" />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -45,7 +45,7 @@ const guides: GuideDefinition[] = [
       { label: 'Building a Package', ids: buildingPackageOrder },
       { label: 'CI Pipeline & Checks', ids: ciOrder },
       { label: 'Developer Experience', ids: bonusOrder },
-      { label: 'Learning Resources', ids: ['checklist', 'external-resources', 'glossary'] },
+      { label: 'Learning Resources', ids: ['checklist'] },
     ],
   },
   {
@@ -57,6 +57,14 @@ const guides: GuideDefinition[] = [
       { label: 'Stack Alternatives', ids: archStackOrder },
       { label: 'Full-Stack Frameworks', ids: ['arch-frameworks-intro', ...archFrameworkOrder] },
       { label: 'Putting It Together', ids: ['arch-how-it-connects'] },
+    ],
+  },
+  {
+    id: 'resources',
+    icon: '\u{1F4DA}',        // 📚
+    title: 'Resources',
+    sections: [
+      { label: null, ids: ['external-resources', 'glossary'] },
     ],
   },
 ]

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -14,7 +14,7 @@ const npmNavOrder = [
   "packagejson", "typescript", "versioning", "workflow",
   ...ciPageIds,
   ...bonusIds,
-  "checklist", "external-resources", "glossary",
+  "checklist",
 ]
 
 export function getNavOrder(currentId?: string): string[] {

--- a/src/data/overallResources.ts
+++ b/src/data/overallResources.ts
@@ -14,57 +14,57 @@ export const overallResources: ResourceGroup[] = [
   {
     category: "Official Documentation",
     items: [
-      { name: "npm Docs — Getting Started", url: "https://docs.npmjs.com/getting-started", desc: "Official npm setup and publishing guide — the starting point for creating and distributing packages", tags: ["docs", "free", "publishing"] },
-      { name: "pnpm Documentation", url: "https://pnpm.io/motivation", desc: "Alternative package manager with strict dependency isolation, commonly used for monorepo package development", tags: ["docs", "free", "tooling"] },
-      { name: "Node.js — Packages Documentation", url: "https://nodejs.org/api/packages.html", desc: "How Node.js resolves package exports and entry points — essential for configuring package.json correctly", tags: ["docs", "free", "modules"] },
-      { name: "MDN — JavaScript Modules", url: "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules", desc: "ESM import/export syntax that npm packages use for tree-shakeable module distribution", tags: ["docs", "free", "modules"] },
-      { name: "TypeScript — Publishing Declaration Files", url: "https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html", desc: "How to ship .d.ts type declarations so consumers get autocomplete and type checking from your package", tags: ["docs", "free", "typescript"] },
-      { name: "Semantic Versioning Specification", url: "https://semver.org/", desc: "The versioning contract every npm package follows — defines how version numbers communicate breaking changes", tags: ["docs", "free", "versioning"] },
+      { name: "npm Docs — Getting Started", url: "https://docs.npmjs.com/getting-started", desc: "Official npm setup and publishing guide — the starting point for creating and distributing packages", tags: ["docs", "free", "publishing", "guide:npm-package"] },
+      { name: "pnpm Documentation", url: "https://pnpm.io/motivation", desc: "Alternative package manager with strict dependency isolation, commonly used for monorepo package development", tags: ["docs", "free", "tooling", "guide:npm-package"] },
+      { name: "Node.js — Packages Documentation", url: "https://nodejs.org/api/packages.html", desc: "How Node.js resolves package exports and entry points — essential for configuring package.json correctly", tags: ["docs", "free", "modules", "guide:npm-package"] },
+      { name: "MDN — JavaScript Modules", url: "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Modules", desc: "ESM import/export syntax that npm packages use for tree-shakeable module distribution", tags: ["docs", "free", "modules", "guide:npm-package"] },
+      { name: "TypeScript — Publishing Declaration Files", url: "https://www.typescriptlang.org/docs/handbook/declaration-files/publishing.html", desc: "How to ship .d.ts type declarations so consumers get autocomplete and type checking from your package", tags: ["docs", "free", "typescript", "guide:npm-package"] },
+      { name: "Semantic Versioning Specification", url: "https://semver.org/", desc: "The versioning contract every npm package follows — defines how version numbers communicate breaking changes", tags: ["docs", "free", "versioning", "guide:npm-package"] },
     ]
   },
   {
     category: "Articles & Tutorials",
     items: [
-      { name: "Best Practices for Creating a Modern npm Package (Snyk)", url: "https://snyk.io/blog/best-practices-create-modern-npm-package/", desc: "End-to-end walkthrough covering TypeScript setup, CI/CD pipelines, security, and automated releases", tags: ["article", "free", "publishing", "ci-cd"] },
-      { name: "Building and Publishing TypeScript NPM Packages", url: "https://akashrajpurohit.com/blog/building-and-publishing-typescript-npm-packages-a-stepbystep-guide/", desc: "Step-by-step guide using tsup, vitest, and semantic-release to build and publish a TypeScript package", tags: ["article", "free", "publishing", "typescript"] },
-      { name: "How to Create an NPM Package in TypeScript (Atomic Object)", url: "https://spin.atomicobject.com/npm-package-typescript/", desc: "Ground-up tutorial building a minimal importable TypeScript module from scratch", tags: ["article", "free", "publishing", "typescript"] },
-      { name: "Conventional Commits", url: "https://www.conventionalcommits.org/", desc: "Commit message standard that enables automated version bumps and changelog generation for packages", tags: ["docs", "free", "versioning"] },
+      { name: "Best Practices for Creating a Modern npm Package (Snyk)", url: "https://snyk.io/blog/best-practices-create-modern-npm-package/", desc: "End-to-end walkthrough covering TypeScript setup, CI/CD pipelines, security, and automated releases", tags: ["article", "free", "publishing", "ci-cd", "guide:npm-package"] },
+      { name: "Building and Publishing TypeScript NPM Packages", url: "https://akashrajpurohit.com/blog/building-and-publishing-typescript-npm-packages-a-stepbystep-guide/", desc: "Step-by-step guide using tsup, vitest, and semantic-release to build and publish a TypeScript package", tags: ["article", "free", "publishing", "typescript", "guide:npm-package"] },
+      { name: "How to Create an NPM Package in TypeScript (Atomic Object)", url: "https://spin.atomicobject.com/npm-package-typescript/", desc: "Ground-up tutorial building a minimal importable TypeScript module from scratch", tags: ["article", "free", "publishing", "typescript", "guide:npm-package"] },
+      { name: "Conventional Commits", url: "https://www.conventionalcommits.org/", desc: "Commit message standard that enables automated version bumps and changelog generation for packages", tags: ["docs", "free", "versioning", "guide:npm-package"] },
     ]
   },
   {
     category: "Free Courses & Interactive Learning",
     items: [
-      { name: "Publish JavaScript Packages on npm (egghead.io)", url: "https://egghead.io/courses/publish-javascript-packages-on-npm", desc: "Hands-on video course covering package creation, testing, publishing, and update workflows on npm", tags: ["course", "free", "video", "publishing"] },
-      { name: "How to Write an Open Source JavaScript Library (egghead.io)", url: "https://egghead.io/courses/how-to-write-an-open-source-javascript-library", desc: "Covers GitHub setup, npm publishing, semantic-release, and CI automation for open-source packages", tags: ["course", "free", "video", "publishing", "ci-cd"] },
-      { name: "NodeSchool Workshops", url: "https://nodeschool.io/", desc: "Terminal-based tutorials for Node.js and npm fundamentals — builds the foundation for package development", tags: ["interactive", "free"] },
-      { name: "Learn NPM — codedamn", url: "https://codedamn.com/learn/npm-basics", desc: "Browser-based interactive exercises covering npm basics like installing, updating, and managing packages", tags: ["interactive", "free"] },
+      { name: "Publish JavaScript Packages on npm (egghead.io)", url: "https://egghead.io/courses/publish-javascript-packages-on-npm", desc: "Hands-on video course covering package creation, testing, publishing, and update workflows on npm", tags: ["course", "free", "video", "publishing", "guide:npm-package"] },
+      { name: "How to Write an Open Source JavaScript Library (egghead.io)", url: "https://egghead.io/courses/how-to-write-an-open-source-javascript-library", desc: "Covers GitHub setup, npm publishing, semantic-release, and CI automation for open-source packages", tags: ["course", "free", "video", "publishing", "ci-cd", "guide:npm-package"] },
+      { name: "NodeSchool Workshops", url: "https://nodeschool.io/", desc: "Terminal-based tutorials for Node.js and npm fundamentals — builds the foundation for package development", tags: ["interactive", "free", "guide:npm-package"] },
+      { name: "Learn NPM — codedamn", url: "https://codedamn.com/learn/npm-basics", desc: "Browser-based interactive exercises covering npm basics like installing, updating, and managing packages", tags: ["interactive", "free", "guide:npm-package"] },
     ]
   },
   {
     category: "Paid Courses",
     items: [
-      { name: "Creating NPM Packages: The Complete Guide (Udemy)", url: "https://www.udemy.com/course/creating-npm-packages-the-complete-guide/", desc: "Comprehensive course covering tree-shaking, CI automation, pre-release versions, and TypeScript package setup", tags: ["course", "paid", "video", "publishing", "typescript"] },
-      { name: "NPM Mastery: Package Management & Publishing (Udemy)", url: "https://www.udemy.com/course/npm-mastery-nodejs-package-management-publishing/", desc: "Bootcamp-style course from package basics to publishing, with a capstone CLI project", tags: ["course", "paid", "video", "publishing"] },
-      { name: "Understanding NPM (Udemy)", url: "https://www.udemy.com/course/understanding-npm/", desc: "Deep dive into npm internals — scripts, bins, semver, and lock files relevant to package authoring", tags: ["course", "paid", "video"] },
+      { name: "Creating NPM Packages: The Complete Guide (Udemy)", url: "https://www.udemy.com/course/creating-npm-packages-the-complete-guide/", desc: "Comprehensive course covering tree-shaking, CI automation, pre-release versions, and TypeScript package setup", tags: ["course", "paid", "video", "publishing", "typescript", "guide:npm-package"] },
+      { name: "NPM Mastery: Package Management & Publishing (Udemy)", url: "https://www.udemy.com/course/npm-mastery-nodejs-package-management-publishing/", desc: "Bootcamp-style course from package basics to publishing, with a capstone CLI project", tags: ["course", "paid", "video", "publishing", "guide:npm-package"] },
+      { name: "Understanding NPM (Udemy)", url: "https://www.udemy.com/course/understanding-npm/", desc: "Deep dive into npm internals — scripts, bins, semver, and lock files relevant to package authoring", tags: ["course", "paid", "video", "guide:npm-package"] },
     ]
   },
   {
     category: "Starter Templates & Tools",
     items: [
-      { name: "npm Package Boilerplate 2025", url: "https://github.com/simonorzel26/npm-package-boilerplate-2025", desc: "Opinionated starter template with pnpm, TypeScript, dual ESM+CJS output, and automated releases", tags: ["repo", "free", "publishing", "typescript"] },
-      { name: "tsup — Bundle TypeScript Libraries", url: "https://tsup.egoist.dev/", desc: "Zero-config TypeScript bundler producing ESM and CJS outputs — the most popular choice for package builds", tags: ["docs", "free", "tooling", "bundling"] },
-      { name: "changesets — Version Management", url: "https://github.com/changesets/changesets", desc: "Manages versioning and changelogs across packages, especially useful in monorepo setups", tags: ["repo", "free", "versioning", "monorepo"] },
-      { name: "semantic-release", url: "https://semantic-release.gitbook.io/semantic-release", desc: "Automates version bumps, npm publishing, and changelog generation based on commit messages", tags: ["docs", "free", "versioning", "ci-cd"] },
+      { name: "npm Package Boilerplate 2025", url: "https://github.com/simonorzel26/npm-package-boilerplate-2025", desc: "Opinionated starter template with pnpm, TypeScript, dual ESM+CJS output, and automated releases", tags: ["repo", "free", "publishing", "typescript", "guide:npm-package"] },
+      { name: "tsup — Bundle TypeScript Libraries", url: "https://tsup.egoist.dev/", desc: "Zero-config TypeScript bundler producing ESM and CJS outputs — the most popular choice for package builds", tags: ["docs", "free", "tooling", "bundling", "guide:npm-package"] },
+      { name: "changesets — Version Management", url: "https://github.com/changesets/changesets", desc: "Manages versioning and changelogs across packages, especially useful in monorepo setups", tags: ["repo", "free", "versioning", "monorepo", "guide:npm-package"] },
+      { name: "semantic-release", url: "https://semantic-release.gitbook.io/semantic-release", desc: "Automates version bumps, npm publishing, and changelog generation based on commit messages", tags: ["docs", "free", "versioning", "ci-cd", "guide:npm-package"] },
     ]
   },
   {
     category: "Monorepo Tools & Resources",
     items: [
-      { name: "Turborepo — Getting Started", url: "https://turbo.build/repo/docs", desc: "Build system for JS/TS monorepos with smart caching — ideal for developing multiple related packages", tags: ["docs", "free", "monorepo", "tooling"] },
-      { name: "Nx — Getting Started", url: "https://nx.dev/getting-started/intro", desc: "Full-featured monorepo tool with dependency graph and code generation for multi-package repos", tags: ["docs", "free", "monorepo", "tooling"] },
-      { name: "Lerna — Modern Monorepo Management", url: "https://lerna.js.org/", desc: "Coordinates versioning and publishing across multiple packages in a monorepo", tags: ["docs", "free", "monorepo", "publishing"] },
-      { name: "npm Workspaces docs", url: "https://docs.npmjs.com/cli/v10/using-npm/workspaces", desc: "Built-in npm feature for linking and managing multiple local packages in a single repository", tags: ["docs", "free", "monorepo"] },
-      { name: "pnpm Workspaces docs", url: "https://pnpm.io/workspaces", desc: "pnpm's workspace protocol for managing monorepo package dependencies with strict isolation", tags: ["docs", "free", "monorepo"] },
+      { name: "Turborepo — Getting Started", url: "https://turbo.build/repo/docs", desc: "Build system for JS/TS monorepos with smart caching — ideal for developing multiple related packages", tags: ["docs", "free", "monorepo", "tooling", "guide:npm-package"] },
+      { name: "Nx — Getting Started", url: "https://nx.dev/getting-started/intro", desc: "Full-featured monorepo tool with dependency graph and code generation for multi-package repos", tags: ["docs", "free", "monorepo", "tooling", "guide:npm-package"] },
+      { name: "Lerna — Modern Monorepo Management", url: "https://lerna.js.org/", desc: "Coordinates versioning and publishing across multiple packages in a monorepo", tags: ["docs", "free", "monorepo", "publishing", "guide:npm-package"] },
+      { name: "npm Workspaces docs", url: "https://docs.npmjs.com/cli/v10/using-npm/workspaces", desc: "Built-in npm feature for linking and managing multiple local packages in a single repository", tags: ["docs", "free", "monorepo", "guide:npm-package"] },
+      { name: "pnpm Workspaces docs", url: "https://pnpm.io/workspaces", desc: "pnpm's workspace protocol for managing monorepo package dependencies with strict isolation", tags: ["docs", "free", "monorepo", "guide:npm-package"] },
     ]
   }
 ];
@@ -81,6 +81,9 @@ export const badgeMap: Record<string, { cls: string; label: string }> = {
   interactive: { cls: "bg-teal-100 text-teal-800 dark:bg-teal-500/15 dark:text-teal-300", label: "Interactive" },
   free: { cls: "bg-emerald-100 text-emerald-800 dark:bg-emerald-500/15 dark:text-emerald-300", label: "Free" },
   paid: { cls: "bg-amber-100 text-amber-800 dark:bg-amber-500/15 dark:text-amber-300", label: "Paid" },
+  // Guide
+  "guide:npm-package": { cls: "bg-indigo-50 text-indigo-700 dark:bg-indigo-500/15 dark:text-indigo-300", label: "NPM Package Guide" },
+  "guide:architecture": { cls: "bg-cyan-50 text-cyan-700 dark:bg-cyan-500/15 dark:text-cyan-300", label: "Architecture Guide" },
   // Topic
   publishing: { cls: "bg-yellow-100 text-yellow-800 dark:bg-yellow-500/15 dark:text-yellow-300", label: "Publishing" },
   typescript: { cls: "bg-sky-100 text-sky-700 dark:bg-sky-500/15 dark:text-sky-300", label: "TypeScript" },
@@ -99,3 +102,4 @@ export const badgeMap: Record<string, { cls: string; label: string }> = {
 
 export const typeTags = new Set(["docs", "article", "course", "video", "repo", "interactive", "free", "paid"]);
 export const topicTags = new Set(["publishing", "typescript", "versioning", "ci-cd", "monorepo", "modules", "tooling", "bundling", "testing", "linting", "architecture", "frameworks", "databases"]);
+export const guideTags = new Set(["guide:npm-package", "guide:architecture"]);

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -19,14 +19,19 @@ const indexRoute = createRoute({
   component: GuidesIndexPage,
 })
 
+interface SectionSearch {
+  guide?: string
+}
+
 // eslint-disable-next-line react-refresh/only-export-components
 function SectionRouter() {
   const { sectionId } = sectionRoute.useParams()
+  const { guide } = sectionRoute.useSearch()
 
   if (sectionId === 'roadmap') return <RoadmapPage />
   if (sectionId === 'checklist') return <ChecklistPage />
-  if (sectionId === 'external-resources') return <ExternalResourcesPage />
-  if (sectionId === 'glossary') return <GlossaryPage />
+  if (sectionId === 'external-resources') return <ExternalResourcesPage initialGuide={guide} />
+  if (sectionId === 'glossary') return <GlossaryPage initialGuide={guide} />
   if (sectionId === 'architecture' || sectionId === 'arch-start') return <ArchStartPage />
 
   const page = contentPages.get(sectionId)
@@ -39,6 +44,9 @@ const sectionRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: '/$sectionId',
   component: SectionRouter,
+  validateSearch: (search: Record<string, unknown>): SectionSearch => ({
+    guide: typeof search.guide === 'string' ? search.guide : undefined,
+  }),
 })
 
 const routeTree = rootRoute.addChildren([indexRoute, sectionRoute])


### PR DESCRIPTION
## Summary
This PR refactors the Glossary and External Resources pages to support filtering by guide (NPM Package vs Architecture), making these shared resource pages more contextual to each guide. It also reorganizes the sidebar navigation to separate top-level resources into their own section.

## Key Changes

- **Guide Filtering**: Added `guide` query parameter support to both Glossary and External Resources pages, allowing users to filter content by guide context
  - `GlossaryPage` now accepts `initialGuide` prop and filters terms by derived guide (based on `sectionId`)
  - `ExternalResourcesPage` now accepts `initialGuide` prop and filters resources by guide tags
  - Added `deriveGuide()` helper to determine guide from section IDs (architecture vs npm-package)

- **Data Updates**: Tagged all resources in `overallResources.ts` with guide identifiers (`guide:npm-package` or `guide:architecture`)

- **Navigation Restructuring**:
  - Moved External Resources and Glossary out of guide-specific "Learning Resources" sections
  - Created new top-level "Resources" section in sidebar for shared pages
  - Updated command menu to reflect new resource organization

- **UI Improvements**:
  - Added labeled filter sections (Guide, Category, Type, Topic) with visual grouping
  - Extracted filter styling into reusable CSS classes
  - Updated page descriptions to reflect cross-guide nature
  - Removed emoji from Glossary title for consistency
  - Removed Previous/Next navigation from resource pages (they're not sequential)

- **Router Updates**: Added `SectionSearch` interface to support `guide` query parameter in section routes

## Implementation Details

- Guide filtering uses `useMemo` to efficiently filter data based on `guideFilter` state
- Guide tags follow pattern `guide:{npm-package|architecture}` for consistency with existing tag system
- `RoadmapPage` now includes `GuideJumpButton` component to navigate to resources with pre-selected guide filter
- Resource pages can be accessed directly or via guide-filtered links from the roadmap

https://claude.ai/code/session_01LJ1UBGRRAN1YKGuXWzinEB