### PR TITLE
Refactor theme toggle and add tooltips to sidebar icons

### DIFF
--- a/e2e/theme.spec.ts
+++ b/e2e/theme.spec.ts
@@ -11,12 +11,17 @@ test.describe('Theme Toggle', () => {
     // Default should be light (no dark class)
     await expect(html).not.toHaveClass(/dark/)
 
-    // Click theme toggle to switch to dark
-    await page.locator('[data-testid="theme-toggle"]').click()
+    // Open sidebar, then open options dropdown
+    await page.locator('[data-testid="menu-toggle"]').click()
+    await page.locator('[data-testid="options-dropdown-toggle"]').click()
+
+    // Click Dark to switch to dark mode
+    await page.locator('[data-testid="theme-option-dark"]').click()
     await expect(html).toHaveClass(/dark/)
 
-    // Click again to switch back to light
-    await page.locator('[data-testid="theme-toggle"]').click()
+    // Re-open dropdown and click Light to switch back
+    await page.locator('[data-testid="options-dropdown-toggle"]').click()
+    await page.locator('[data-testid="theme-option-light"]').click()
     await expect(html).not.toHaveClass(/dark/)
   })
 })

--- a/src/components/OptionsDropdown.tsx
+++ b/src/components/OptionsDropdown.tsx
@@ -25,7 +25,12 @@ export function OptionsDropdown({ position = 'header' }: OptionsDropdownProps) {
   return (
     <>
       <button
-        className="flex items-center justify-center w-9 h-9 border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 rounded-lg cursor-pointer shrink-0 transition-all duration-150 hover:border-blue-500 dark:hover:border-blue-400 hover:text-blue-500 dark:hover:text-blue-400 hover:shadow-md hover:shadow-blue-500/10"
+        className={clsx(
+          'flex items-center justify-center rounded-lg cursor-pointer shrink-0 transition-all duration-150',
+          position === 'sidebar'
+            ? 'w-10 h-10 border-none bg-transparent text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 group/settings relative'
+            : 'w-9 h-9 border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 hover:border-blue-500 dark:hover:border-blue-400 hover:text-blue-500 dark:hover:text-blue-400 hover:shadow-md hover:shadow-blue-500/10'
+        )}
         onClick={(e) => { e.stopPropagation(); setOpen(!open) }}
         aria-label="Options"
         data-testid="options-dropdown-toggle"
@@ -34,6 +39,11 @@ export function OptionsDropdown({ position = 'header' }: OptionsDropdownProps) {
           <circle cx="12" cy="12" r="3"/>
           <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 2.83-2.83l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z"/>
         </svg>
+        {position === 'sidebar' && !open && (
+          <span className="absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2 py-1 text-[11px] font-normal text-white dark:text-slate-200 bg-slate-800 dark:bg-slate-600 rounded whitespace-nowrap opacity-0 pointer-events-none transition-opacity duration-150 group-hover/settings:opacity-100 z-50">
+            Settings
+          </span>
+        )}
       </button>
       <div
         className={clsx(
@@ -47,30 +57,28 @@ export function OptionsDropdown({ position = 'header' }: OptionsDropdownProps) {
       >
         <div className="px-3 py-1.5 text-xs font-semibold text-gray-400 dark:text-slate-500 uppercase tracking-wider">Appearance</div>
         <button
-          className="flex items-center w-full px-3 py-1.5 text-sm text-slate-700 dark:text-slate-300 bg-transparent border-none cursor-pointer transition-colors duration-150 hover:bg-slate-50 dark:hover:bg-slate-700"
-          onClick={toggleTheme}
-          data-testid="theme-toggle"
+          className={clsx(
+            'flex items-center w-full px-3 py-1.5 text-sm bg-transparent border-none cursor-pointer transition-colors duration-150',
+            theme === 'light'
+              ? 'text-blue-600 dark:text-blue-400 font-semibold'
+              : 'text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700'
+          )}
+          onClick={() => { if (theme !== 'light') toggleTheme(); setOpen(false) }}
+          data-testid="theme-option-light"
         >
-          <span className="w-5 text-base leading-none shrink-0">
-            {theme === 'light' ? (
-              <svg className="w-3.5 h-3.5 stroke-current fill-none" viewBox="0 0 24 24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
-              </svg>
-            ) : (
-              <svg className="w-3.5 h-3.5 stroke-current fill-none" viewBox="0 0 24 24" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                <circle cx="12" cy="12" r="5" />
-                <line x1="12" y1="1" x2="12" y2="3" />
-                <line x1="12" y1="21" x2="12" y2="23" />
-                <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
-                <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
-                <line x1="1" y1="12" x2="3" y2="12" />
-                <line x1="21" y1="12" x2="23" y2="12" />
-                <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
-                <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
-              </svg>
-            )}
-          </span>
-          {theme === 'light' ? 'Dark mode' : 'Light mode'}
+          <span className="w-5 text-xs text-blue-500 dark:text-blue-400">{theme === 'light' ? '\u2713' : ''}</span> Light
+        </button>
+        <button
+          className={clsx(
+            'flex items-center w-full px-3 py-1.5 text-sm bg-transparent border-none cursor-pointer transition-colors duration-150',
+            theme === 'dark'
+              ? 'text-blue-600 dark:text-blue-400 font-semibold'
+              : 'text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700'
+          )}
+          onClick={() => { if (theme !== 'dark') toggleTheme(); setOpen(false) }}
+          data-testid="theme-option-dark"
+        >
+          <span className="w-5 text-xs text-blue-500 dark:text-blue-400">{theme === 'dark' ? '\u2713' : ''}</span> Dark
         </button>
 
         <div className="mx-2.5 my-1 h-px bg-slate-200 dark:bg-slate-700" />

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -194,9 +194,10 @@ function IconRail({
   onResourceClick: (id: string) => void
   currentId: string
 }) {
-  const iconBtnCls = 'flex items-center justify-center w-10 h-10 rounded-lg border-none cursor-pointer transition-all duration-150'
+  const iconBtnCls = 'flex items-center justify-center w-10 h-10 rounded-lg border-none cursor-pointer transition-all duration-150 group relative'
   const activeCls = 'bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400'
   const inactiveCls = 'bg-transparent text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800'
+  const tooltipCls = 'absolute left-full top-1/2 -translate-y-1/2 ml-2 px-2 py-1 text-[11px] font-normal text-white dark:text-slate-200 bg-slate-800 dark:bg-slate-600 rounded whitespace-nowrap opacity-0 pointer-events-none transition-opacity duration-150 group-hover:opacity-100 z-50'
 
   return (
     <div className="flex flex-col items-center w-[52px] shrink-0 border-r border-slate-200 dark:border-slate-700 py-3 gap-1">
@@ -205,13 +206,13 @@ function IconRail({
         to="/"
         className={clsx(iconBtnCls, !currentId ? activeCls : inactiveCls)}
         onClick={onHomeClick}
-        title="Home"
         data-testid="sidebar-home-icon"
       >
         <svg className="w-5 h-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
           <path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/>
           <polyline points="9 22 9 12 15 12 15 22"/>
         </svg>
+        <span className={tooltipCls}>Home</span>
       </Link>
 
       <div className="w-6 h-px bg-slate-200 dark:bg-slate-700 my-1.5" />
@@ -222,10 +223,10 @@ function IconRail({
           key={guide.id}
           className={clsx(iconBtnCls, activeGuideId === guide.id ? activeCls : inactiveCls)}
           onClick={() => onSelectGuide(guide.id)}
-          title={guide.title}
           data-testid={`sidebar-guide-icon-${guide.id}`}
         >
           <span className="text-lg leading-none">{guide.icon}</span>
+          <span className={tooltipCls}>{guide.title}</span>
         </button>
       ))}
 
@@ -236,18 +237,18 @@ function IconRail({
       <button
         className={clsx(iconBtnCls, currentId === 'external-resources' ? activeCls : inactiveCls)}
         onClick={() => onResourceClick('external-resources')}
-        title="External Resources"
         data-testid="sidebar-icon-external-resources"
       >
         <span className="text-lg leading-none">{'\u{1F4DA}'}</span>
+        <span className={tooltipCls}>External Resources</span>
       </button>
       <button
         className={clsx(iconBtnCls, currentId === 'glossary' ? activeCls : inactiveCls)}
         onClick={() => onResourceClick('glossary')}
-        title="Glossary"
         data-testid="sidebar-icon-glossary"
       >
         <span className="text-lg leading-none">{'\u{1F4D6}'}</span>
+        <span className={tooltipCls}>Glossary</span>
       </button>
 
       <div className="w-6 h-px bg-slate-200 dark:bg-slate-700 my-1.5" />


### PR DESCRIPTION
## Summary
This PR refactors the theme selection UI from a single toggle button to separate Light/Dark mode options in the dropdown menu, and adds hover tooltips to sidebar icons for better UX.

## Key Changes

- **Theme Selection UI**: Converted the theme toggle from a single button that cycles between modes to two separate buttons (Light/Dark) with visual indicators (checkmarks) showing the currently active theme
  - Each theme option only triggers a change if it's not already the active theme
  - Dropdown closes automatically after selecting a theme
  - Active theme is highlighted with blue text and checkmark

- **Sidebar Tooltips**: Replaced HTML `title` attributes with styled tooltip elements that appear on hover
  - Tooltips use a consistent dark background style with smooth opacity transitions
  - Applied to Home, Guide icons, External Resources, and Glossary buttons
  - Tooltips are positioned to the right of icons with proper spacing

- **Options Dropdown Styling**: Enhanced the dropdown button to support different styles based on position
  - Header position: Original bordered style with blue hover effects
  - Sidebar position: Transparent background with tooltip label that appears on hover
  - Uses `clsx` for conditional styling

- **Test Updates**: Updated e2e tests to reflect the new theme selection flow
  - Tests now open the sidebar and use the new theme option buttons
  - Updated test IDs to match new button structure

## Implementation Details

- Tooltip styling is consistent across sidebar icons using a shared `tooltipCls` variable
- Theme options use conditional styling to highlight the active selection
- Dropdown automatically closes after theme selection for better UX
- All tooltips use the same visual treatment for consistency

https://claude.ai/code/session_018X8TPoNuQm4zTcRCzWgWxV