### PR TITLE
Centralize guide metadata in guideRegistry for DRY navigation

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -1,50 +1,13 @@
 import { Command } from 'cmdk'
 import { useNavigate } from '@tanstack/react-router'
 import { getNavTitle } from '../data/navigation'
+import { guides } from '../data/guideRegistry'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
 
 interface CommandMenuProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }
-
-const buildingPackageOrder = [
-  'bigpicture', 'monorepo', 'npm-vs-pnpm',
-  'build', 'tsconfig', 'deps', 'dist',
-  'packagejson', 'typescript', 'versioning', 'workflow',
-]
-
-const ciOrder = [
-  'ci-overview', 'ci-linting', 'ci-build', 'ci-testing', 'ci-repo-maintenance',
-]
-
-const bonusOrder = ['storybook']
-
-const resourceIds = ['checklist']
-
-const topLevelResourceIds = ['external-resources', 'glossary']
-
-const archStackOrder = [
-  'arch-stack-mern', 'arch-stack-pfrn', 'arch-stack-mean',
-  'arch-stack-lamp', 'arch-stack-django', 'arch-stack-rails',
-]
-
-const promptMistakesOrder = [
-  'prompt-mistakes-logic', 'prompt-mistakes-apis', 'prompt-mistakes-structural', 'prompt-mistakes-style',
-]
-
-const promptCtxOrder = [
-  'prompt-ctx-system-prompt', 'prompt-ctx-claude-md', 'prompt-ctx-chaining',
-  'prompt-ctx-few-shot', 'prompt-ctx-window', 'prompt-ctx-thinking',
-]
-
-const archFrameworkOrder = [
-  'arch-fw-nextjs', 'arch-fw-react-router', 'arch-fw-tanstack-start', 'arch-fw-remix',
-]
-
-const testingFundamentals = ['test-overview', 'test-unit', 'test-component', 'test-e2e']
-const testingPractices = ['test-comparison', 'test-best-practices']
-const testingTooling = ['test-review-checklist', 'test-tools']
 
 function PageItem({ id, onSelect }: { id: string; onSelect: (id: string) => void }) {
   const title = getNavTitle(id)
@@ -93,106 +56,22 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
           All Guides
         </Command.Item>
 
-        <Command.Group heading="NPM Package Guide">
-          <PageItem id="roadmap" onSelect={handleSelect} />
-        </Command.Group>
-
-        <Command.Group heading="NPM Package Guide \u203A Building a Package">
-          {buildingPackageOrder.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="NPM Package Guide \u203A CI Pipeline & Checks">
-          {ciOrder.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="NPM Package Guide \u203A Developer Experience">
-          {bonusOrder.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="NPM Package Guide \u203A Learning Resources">
-          {resourceIds.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="Architecture Guide">
-          <PageItem id="arch-start" onSelect={handleSelect} />
-          <PageItem id="arch-what-is-a-stack" onSelect={handleSelect} />
-        </Command.Group>
-
-        <Command.Group heading="Architecture Guide \u203A Stack Alternatives">
-          {archStackOrder.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="Architecture Guide \u203A Full-Stack Frameworks">
-          <PageItem id="arch-frameworks-intro" onSelect={handleSelect} />
-          {archFrameworkOrder.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="Architecture Guide \u203A Putting It Together">
-          <PageItem id="arch-how-it-connects" onSelect={handleSelect} />
-        </Command.Group>
-
-        <Command.Group heading="Testing Guide">
-          <PageItem id="test-start" onSelect={handleSelect} />
-        </Command.Group>
-
-        <Command.Group heading="Testing Guide \u203A Testing Fundamentals">
-          {testingFundamentals.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="Testing Guide \u203A Comparing Tests">
-          {testingPractices.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="Testing Guide \u203A Checklists & Tools">
-          {testingTooling.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-        </Command.Group>
-
-        <Command.Group heading="Prompt Engineering">
-          <PageItem id="prompt-start" onSelect={handleSelect} />
-        </Command.Group>
-
-        <Command.Group heading="Prompt Engineering \u203A Common AI Mistakes">
-          {promptMistakesOrder.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-          <PageItem id="prompt-testing" onSelect={handleSelect} />
-        </Command.Group>
-
-        <Command.Group heading="Prompt Engineering \u203A Context Management">
-          {promptCtxOrder.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
-          <PageItem id="prompt-claudemd-checklist" onSelect={handleSelect} />
-        </Command.Group>
-
-        <Command.Group heading="Prompt Engineering \u203A Tooling & Reference">
-          <PageItem id="prompt-cli-reference" onSelect={handleSelect} />
-          <PageItem id="prompt-tools-advanced" onSelect={handleSelect} />
-          <PageItem id="prompt-meta-tooling" onSelect={handleSelect} />
-        </Command.Group>
+        {guides.map(guide =>
+          guide.sections.map((section, sIdx) => (
+            <Command.Group
+              key={`${guide.id}-${sIdx}`}
+              heading={section.label ? `${guide.title} \u203A ${section.label}` : guide.title}
+            >
+              {section.ids.map(id => (
+                <PageItem key={id} id={id} onSelect={handleSelect} />
+              ))}
+            </Command.Group>
+          ))
+        )}
 
         <Command.Group heading="Resources">
-          {topLevelResourceIds.map(id => (
-            <PageItem key={id} id={id} onSelect={handleSelect} />
-          ))}
+          <PageItem id="external-resources" onSelect={handleSelect} />
+          <PageItem id="glossary" onSelect={handleSelect} />
         </Command.Group>
       </Command.List>
     </Command.Dialog>

--- a/src/components/GuidesIndexPage.tsx
+++ b/src/components/GuidesIndexPage.tsx
@@ -1,12 +1,5 @@
 import { useNavigate } from '@tanstack/react-router'
-
-interface GuideTile {
-  id: string
-  sectionId: string
-  icon: string
-  title: string
-  description: string
-}
+import { guides } from '../data/guideRegistry'
 
 interface ResourceTile {
   sectionId: string
@@ -29,41 +22,6 @@ const resources: ResourceTile[] = [
     title: 'Glossary',
     description:
       'Key terms you\'ll encounter across all guides, with links to relevant sections and external documentation.',
-  },
-]
-
-const guides: GuideTile[] = [
-  {
-    id: 'npm-package',
-    sectionId: 'roadmap',
-    icon: '\u{1F4E6}',
-    title: 'Web App vs. NPM Package',
-    description:
-      'Learn the differences between building a web app and an npm package, from project setup through CI/CD and publishing.',
-  },
-  {
-    id: 'architecture',
-    sectionId: 'arch-start',
-    icon: '\u{1F3D7}\uFE0F',
-    title: 'Architecture Guide',
-    description:
-      'Understand common frontend architecture patterns and how to structure your projects for maintainability and scale.',
-  },
-  {
-    id: 'testing',
-    sectionId: 'test-start',
-    icon: '\u{1F9EA}',
-    title: 'Testing Guide',
-    description:
-      'Learn frontend testing fundamentals \u2014 the testing pyramid, best practices, and how to choose the right tools for unit, component, and E2E tests.',
-  },
-  {
-    id: 'prompt-engineering',
-    sectionId: 'prompt-start',
-    icon: '\u{1F9E0}',
-    title: 'Prompt Engineering',
-    description:
-      'Practical patterns for working with AI coding assistants \u2014 common mistakes to watch for, context management techniques, and CLI commands.',
   },
 ]
 
@@ -90,7 +48,7 @@ export function GuidesIndexPage() {
             onClick={() =>
               navigate({
                 to: '/$sectionId',
-                params: { sectionId: guide.sectionId },
+                params: { sectionId: guide.startPageId },
               })
             }
           >

--- a/src/components/RoadmapPage.tsx
+++ b/src/components/RoadmapPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate } from '@tanstack/react-router'
 import { roadmapSteps } from '../data/roadmapSteps'
 import { contentPages } from '../content/registry'
-import { findNavItem } from '../helpers/findNavItem'
+import { getNavTitle } from '../data/navigation'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
 import { PrevNextNav } from './PrevNextNav'
 
@@ -99,9 +99,7 @@ export function RoadmapPage() {
               <div className="step-detail text-xs text-gray-400 dark:text-slate-400 leading-relaxed bg-slate-50 dark:bg-slate-800 rounded-lg py-2.5 px-3.5 mb-2 border border-slate-100 dark:border-slate-700" dangerouslySetInnerHTML={{ __html: step.detail }} />
               {step.jumpTo && (
                 <JumpButton jumpTo={step.jumpTo}>
-                  {'\u2192'} Deep dive: {step.jumpTo === 'checklist'
-                    ? '\u2705 Publish Checklist'
-                    : (findNavItem(step.jumpTo)?.title ?? step.jumpTo)}
+                  {'\u2192'} Deep dive: {getNavTitle(step.jumpTo)}
                 </JumpButton>
               )}
               {step.substep && (
@@ -109,7 +107,7 @@ export function RoadmapPage() {
                   <h3 className="text-sm font-bold text-slate-900 dark:text-slate-100 m-0 mb-0.5">{step.substep.title}</h3>
                   <div className="text-sm text-slate-800 dark:text-slate-300 leading-relaxed">{step.substep.text}</div>
                   <JumpButton jumpTo={step.substep.jumpTo} style={{ marginTop: 4 }}>
-                    {'\u2192'} Deep dive: {findNavItem(step.substep.jumpTo)?.title ?? step.substep.jumpTo}
+                    {'\u2192'} Deep dive: {getNavTitle(step.substep.jumpTo)}
                   </JumpButton>
                 </div>
               )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react'
 import { useParams, Link } from '@tanstack/react-router'
 import clsx from 'clsx'
-import { contentPages } from '../content/registry'
+import { guides, getGuideForPage, type GuideDefinition } from '../data/guideRegistry'
+import { getNavTitle } from '../data/navigation'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
 import { OptionsDropdown } from './OptionsDropdown'
 
@@ -12,135 +13,13 @@ interface SidebarProps {
   onTogglePin: () => void
 }
 
-// ── Guide data structure ──────────────────────────────────────────────
-
-interface GuideSection { label: string | null; ids: string[] }
-interface GuideDefinition { id: string; icon: string; title: string; sections: GuideSection[] }
-
-const buildingPackageOrder = [
-  'bigpicture', 'monorepo', 'npm-vs-pnpm',
-  'build', 'tsconfig', 'deps', 'dist',
-  'packagejson', 'typescript', 'versioning', 'workflow',
-]
-
-const ciOrder = [
-  'ci-overview', 'ci-linting', 'ci-build', 'ci-testing', 'ci-repo-maintenance',
-]
-
-const bonusOrder = ['storybook']
-
-const archStackOrder = [
-  'arch-stack-mern', 'arch-stack-pfrn', 'arch-stack-mean',
-  'arch-stack-lamp', 'arch-stack-django', 'arch-stack-rails',
-]
-
-const archFrameworkOrder = [
-  'arch-fw-nextjs', 'arch-fw-react-router', 'arch-fw-tanstack-start', 'arch-fw-remix',
-]
-
-const testingFundamentals = [
-  'test-overview', 'test-unit', 'test-component', 'test-e2e',
-]
-
-const testingPractices = [
-  'test-comparison', 'test-best-practices',
-]
-
-const testingTools = [
-  'test-review-checklist', 'test-tools',
-]
-
-const promptMistakesOrder = [
-  'prompt-mistakes-logic', 'prompt-mistakes-apis', 'prompt-mistakes-structural', 'prompt-mistakes-style',
-]
-
-const promptCtxOrder = [
-  'prompt-ctx-system-prompt', 'prompt-ctx-claude-md', 'prompt-ctx-chaining',
-  'prompt-ctx-few-shot', 'prompt-ctx-window', 'prompt-ctx-thinking',
-]
-
-const guides: GuideDefinition[] = [
-  {
-    id: 'npm-package',
-    icon: '\u{1F4E6}',        // 📦
-    title: 'Web App vs. NPM Package',
-    sections: [
-      { label: null, ids: ['roadmap'] },
-      { label: 'Building a Package', ids: buildingPackageOrder },
-      { label: 'CI Pipeline & Checks', ids: ciOrder },
-      { label: 'Developer Experience', ids: bonusOrder },
-      { label: 'Learning Resources', ids: ['checklist'] },
-    ],
-  },
-  {
-    id: 'architecture',
-    icon: '\u{1F3D7}\uFE0F',  // 🏗️
-    title: 'Architecture Guide',
-    sections: [
-      { label: null, ids: ['arch-start', 'arch-what-is-a-stack'] },
-      { label: 'Stack Alternatives', ids: archStackOrder },
-      { label: 'Full-Stack Frameworks', ids: ['arch-frameworks-intro', ...archFrameworkOrder] },
-      { label: 'Putting It Together', ids: ['arch-how-it-connects'] },
-    ],
-  },
-  {
-    id: 'testing',
-    icon: '\u{1F9EA}',        // 🧪
-    title: 'Testing Guide',
-    sections: [
-      { label: null, ids: ['test-start'] },
-      { label: 'Testing Fundamentals', ids: testingFundamentals },
-      { label: 'Comparing Tests', ids: testingPractices },
-      { label: 'Checklists & Tools', ids: testingTools },
-    ],
-  },
-  {
-    id: 'prompt-engineering',
-    icon: '\u{1F9E0}',        // 🧠
-    title: 'Prompt Engineering',
-    sections: [
-      { label: null, ids: ['prompt-start'] },
-      { label: 'Common AI Mistakes', ids: [...promptMistakesOrder, 'prompt-testing'] },
-      { label: 'Context Management', ids: [...promptCtxOrder, 'prompt-claudemd-checklist'] },
-      { label: 'Tooling & Reference', ids: ['prompt-cli-reference', 'prompt-tools-advanced', 'prompt-meta-tooling'] },
-    ],
-  },
-]
-
-const allGuidePageIds = new Map<string, string>()
-for (const guide of guides) {
-  for (const section of guide.sections) {
-    for (const id of section.ids) {
-      allGuidePageIds.set(id, guide.id)
-    }
-  }
-}
-// Legacy route: #/architecture renders ArchStartPage
-allGuidePageIds.set('architecture', 'architecture')
-
-function findGuideForPage(pageId: string): GuideDefinition | undefined {
-  const guideId = allGuidePageIds.get(pageId)
-  return guideId ? guides.find(g => g.id === guideId) : undefined
-}
-
-// ── Title resolution (special pages aren't in contentPages) ───────────
-
-const titleOverrides: Record<string, string> = {
-  'roadmap': 'Start Here \u{1F680}',
-  'arch-start': 'Start Here \u{1F3D7}\uFE0F',
-  'test-start': 'Start Here \u{1F9EA}',
-  'prompt-start': 'Start Here \u{1F9E0}',
-  'checklist': 'Publish Checklist \u2705',
-  'external-resources': 'External Resources \u{1F4DA}',
-  'glossary': 'Glossary \u{1F4D6}',
-}
+// ── Title resolution ────────────────────────────────────────────────
 
 function resolveItems(ids: string[]) {
   return ids
     .map(id => {
-      if (titleOverrides[id]) return { id, title: titleOverrides[id] }
-      const page = contentPages.get(id)
-      return page ? { id: page.id, title: page.title } : null
+      const title = getNavTitle(id)
+      return title !== id ? { id, title } : null
     })
     .filter((item): item is { id: string; title: string } => item !== null)
 }
@@ -364,7 +243,7 @@ export function Sidebar({ open, onClose, pinned, onTogglePin }: SidebarProps) {
   const currentId = params.sectionId || ''
 
   const [activeGuideId, setActiveGuideId] = useState<string | null>(() => {
-    return findGuideForPage(currentId)?.id ?? null
+    return getGuideForPage(currentId)?.id ?? null
   })
 
   // Re-sync active guide when sidebar transitions from closed to open
@@ -372,7 +251,7 @@ export function Sidebar({ open, onClose, pinned, onTogglePin }: SidebarProps) {
   if (open !== prevOpen) {
     setPrevOpen(open)
     if (open) {
-      const expected = findGuideForPage(currentId)?.id ?? null
+      const expected = getGuideForPage(currentId)?.id ?? null
       if (expected !== activeGuideId) {
         setActiveGuideId(expected)
       }

--- a/src/content/architecture/arch-frameworks-intro.mdx
+++ b/src/content/architecture/arch-frameworks-intro.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-frameworks-intro"
 title: "Full-Stack Frameworks 🏠"
+guide: "architecture"
 usedFootnotes: [2]
 links:
   - label: "React documentation"

--- a/src/content/architecture/arch-fw-nextjs.mdx
+++ b/src/content/architecture/arch-fw-nextjs.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-fw-nextjs"
 title: "Next.js ▲"
+guide: "architecture"
 usedFootnotes: [1, 2]
 links:
   - label: "Next.js documentation"

--- a/src/content/architecture/arch-fw-react-router.mdx
+++ b/src/content/architecture/arch-fw-react-router.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-fw-react-router"
 title: "React Router Framework 🔀"
+guide: "architecture"
 usedFootnotes: [1, 2]
 links:
   - label: "React Router documentation"

--- a/src/content/architecture/arch-fw-remix.mdx
+++ b/src/content/architecture/arch-fw-remix.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-fw-remix"
 title: "Remix 💿"
+guide: "architecture"
 usedFootnotes: [1, 2]
 links:
   - label: "React Router v7 documentation"

--- a/src/content/architecture/arch-fw-tanstack-start.mdx
+++ b/src/content/architecture/arch-fw-tanstack-start.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-fw-tanstack-start"
 title: "TanStack Start 🔥"
+guide: "architecture"
 usedFootnotes: [1, 2]
 links:
   - label: "TanStack Start documentation"

--- a/src/content/architecture/arch-how-it-connects.mdx
+++ b/src/content/architecture/arch-how-it-connects.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-how-it-connects"
 title: "How it all Connects 🔄"
+guide: "architecture"
 usedFootnotes: [1]
 links:
   - label: "MDN — An overview of HTTP"

--- a/src/content/architecture/arch-stack-django.mdx
+++ b/src/content/architecture/arch-stack-django.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-stack-django"
 title: "Django Stack 🐍"
+guide: "architecture"
 usedFootnotes: [1]
 links:
   - label: "Django documentation"

--- a/src/content/architecture/arch-stack-lamp.mdx
+++ b/src/content/architecture/arch-stack-lamp.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-stack-lamp"
 title: "LAMP Stack 💡"
+guide: "architecture"
 usedFootnotes: [4]
 links:
   - label: "PHP documentation"

--- a/src/content/architecture/arch-stack-mean.mdx
+++ b/src/content/architecture/arch-stack-mean.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-stack-mean"
 title: "MEAN Stack 🔷"
+guide: "architecture"
 usedFootnotes: [1]
 links:
   - label: "Angular documentation"

--- a/src/content/architecture/arch-stack-mern.mdx
+++ b/src/content/architecture/arch-stack-mern.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-stack-mern"
 title: "MERN Stack 🔗"
+guide: "architecture"
 usedFootnotes: [1, 2]
 links:
   - label: "MongoDB documentation"

--- a/src/content/architecture/arch-stack-pfrn.mdx
+++ b/src/content/architecture/arch-stack-pfrn.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-stack-pfrn"
 title: "PFRN Stack (This Guide) ⚡"
+guide: "architecture"
 usedFootnotes: [1, 3]
 links:
   - label: "PostgreSQL documentation"

--- a/src/content/architecture/arch-stack-rails.mdx
+++ b/src/content/architecture/arch-stack-rails.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-stack-rails"
 title: "Rails Stack 🛤️"
+guide: "architecture"
 usedFootnotes: [1, 2]
 links:
   - label: "Ruby on Rails guides"

--- a/src/content/architecture/arch-what-is-a-stack.mdx
+++ b/src/content/architecture/arch-what-is-a-stack.mdx
@@ -1,6 +1,7 @@
 ---
 id: "arch-what-is-a-stack"
 title: "What is a Stack? 📚"
+guide: "architecture"
 usedFootnotes: [1, 2]
 links:
   - label: "How the web works"

--- a/src/content/bonus/storybook.mdx
+++ b/src/content/bonus/storybook.mdx
@@ -1,6 +1,7 @@
 ---
 id: "storybook"
 title: "Storybook 📖"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3, 4]
 links:
   - label: "Storybook — Getting Started"

--- a/src/content/ci/ci-build.mdx
+++ b/src/content/ci/ci-build.mdx
@@ -1,6 +1,7 @@
 ---
 id: "ci-build"
 title: "Build Verification 🔨"
+guide: "npm-package"
 links: []
 ---
 

--- a/src/content/ci/ci-linting.mdx
+++ b/src/content/ci/ci-linting.mdx
@@ -1,6 +1,7 @@
 ---
 id: "ci-linting"
 title: "Linting & Formatting 🧹"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3, 4, 5]
 links:
   - label: "ESLint — Getting Started"

--- a/src/content/ci/ci-overview.mdx
+++ b/src/content/ci/ci-overview.mdx
@@ -1,6 +1,7 @@
 ---
 id: "ci-overview"
 title: "CI Overview 🔄"
+guide: "npm-package"
 usedFootnotes: [1, 2]
 links:
   - label: "GitHub Actions — Quickstart"

--- a/src/content/ci/ci-repo-maintenance.mdx
+++ b/src/content/ci/ci-repo-maintenance.mdx
@@ -1,6 +1,7 @@
 ---
 id: "ci-repo-maintenance"
 title: "Repo Maintenance 🧹"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3]
 links:
   - label: "knip — Find unused files, dependencies and exports"

--- a/src/content/ci/ci-testing.mdx
+++ b/src/content/ci/ci-testing.mdx
@@ -1,6 +1,7 @@
 ---
 id: "ci-testing"
 title: "Testing 🧪"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3, 4, 5]
 links:
   - label: "Vitest — Getting Started"

--- a/src/content/prompt-engineering/prompt-claudemd-checklist.mdx
+++ b/src/content/prompt-engineering/prompt-claudemd-checklist.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-claudemd-checklist"
 title: "CLAUDE.md Checklist ✅"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-cli-reference.mdx
+++ b/src/content/prompt-engineering/prompt-cli-reference.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-cli-reference"
 title: "CLI Quick Reference ⌨️"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-ctx-chaining.mdx
+++ b/src/content/prompt-engineering/prompt-ctx-chaining.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-ctx-chaining"
 title: "Prompt Chaining & Decomposition 🔗"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-ctx-claude-md.mdx
+++ b/src/content/prompt-engineering/prompt-ctx-claude-md.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-ctx-claude-md"
 title: "CLAUDE.md / Memory Files 📝"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-ctx-few-shot.mdx
+++ b/src/content/prompt-engineering/prompt-ctx-few-shot.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-ctx-few-shot"
 title: "Few-Shot Examples 🎯"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-ctx-system-prompt.mdx
+++ b/src/content/prompt-engineering/prompt-ctx-system-prompt.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-ctx-system-prompt"
 title: "System Prompt Architecture 📐"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-ctx-thinking.mdx
+++ b/src/content/prompt-engineering/prompt-ctx-thinking.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-ctx-thinking"
 title: "Thinking & Reflection 💭"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-ctx-window.mdx
+++ b/src/content/prompt-engineering/prompt-ctx-window.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-ctx-window"
 title: "Context Window Management 📊"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-meta-tooling.mdx
+++ b/src/content/prompt-engineering/prompt-meta-tooling.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-meta-tooling"
 title: "Meta-Tooling & Workflows 🏭"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-mistakes-apis.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-apis.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-mistakes-apis"
 title: "Hallucinated APIs & Packages 👻"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-mistakes-logic.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-logic.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-mistakes-logic"
 title: "Logic & Condition Errors ⚡"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-mistakes-structural.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-structural.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-mistakes-structural"
 title: "Structural & Architectural Issues 🏗️"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-mistakes-style.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-style.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-mistakes-style"
 title: "Style & Formatting Drift 🎨"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-testing.mdx
+++ b/src/content/prompt-engineering/prompt-testing.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-testing"
 title: "Testing Best Practices 🧪"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/prompt-engineering/prompt-tools-advanced.mdx
+++ b/src/content/prompt-engineering/prompt-tools-advanced.mdx
@@ -1,6 +1,7 @@
 ---
 id: "prompt-tools-advanced"
 title: "Advanced Tool Usage 🔧"
+guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/registry.ts
+++ b/src/content/registry.ts
@@ -4,6 +4,7 @@ import type { SectionLink } from '../helpers/renderFootnotes'
 export interface ContentPage {
   id: string
   title: string
+  guide?: string
   group?: string
   links?: SectionLink[]
   usedFootnotes?: number[]
@@ -24,6 +25,7 @@ for (const [, mod] of Object.entries(mdxModules)) {
   contentPages.set(id, {
     id,
     title: (fm.title as string) ?? id,
+    guide: fm.guide as string | undefined,
     group: fm.group as string | undefined,
     links: fm.links as SectionLink[] | undefined,
     usedFootnotes: fm.usedFootnotes as number[] | undefined,

--- a/src/content/sections/bigpicture.mdx
+++ b/src/content/sections/bigpicture.mdx
@@ -1,6 +1,7 @@
 ---
 id: "bigpicture"
 title: "Big Picture 🗺️"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3]
 links:
   - label: "What is npm?"

--- a/src/content/sections/build.mdx
+++ b/src/content/sections/build.mdx
@@ -1,6 +1,7 @@
 ---
 id: "build"
 title: "Build & Output ⚙️"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3, 4, 5, 6, 7]
 links:
   - label: "Vite — Getting Started"

--- a/src/content/sections/deps.mdx
+++ b/src/content/sections/deps.mdx
@@ -1,6 +1,7 @@
 ---
 id: "deps"
 title: "Dependencies 📦"
+guide: "npm-package"
 usedFootnotes: [1, 2]
 links:
   - label: "package.json dependencies"

--- a/src/content/sections/dist.mdx
+++ b/src/content/sections/dist.mdx
@@ -1,6 +1,7 @@
 ---
 id: "dist"
 title: "Folder Structure 📁"
+guide: "npm-package"
 group: "concepts"
 usedFootnotes: [1, 2, 3]
 links:

--- a/src/content/sections/monorepo.mdx
+++ b/src/content/sections/monorepo.mdx
@@ -1,6 +1,7 @@
 ---
 id: "monorepo"
 title: "Monorepo vs Monolith 🏗️"
+guide: "npm-package"
 group: "concepts"
 usedFootnotes: [1, 2, 3, 4, 5, 6]
 links:

--- a/src/content/sections/npm-vs-pnpm.mdx
+++ b/src/content/sections/npm-vs-pnpm.mdx
@@ -1,6 +1,7 @@
 ---
 id: "npm-vs-pnpm"
 title: "npm vs pnpm 📦"
+guide: "npm-package"
 group: "concepts"
 usedFootnotes: [1, 2, 3, 4, 5, 6]
 links:

--- a/src/content/sections/packagejson.mdx
+++ b/src/content/sections/packagejson.mdx
@@ -1,6 +1,7 @@
 ---
 id: "packagejson"
 title: "package.json 📋"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3, 4]
 links:
   - label: "package.json full reference"

--- a/src/content/sections/tsconfig.mdx
+++ b/src/content/sections/tsconfig.mdx
@@ -1,6 +1,7 @@
 ---
 id: "tsconfig"
 title: "tsconfig.json ⚙️"
+guide: "npm-package"
 group: "concepts"
 usedFootnotes: [1, 3, 4]
 links:

--- a/src/content/sections/typescript.mdx
+++ b/src/content/sections/typescript.mdx
@@ -1,6 +1,7 @@
 ---
 id: "typescript"
 title: "TypeScript & Types 🔷"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3, 4, 5]
 links:
   - label: "TypeScript declaration files"

--- a/src/content/sections/versioning.mdx
+++ b/src/content/sections/versioning.mdx
@@ -1,6 +1,7 @@
 ---
 id: "versioning"
 title: "Versioning 🏷️"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3, 4, 5, 6]
 links:
   - label: "Semantic Versioning spec"

--- a/src/content/sections/workflow.mdx
+++ b/src/content/sections/workflow.mdx
@@ -1,6 +1,7 @@
 ---
 id: "workflow"
 title: "Dev Workflow 🔄"
+guide: "npm-package"
 usedFootnotes: [1, 2, 3, 4, 5, 6]
 links:
   - label: "npm link docs"

--- a/src/content/testing/test-best-practices.mdx
+++ b/src/content/testing/test-best-practices.mdx
@@ -1,6 +1,7 @@
 ---
 id: "test-best-practices"
 title: "Best Practices ✅"
+guide: "testing"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/testing/test-comparison.mdx
+++ b/src/content/testing/test-comparison.mdx
@@ -1,6 +1,7 @@
 ---
 id: "test-comparison"
 title: "At a Glance 📊"
+guide: "testing"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/testing/test-component.mdx
+++ b/src/content/testing/test-component.mdx
@@ -1,6 +1,7 @@
 ---
 id: "test-component"
 title: "Component Testing 🧱"
+guide: "testing"
 links:
   - label: "React Testing Library"
     url: "https://testing-library.com/docs/react-testing-library/intro/"

--- a/src/content/testing/test-e2e.mdx
+++ b/src/content/testing/test-e2e.mdx
@@ -1,6 +1,7 @@
 ---
 id: "test-e2e"
 title: "E2E Testing 🌐"
+guide: "testing"
 links:
   - label: "Playwright documentation"
     url: "https://playwright.dev"

--- a/src/content/testing/test-overview.mdx
+++ b/src/content/testing/test-overview.mdx
@@ -1,6 +1,7 @@
 ---
 id: "test-overview"
 title: "Testing Pyramid 🔺"
+guide: "testing"
 links:
   - label: "The Practical Test Pyramid"
     url: "https://martinfowler.com/articles/practical-test-pyramid.html"

--- a/src/content/testing/test-review-checklist.mdx
+++ b/src/content/testing/test-review-checklist.mdx
@@ -1,6 +1,7 @@
 ---
 id: "test-review-checklist"
 title: "Quick Test Review 📋"
+guide: "testing"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/testing/test-tools.mdx
+++ b/src/content/testing/test-tools.mdx
@@ -1,6 +1,7 @@
 ---
 id: "test-tools"
 title: "Popular Tools 🧰"
+guide: "testing"
 links:
   - label: "Vitest"
     url: "https://vitest.dev"

--- a/src/content/testing/test-unit.mdx
+++ b/src/content/testing/test-unit.mdx
@@ -1,6 +1,7 @@
 ---
 id: "test-unit"
 title: "Unit Testing 🧩"
+guide: "testing"
 links:
   - label: "Vitest documentation"
     url: "https://vitest.dev"

--- a/src/data/archData.ts
+++ b/src/data/archData.ts
@@ -878,21 +878,20 @@ export const FRAMEWORK_PAGES: FrameworkPageData[] = [
 
 /* ───────────────────────── NAVIGATION ───────────────────────── */
 
-export const ARCH_NAV_ORDER = [
-  "arch-start",
-  "arch-what-is-a-stack",
-  "arch-stack-mern",
-  "arch-stack-pfrn",
-  "arch-stack-mean",
-  "arch-stack-lamp",
-  "arch-stack-django",
-  "arch-stack-rails",
-  "arch-frameworks-intro",
-  "arch-fw-nextjs",
-  "arch-fw-react-router",
-  "arch-fw-tanstack-start",
-  "arch-fw-remix",
-  "arch-how-it-connects",
+import type { GuideSection } from './guideTypes'
+
+export const ARCH_GUIDE_SECTIONS: GuideSection[] = [
+  { label: null, ids: ['arch-start', 'arch-what-is-a-stack'] },
+  { label: 'Stack Alternatives', ids: [
+    'arch-stack-mern', 'arch-stack-pfrn', 'arch-stack-mean',
+    'arch-stack-lamp', 'arch-stack-django', 'arch-stack-rails',
+  ]},
+  { label: 'Full-Stack Frameworks', ids: [
+    'arch-frameworks-intro', 'arch-fw-nextjs', 'arch-fw-react-router',
+    'arch-fw-tanstack-start', 'arch-fw-remix',
+  ]},
+  { label: 'Putting It Together', ids: ['arch-how-it-connects'] },
 ]
 
+export const ARCH_NAV_ORDER = ARCH_GUIDE_SECTIONS.flatMap(s => s.ids)
 export const ARCH_PAGE_IDS = new Set(ARCH_NAV_ORDER)

--- a/src/data/guideRegistry.ts
+++ b/src/data/guideRegistry.ts
@@ -1,0 +1,87 @@
+import type { GuideSection, GuideDefinition } from './guideTypes'
+import { ARCH_GUIDE_SECTIONS } from './archData'
+import { TESTING_GUIDE_SECTIONS } from './testingData'
+import { PROMPT_GUIDE_SECTIONS } from './promptData'
+
+export type { GuideSection, GuideDefinition }
+
+// ── NPM Package Guide sections (no separate data file needed) ────────
+
+const NPM_GUIDE_SECTIONS: GuideSection[] = [
+  { label: null, ids: ['roadmap'] },
+  { label: 'Building a Package', ids: [
+    'bigpicture', 'monorepo', 'npm-vs-pnpm',
+    'build', 'tsconfig', 'deps', 'dist',
+    'packagejson', 'typescript', 'versioning', 'workflow',
+  ]},
+  { label: 'CI Pipeline & Checks', ids: [
+    'ci-overview', 'ci-linting', 'ci-build', 'ci-testing', 'ci-repo-maintenance',
+  ]},
+  { label: 'Developer Experience', ids: ['storybook'] },
+  { label: 'Learning Resources', ids: ['checklist'] },
+]
+
+// ── All guides ───────────────────────────────────────────────────────
+
+export const guides: GuideDefinition[] = [
+  {
+    id: 'npm-package',
+    icon: '\u{1F4E6}',        // 📦
+    title: 'Web App vs. NPM Package',
+    startPageId: 'roadmap',
+    description:
+      'Learn the differences between building a web app and an npm package, from project setup through CI/CD and publishing.',
+    sections: NPM_GUIDE_SECTIONS,
+  },
+  {
+    id: 'architecture',
+    icon: '\u{1F3D7}\uFE0F',  // 🏗️
+    title: 'Architecture Guide',
+    startPageId: 'arch-start',
+    description:
+      'Understand common frontend architecture patterns and how to structure your projects for maintainability and scale.',
+    sections: ARCH_GUIDE_SECTIONS,
+  },
+  {
+    id: 'testing',
+    icon: '\u{1F9EA}',        // 🧪
+    title: 'Testing Guide',
+    startPageId: 'test-start',
+    description:
+      'Learn frontend testing fundamentals \u2014 the testing pyramid, best practices, and how to choose the right tools for unit, component, and E2E tests.',
+    sections: TESTING_GUIDE_SECTIONS,
+  },
+  {
+    id: 'prompt-engineering',
+    icon: '\u{1F9E0}',        // 🧠
+    title: 'Prompt Engineering',
+    startPageId: 'prompt-start',
+    description:
+      'Practical patterns for working with AI coding assistants \u2014 common mistakes to watch for, context management techniques, and CLI commands.',
+    sections: PROMPT_GUIDE_SECTIONS,
+  },
+]
+
+// ── Derived lookups ─────────────────────────────────────────────────
+
+const pageToGuide = new Map<string, string>()
+for (const guide of guides) {
+  for (const section of guide.sections) {
+    for (const id of section.ids) {
+      pageToGuide.set(id, guide.id)
+    }
+  }
+}
+// Legacy route: #/architecture renders ArchStartPage
+pageToGuide.set('architecture', 'architecture')
+
+export function getGuideForPage(pageId: string): GuideDefinition | undefined {
+  const guideId = pageToGuide.get(pageId)
+  return guideId ? guides.find(g => g.id === guideId) : undefined
+}
+
+export function getNavOrderForPage(pageId: string): string[] {
+  const guide = getGuideForPage(pageId)
+  if (!guide) return []
+  return guide.sections.flatMap(s => s.ids)
+}

--- a/src/data/guideTypes.ts
+++ b/src/data/guideTypes.ts
@@ -1,0 +1,13 @@
+export interface GuideSection {
+  label: string | null
+  ids: string[]
+}
+
+export interface GuideDefinition {
+  id: string
+  icon: string
+  title: string
+  startPageId: string
+  description: string
+  sections: GuideSection[]
+}

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,86 +1,26 @@
-import { findNavItem } from '../helpers/findNavItem'
-import { ARCH_NAV_ORDER, ARCH_PAGE_IDS } from './archData'
-import { TESTING_NAV_ORDER, TESTING_PAGE_IDS } from './testingData'
-import { PROMPT_NAV_ORDER, PROMPT_PAGE_IDS } from './promptData'
+import { contentPages } from '../content/registry'
+import { getNavOrderForPage } from './guideRegistry'
 
-const ciPageIds = [
-  'ci-overview', 'ci-linting', 'ci-build', 'ci-testing', 'ci-repo-maintenance',
-]
-
-const bonusIds = ['storybook']
-
-const npmNavOrder = [
-  "roadmap",
-  "bigpicture", "monorepo", "npm-vs-pnpm",
-  "build", "tsconfig", "deps", "dist",
-  "packagejson", "typescript", "versioning", "workflow",
-  ...ciPageIds,
-  ...bonusIds,
-  "checklist",
-]
-
-export function getNavOrder(currentId?: string): string[] {
-  if (currentId && ARCH_PAGE_IDS.has(currentId)) {
-    return [...ARCH_NAV_ORDER]
-  }
-  if (currentId && TESTING_PAGE_IDS.has(currentId)) {
-    return [...TESTING_NAV_ORDER]
-  }
-  if (currentId && PROMPT_PAGE_IDS.has(currentId)) {
-    return [...PROMPT_NAV_ORDER]
-  }
-  // Order matches the Start Page roadmap steps and sidebar sections
-  return [...npmNavOrder]
+// Title overrides for non-MDX pages (component-rendered start pages, resource pages)
+const staticTitles: Record<string, string> = {
+  'roadmap': 'Start Here \u{1F680}',
+  'checklist': 'Publish Checklist \u2705',
+  'external-resources': 'External Resources \u{1F4DA}',
+  'glossary': 'Glossary \u{1F4D6}',
+  'architecture': 'Architecture Guide \u{1F3D7}\uFE0F',
+  'arch-start': 'Start Here \u{1F3D7}\uFE0F',
+  'test-start': 'Start Here \u{1F9EA}',
+  'prompt-start': 'Start Here \u{1F9E0}',
 }
 
-const staticTitles: Record<string, string> = {
-  roadmap: "Start Here \u{1F680}",
-  checklist: "Publish Checklist \u2705",
-  "external-resources": "External Resources \u{1F4DA}",
-  glossary: "Glossary \u{1F4D6}",
-  architecture: "Architecture Guide \u{1F3D7}\uFE0F",
-  "arch-start": "Start Here \u{1F3D7}\uFE0F",
-  "arch-what-is-a-stack": "What is a Stack? \u{1F4DA}",
-  "arch-stack-mern": "MERN Stack \u{1F517}",
-  "arch-stack-pfrn": "PFRN Stack \u26A1",
-  "arch-stack-mean": "MEAN Stack \u{1F537}",
-  "arch-stack-lamp": "LAMP Stack \u{1F4A1}",
-  "arch-stack-django": "Django Stack \u{1F40D}",
-  "arch-stack-rails": "Rails Stack \u{1F6E4}\uFE0F",
-  "arch-frameworks-intro": "Full-Stack Frameworks \u{1F3E0}",
-  "arch-fw-nextjs": "Next.js \u25B2",
-  "arch-fw-react-router": "React Router Framework \u{1F500}",
-  "arch-fw-tanstack-start": "TanStack Start \u{1F525}",
-  "arch-fw-remix": "Remix \u{1F4BF}",
-  "arch-how-it-connects": "How it all Connects \u{1F504}",
-  "test-start": "Start Here \u{1F9EA}",
-  "test-overview": "Testing Pyramid \u{1F53A}",
-  "test-unit": "Unit Testing \u{1F9E9}",
-  "test-component": "Component Testing \u{1F9F1}",
-  "test-e2e": "E2E Testing \u{1F310}",
-  "test-comparison": "At a Glance \u{1F4CA}",
-  "test-best-practices": "Best Practices \u2705",
-  "test-review-checklist": "Quick Test Review \u{1F4CB}",
-  "test-tools": "Popular Tools \u{1F9F0}",
-  "prompt-start": "Start Here \u{1F9E0}",
-  "prompt-mistakes-logic": "Logic & Condition Errors \u26A1",
-  "prompt-mistakes-apis": "Hallucinated APIs & Packages \u{1F47B}",
-  "prompt-mistakes-structural": "Structural & Architectural Issues \u{1F3D7}\uFE0F",
-  "prompt-mistakes-style": "Style & Formatting Drift \u{1F3A8}",
-  "prompt-ctx-system-prompt": "System Prompt Architecture \u{1F4D0}",
-  "prompt-ctx-claude-md": "CLAUDE.md / Memory Files \u{1F4DD}",
-  "prompt-ctx-chaining": "Prompt Chaining & Decomposition \u{1F517}",
-  "prompt-ctx-few-shot": "Few-Shot Examples \u{1F3AF}",
-  "prompt-ctx-window": "Context Window Management \u{1F4CA}",
-  "prompt-ctx-thinking": "Thinking & Reflection \u{1F4AD}",
-  "prompt-testing": "Testing Best Practices \u{1F9EA}",
-  "prompt-claudemd-checklist": "CLAUDE.md Checklist \u2705",
-  "prompt-cli-reference": "CLI Quick Reference \u2328\uFE0F",
-  "prompt-tools-advanced": "Advanced Tool Usage \u{1F527}",
-  "prompt-meta-tooling": "Meta-Tooling & Workflows \u{1F3ED}",
+export function getNavOrder(currentId?: string): string[] {
+  if (!currentId) return getNavOrderForPage('roadmap')
+  return getNavOrderForPage(currentId)
 }
 
 export function getNavTitle(id: string): string {
   if (staticTitles[id]) return staticTitles[id]
-  return findNavItem(id)?.title ?? id
+  const page = contentPages.get(id)
+  if (page) return page.title
+  return id
 }

--- a/src/data/promptData.ts
+++ b/src/data/promptData.ts
@@ -729,23 +729,23 @@ export const CLI_CATEGORIES: Record<string, string> = {
 
 // ── Navigation ───────────────────────────────────────────────────────
 
-export const PROMPT_NAV_ORDER: string[] = [
-  'prompt-start',
-  'prompt-mistakes-logic',
-  'prompt-mistakes-apis',
-  'prompt-mistakes-structural',
-  'prompt-mistakes-style',
-  'prompt-testing',
-  'prompt-ctx-system-prompt',
-  'prompt-ctx-claude-md',
-  'prompt-ctx-chaining',
-  'prompt-ctx-few-shot',
-  'prompt-ctx-window',
-  'prompt-ctx-thinking',
-  'prompt-claudemd-checklist',
-  'prompt-cli-reference',
-  'prompt-tools-advanced',
-  'prompt-meta-tooling',
+import type { GuideSection } from './guideTypes'
+
+export const PROMPT_GUIDE_SECTIONS: GuideSection[] = [
+  { label: null, ids: ['prompt-start'] },
+  { label: 'Common AI Mistakes', ids: [
+    'prompt-mistakes-logic', 'prompt-mistakes-apis', 'prompt-mistakes-structural',
+    'prompt-mistakes-style', 'prompt-testing',
+  ]},
+  { label: 'Context Management', ids: [
+    'prompt-ctx-system-prompt', 'prompt-ctx-claude-md', 'prompt-ctx-chaining',
+    'prompt-ctx-few-shot', 'prompt-ctx-window', 'prompt-ctx-thinking',
+    'prompt-claudemd-checklist',
+  ]},
+  { label: 'Tooling & Reference', ids: [
+    'prompt-cli-reference', 'prompt-tools-advanced', 'prompt-meta-tooling',
+  ]},
 ]
 
+export const PROMPT_NAV_ORDER: string[] = PROMPT_GUIDE_SECTIONS.flatMap(s => s.ids)
 export const PROMPT_PAGE_IDS = new Set(PROMPT_NAV_ORDER)

--- a/src/data/testingData.ts
+++ b/src/data/testingData.ts
@@ -344,16 +344,14 @@ export const TAG_COLORS: Record<TestType, { color: string; bg: string; darkBg: s
 
 /* ───────────────────────── NAVIGATION ───────────────────────── */
 
-export const TESTING_NAV_ORDER = [
-  'test-start',
-  'test-overview',
-  'test-unit',
-  'test-component',
-  'test-e2e',
-  'test-comparison',
-  'test-best-practices',
-  'test-review-checklist',
-  'test-tools',
+import type { GuideSection } from './guideTypes'
+
+export const TESTING_GUIDE_SECTIONS: GuideSection[] = [
+  { label: null, ids: ['test-start'] },
+  { label: 'Testing Fundamentals', ids: ['test-overview', 'test-unit', 'test-component', 'test-e2e'] },
+  { label: 'Comparing Tests', ids: ['test-comparison', 'test-best-practices'] },
+  { label: 'Checklists & Tools', ids: ['test-review-checklist', 'test-tools'] },
 ]
 
+export const TESTING_NAV_ORDER = TESTING_GUIDE_SECTIONS.flatMap(s => s.ids)
 export const TESTING_PAGE_IDS = new Set(TESTING_NAV_ORDER)

--- a/src/helpers/findNavItem.ts
+++ b/src/helpers/findNavItem.ts
@@ -1,7 +1,0 @@
-import { contentPages } from '../content/registry'
-
-export function findNavItem(id: string): { id: string; title: string } | undefined {
-  const page = contentPages.get(id)
-  if (page) return { id: page.id, title: page.title }
-  return undefined
-}


### PR DESCRIPTION
## Summary
Consolidates all guide metadata (sections, page ordering, navigation structure) into a single source of truth (`src/data/guideRegistry.ts`), eliminating duplication across Sidebar, CommandMenu, and navigation utilities. This makes it easier to add guides and maintain consistent navigation across the app.

## Key Changes

- **New centralized registry** (`src/data/guideRegistry.ts`):
  - Exports `guides` array with all guide definitions (id, icon, title, startPageId, description, sections)
  - Provides `getGuideForPage()` and `getNavOrderForPage()` helpers for consistent lookups
  - Imports `*_GUIDE_SECTIONS` from individual guide data files

- **New shared types** (`src/data/guideTypes.ts`):
  - `GuideSection` interface: `{ label: string | null, ids: string[] }`
  - `GuideDefinition` interface: guide metadata with sections array

- **Refactored guide data files** (`archData.ts`, `testingData.ts`, `promptData.ts`):
  - Changed from flat `*_NAV_ORDER` arrays to structured `*_GUIDE_SECTIONS` arrays with labeled sections
  - Derive `*_NAV_ORDER` from sections for backward compatibility
  - Sections now capture the sidebar grouping structure

- **Simplified components**:
  - `Sidebar.tsx`: Removed hardcoded guide definitions; now imports from `guideRegistry`
  - `CommandMenu.tsx`: Removed 40+ lines of hardcoded order arrays; now iterates `guides.sections` dynamically
  - `GuidesIndexPage.tsx`: Removed duplicate guide tiles; now maps from `guides` array

- **Updated navigation** (`src/data/navigation.ts`):
  - Simplified `getNavOrder()` to delegate to `getNavOrderForPage()` from registry
  - Consolidated title resolution in `getNavTitle()` using `contentPages` and `staticTitles`
  - Removed `findNavItem` helper (no longer needed)

- **Added guide metadata to MDX frontmatter**:
  - All content pages now include `guide: "guide-id"` field for explicit guide association
  - Enables future filtering and guide-specific features

## Implementation Details

- The `*_GUIDE_SECTIONS` structure mirrors the sidebar's visual grouping (sections with optional labels)
- Navigation order is automatically derived from section IDs, eliminating manual sync points
- `getGuideForPage()` uses a pre-built `pageToGuide` Map for O(1) lookups
- Legacy route `#/architecture` is explicitly mapped to the architecture guide
- Top-level resources (external-resources, glossary) remain outside guide navigation

https://claude.ai/code/session_01RY51g1ScpL2NGXFjWMEexf