### PR TITLE
Refactor TestPracticeCards to support combined do/dont view

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,7 +125,7 @@ body.pnpm .cmd-npm { display: none; }
   @apply max-h-80 overflow-y-auto p-2;
 }
 [cmdk-item] {
-  @apply flex items-center px-3 py-2 text-sm rounded-lg cursor-pointer text-slate-700 dark:text-slate-300 transition-colors duration-150;
+  @apply flex items-center justify-between px-3 py-2 text-sm rounded-lg cursor-pointer text-slate-700 dark:text-slate-300 transition-colors duration-150;
 }
 [cmdk-item][data-selected="true"] {
   @apply bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400;

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -17,8 +17,8 @@ function PageItem({ id, onSelect }: { id: string; onSelect: (id: string) => void
 
   return (
     <Command.Item value={title} keywords={[id]} onSelect={() => onSelect(id)}>
-      <span>{text}</span>
-      {icon && <span className="ml-2 text-base opacity-70">{icon}</span>}
+      <span className="flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap">{text}</span>
+      {icon && <span className="ml-2 text-base opacity-70 shrink-0">{icon}</span>}
     </Command.Item>
   )
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -42,7 +42,7 @@ function SidebarItem({ id, title, active, onClick }: { id: string; title: string
   return (
     <button
       className={clsx(
-        'flex items-center justify-between w-full text-left px-3.5 py-2 text-sm rounded-lg border-none bg-transparent cursor-pointer transition-all duration-150',
+        'flex items-center justify-between w-full text-left px-3.5 py-1.5 text-sm leading-snug rounded-lg border-none bg-transparent cursor-pointer transition-all duration-150',
         active
           ? 'bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 font-semibold'
           : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
@@ -180,7 +180,7 @@ function ContentPanel({
   return (
     <div className="flex-1 flex flex-col min-w-0">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 h-13 border-b border-slate-200 dark:border-slate-700 shrink-0">
+      <div className="flex items-center justify-between px-4 h-12 border-b border-slate-200 dark:border-slate-700 shrink-0">
         <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
           {guide ? guide.title : 'Navigation'}
         </span>

--- a/src/components/mdx/TestPracticeCards.tsx
+++ b/src/components/mdx/TestPracticeCards.tsx
@@ -1,11 +1,9 @@
 import { PRACTICE_CARDS } from '../../data/testingData'
+import type { PracticeCard } from '../../data/testingData'
 
-export function TestPracticeCards({ type }: { type: 'do' | 'dont' }) {
-  const cards = PRACTICE_CARDS.filter((c) => c.type === type)
-  const isDo = type === 'do'
-
+function CardGroup({ cards, isDo }: { cards: PracticeCard[]; isDo: boolean }) {
   return (
-    <div className="grid gap-3 mt-2 mb-4">
+    <div className="grid gap-3 mb-4">
       {cards.map((card, i) => (
         <div
           key={i}
@@ -26,6 +24,34 @@ export function TestPracticeCards({ type }: { type: 'do' | 'dont' }) {
           </p>
         </div>
       ))}
+    </div>
+  )
+}
+
+export function TestPracticeCards({ type }: { type?: 'do' | 'dont' }) {
+  if (type) {
+    const cards = PRACTICE_CARDS.filter((c) => c.type === type)
+    return (
+      <div className="mt-2">
+        <CardGroup cards={cards} isDo={type === 'do'} />
+      </div>
+    )
+  }
+
+  const doCards = PRACTICE_CARDS.filter((c) => c.type === 'do')
+  const dontCards = PRACTICE_CARDS.filter((c) => c.type === 'dont')
+
+  return (
+    <div>
+      <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100 mt-5 mb-2">
+        {'\u2705'} What to do
+      </h2>
+      <CardGroup cards={doCards} isDo={true} />
+
+      <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100 mt-5 mb-2">
+        {'\uD83D\uDEAB'} What to avoid
+      </h2>
+      <CardGroup cards={dontCards} isDo={false} />
     </div>
   )
 }

--- a/src/content/testing/test-best-practices.mdx
+++ b/src/content/testing/test-best-practices.mdx
@@ -6,19 +6,8 @@ guide: "testing"
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
-<Toc>
-  <TocLink id="toc-do">What to do</TocLink>
-  <TocLink id="toc-dont">What to avoid</TocLink>
-</Toc>
-
 <SectionIntro>
 These guidelines apply across all test types. Follow them to write tests that are **maintainable, reliable, and useful** &mdash; not just tests that exist for coverage numbers.
 </SectionIntro>
 
-<SectionSubheading id="toc-do">{'\u2705'} What to do</SectionSubheading>
-
-<TestPracticeCards type="do" />
-
-<SectionSubheading id="toc-dont">{'\uD83D\uDEAB'} What to avoid</SectionSubheading>
-
-<TestPracticeCards type="dont" />
+<TestPracticeCards />


### PR DESCRIPTION
## Summary
This PR refactors the `TestPracticeCards` component to support displaying both "do" and "dont" practice cards together in a single view, while maintaining backward compatibility with the filtered view. It also includes minor UI improvements to spacing and text overflow handling across several components.

## Key Changes

### TestPracticeCards Component
- Extracted card rendering logic into a new `CardGroup` sub-component for reusability
- Made the `type` prop optional to support a combined view mode
- When `type` is provided, displays filtered cards (existing behavior)
- When `type` is omitted, displays both "do" and "dont" cards with section headers
- Added proper TypeScript typing with `PracticeCard` import

### MDX Content
- Simplified `test-best-practices.mdx` by removing manual section headings and table of contents
- Replaced multiple `<TestPracticeCards type="do" />` and `<TestPracticeCards type="dont" />` calls with a single `<TestPracticeCards />` call
- The component now handles all layout and headers internally

### UI/Spacing Improvements
- **CommandMenu**: Added text truncation styles (`flex-1 min-w-0 overflow-hidden text-ellipsis whitespace-nowrap`) and `shrink-0` to icon to prevent overflow
- **Sidebar**: Adjusted padding from `py-2` to `py-1.5` and added `leading-snug` for tighter line height
- **ContentPanel**: Reduced header height from `h-13` to `h-12`
- **App.css**: Added `justify-between` to `[cmdk-item]` for proper spacing of command menu items

## Implementation Details
- The refactored component maintains backward compatibility - existing code using `type="do"` or `type="dont"` will continue to work
- The combined view wraps both card groups in a container with appropriate section headers using emoji indicators
- Removed `mt-2` from `CardGroup` and moved it to the wrapper in the filtered view to maintain consistent spacing

https://claude.ai/code/session_01XEmErvKABTDeNRbBGCYSZY