### PR TITLE
Fix CMD-K icon alignment, sidebar spacing, and testing page (#69)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -125,7 +125,7 @@ body.pnpm .cmd-npm { display: none; }
   @apply max-h-80 overflow-y-auto p-2;
 }
 [cmdk-item] {
-  @apply flex items-center px-3 py-2 text-sm rounded-lg cursor-pointer text-slate-700 dark:text-slate-300 transition-colors duration-150;
+  @apply flex items-center justify-between px-3 py-2 text-sm rounded-lg cursor-pointer text-slate-700 dark:text-slate-300 transition-colors duration-150;
 }
 [cmdk-item][data-selected="true"] {
   @apply bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400;

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -32,6 +32,7 @@ const severityBadges: Record<string, { letter: string; cls: string }> = {
   'prompt-mistakes-apis': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
   'prompt-mistakes-structural': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
   'prompt-mistakes-style': { letter: 'L', cls: 'bg-blue-100 dark:bg-blue-500/20 text-blue-600 dark:text-blue-400' },
+  'prompt-testing': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
 }
 
 function SidebarItem({ id, title, active, onClick }: { id: string; title: string; active: boolean; onClick: (id: string) => void }) {
@@ -42,7 +43,7 @@ function SidebarItem({ id, title, active, onClick }: { id: string; title: string
   return (
     <button
       className={clsx(
-        'flex items-center justify-between w-full text-left px-3.5 py-2 text-sm rounded-lg border-none bg-transparent cursor-pointer transition-all duration-150',
+        'flex items-center justify-between w-full text-left px-3.5 py-1.5 text-sm rounded-lg border-none bg-transparent cursor-pointer transition-all duration-150',
         active
           ? 'bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400 font-semibold'
           : 'text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
@@ -180,7 +181,7 @@ function ContentPanel({
   return (
     <div className="flex-1 flex flex-col min-w-0">
       {/* Header */}
-      <div className="flex items-center justify-between px-4 h-13 border-b border-slate-200 dark:border-slate-700 shrink-0">
+      <div className="flex items-center justify-between px-4 h-11 border-b border-slate-200 dark:border-slate-700 shrink-0">
         <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
           {guide ? guide.title : 'Navigation'}
         </span>

--- a/src/components/mdx/TestingMistakes.tsx
+++ b/src/components/mdx/TestingMistakes.tsx
@@ -12,7 +12,7 @@ export function TestingMistakes({ context }: { context?: 'e2e' | 'unit' }) {
     <div>
       {e2eItems.length > 0 && (
         <>
-          <h3 className="text-base font-bold text-slate-900 dark:text-slate-100 mb-3 mt-6 first:mt-0">
+          <h3 id="toc-e2e" className="text-base font-bold text-slate-900 dark:text-slate-100 mb-3 mt-6 first:mt-0">
             {'\u{1F310}'} End-to-End (E2E) Testing
           </h3>
           <div className="flex flex-col gap-3 mb-6">
@@ -36,7 +36,7 @@ export function TestingMistakes({ context }: { context?: 'e2e' | 'unit' }) {
 
       {unitItems.length > 0 && (
         <>
-          <h3 className="text-base font-bold text-slate-900 dark:text-slate-100 mb-3 mt-6">
+          <h3 id="toc-unit" className="text-base font-bold text-slate-900 dark:text-slate-100 mb-3 mt-6">
             {'\u{1F9EA}'} Unit Testing
           </h3>
           <div className="flex flex-col gap-3">

--- a/src/content/prompt-engineering/prompt-testing.mdx
+++ b/src/content/prompt-engineering/prompt-testing.mdx
@@ -1,10 +1,15 @@
 ---
 id: "prompt-testing"
-title: "Testing Best Practices 🧪"
+title: "Unit/E2E Testing 🧪"
 guide: "prompt-engineering"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+
+<Toc>
+  <TocLink id="toc-e2e">End-to-End (E2E) Testing</TocLink>
+  <TocLink id="toc-unit">Unit Testing</TocLink>
+</Toc>
 
 <SectionIntro>
 AI coding assistants frequently generate tests that look correct but contain subtle mistakes &mdash; flaky E2E tests, implementation-coupled unit tests, and missing edge case coverage. This section documents the most common testing mistakes and how to prevent them with better prompts.

--- a/src/content/sections/bigpicture.mdx
+++ b/src/content/sections/bigpicture.mdx
@@ -17,6 +17,11 @@ links:
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
+<Toc>
+  <TocLink id="toc-webapp">Web App</TocLink>
+  <TocLink id="toc-pkg">NPM Package</TocLink>
+</Toc>
+
 <SectionSubheading id="toc-webapp">{'\u{1F310}'} Web App</SectionSubheading>
 <SectionList>
 <ColItem>A web app is a complete, running application — like a website or dashboard that people open in their browser.</ColItem>


### PR DESCRIPTION
- Add justify-between to cmdk-item for right-aligned icons in command palette
- Reduce sidebar title bar height (h-13 → h-11) and item padding (py-2 → py-1.5)
- Rename Testing Best Practices to Unit/E2E Testing with medium severity badge
- Add table of contents to bigpicture.mdx and prompt-testing.mdx

https://claude.ai/code/session_012L8T2keciYpzMJ13Qad6qZ