### PR TITLE
Replace conditional rendering with invisible class for clear filters button

### DIFF
--- a/src/components/ExternalResourcesPage.tsx
+++ b/src/components/ExternalResourcesPage.tsx
@@ -309,15 +309,16 @@ export function ExternalResourcesPage({ initialGuide }: ExternalResourcesPagePro
               })}
             </div>
           </div>
-          {hasActiveFilters && (
-            <button
-              className="self-start text-xs font-medium text-gray-500 dark:text-slate-400 bg-transparent border-none cursor-pointer px-0 hover:text-blue-500 dark:hover:text-blue-400"
-              onClick={clearFilters}
-              data-testid="resources-clear-filters"
-            >
-              Clear filters
-            </button>
-          )}
+          <button
+            className={clsx(
+              "self-start text-xs font-medium text-gray-500 dark:text-slate-400 bg-transparent border-none cursor-pointer px-0 hover:text-blue-500 dark:hover:text-blue-400",
+              !hasActiveFilters && "invisible"
+            )}
+            onClick={clearFilters}
+            data-testid="resources-clear-filters"
+          >
+            Clear filters
+          </button>
         </div>
 
         {/* Results count */}

--- a/src/components/GlossaryPage.tsx
+++ b/src/components/GlossaryPage.tsx
@@ -230,15 +230,21 @@ export function GlossaryPage({ initialGuide }: GlossaryPageProps) {
           </div>
         </div>
 
-        {hasActiveFilters && (
-          <button
-            className="self-start text-xs font-medium text-gray-500 dark:text-slate-400 bg-transparent border-none cursor-pointer px-0 hover:text-blue-500 dark:hover:text-blue-400"
-            onClick={clearFilters}
-            data-testid="glossary-clear-filters"
-          >
-            Clear filters
-          </button>
-        )}
+        <button
+          className={clsx(
+            "self-start text-xs font-medium text-gray-500 dark:text-slate-400 bg-transparent border-none cursor-pointer px-0 hover:text-blue-500 dark:hover:text-blue-400",
+            !hasActiveFilters && "invisible"
+          )}
+          onClick={clearFilters}
+          data-testid="glossary-clear-filters"
+        >
+          Clear filters
+        </button>
+      </div>
+
+      {/* Results count */}
+      <div className="text-xs text-gray-400 dark:text-slate-500 mb-2.5 font-medium" data-testid="glossary-count">
+        {table.getRowModel().rows.length} of {flatData.length} terms
       </div>
 
       <DataTable table={table} columnCount={3} emptyMessage="No terms match your search." />


### PR DESCRIPTION
## Summary
Refactored the "Clear filters" button in both GlossaryPage and ExternalResourcesPage to use CSS visibility instead of conditional rendering. This ensures the button always occupies DOM space, preventing layout shifts when filters are toggled.

## Key Changes
- **GlossaryPage**: Changed from conditional rendering (`{hasActiveFilters && <button>}`) to always-rendered button with `invisible` class when no filters are active
- **ExternalResourcesPage**: Applied the same refactoring pattern for consistency
- Both components now use `clsx` utility to conditionally apply the `invisible` class based on `hasActiveFilters` state
- Added results count display in GlossaryPage (matching existing pattern in ExternalResourcesPage)

## Implementation Details
- The button remains in the DOM at all times but is visually hidden when `!hasActiveFilters` is true
- Uses Tailwind's `invisible` class which hides the element while preserving its space in the layout
- This approach prevents layout jank that would occur with conditional rendering/unmounting
- Maintains consistent styling and behavior across both pages

https://claude.ai/code/session_015mAn2f1SaKiapRjACqpy8o