### PR TITLE
Refactor sidebar to collapse when no guide is selected

### DIFF
--- a/src/components/FloatingHeader.tsx
+++ b/src/components/FloatingHeader.tsx
@@ -6,6 +6,7 @@ interface FloatingHeaderProps {
   onMenuToggle: () => void
   onSearchClick: () => void
   effectivelyPinned?: boolean
+  hasActiveGuide?: boolean
 }
 
 function getGuideInfo(sectionId: string | undefined) {
@@ -24,7 +25,7 @@ function getGuideInfo(sectionId: string | undefined) {
 
 const isMac = typeof navigator !== 'undefined' && /Mac|iPhone|iPad/.test(navigator.platform)
 
-export function FloatingHeader({ scrolled, onMenuToggle, onSearchClick, effectivelyPinned }: FloatingHeaderProps) {
+export function FloatingHeader({ scrolled, onMenuToggle, onSearchClick, effectivelyPinned, hasActiveGuide }: FloatingHeaderProps) {
   const navigate = useNavigate()
   const params = useParams({ strict: false }) as { sectionId?: string }
   const isGuidesIndex = !params.sectionId
@@ -40,7 +41,7 @@ export function FloatingHeader({ scrolled, onMenuToggle, onSearchClick, effectiv
     <div className={clsx(
       'floating-header fixed top-0 right-0 z-50 bg-white/90 dark:bg-slate-900/90 backdrop-blur-md border-b border-slate-200 dark:border-slate-700 px-5 transition-[left,box-shadow] duration-250',
       scrolled && 'shadow-md dark:shadow-lg',
-      effectivelyPinned ? 'left-0 lg:left-90' : 'left-0'
+      effectivelyPinned ? (hasActiveGuide ? 'left-0 lg:left-90' : 'left-0 lg:left-[52px]') : 'left-0'
     )}>
       <div className="mx-auto max-w-4xl flex items-center h-13 gap-3.5">
         <button

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -12,6 +12,7 @@ export function Layout() {
   const [sidebarOpen, setSidebarOpen] = useState(false)
   const [cmdMenuOpen, setCmdMenuOpen] = useState(false)
   const [scrolled, setScrolled] = useState(false)
+  const [hasActiveGuide, setHasActiveGuide] = useState(false)
   const { effectivelyPinned, pinned, togglePin, unpin } = useSidebarPin()
 
   const sidebarVisible = sidebarOpen || effectivelyPinned
@@ -67,10 +68,11 @@ export function Layout() {
         onMenuToggle={handleMenuToggle}
         onSearchClick={openCmdMenu}
         effectivelyPinned={effectivelyPinned}
+        hasActiveGuide={hasActiveGuide}
       />
       <div className={clsx(
         'mx-auto max-w-4xl px-5 pt-18 pb-15 max-sm:px-3.5 max-sm:pt-16 max-sm:pb-10 transition-[margin-left] duration-250',
-        effectivelyPinned && 'lg:ml-90'
+        effectivelyPinned && (hasActiveGuide ? 'lg:ml-90' : 'lg:ml-[52px]')
       )}>
         <Outlet />
       </div>
@@ -84,6 +86,7 @@ export function Layout() {
         onClose={handleSidebarClose}
         pinned={pinned}
         onTogglePin={togglePin}
+        onActiveGuideChange={setHasActiveGuide}
       />
       <CommandMenu open={cmdMenuOpen} onOpenChange={setCmdMenuOpen} />
       <GlossaryTooltip />


### PR DESCRIPTION
## Summary
This PR refactors the sidebar to collapse to an icon rail (52px width) when no guide is selected, and expand to full width (360px) only when a guide is active. This improves the UI by reducing visual clutter and providing a cleaner navigation experience.

## Key Changes

- **Sidebar state management**: Modified `ContentPanel` to only render when a guide is active, and updated the sidebar width to be dynamic based on `activeGuide` state
- **Guide selection toggle**: Changed `onSelectGuide` behavior to toggle guides on/off (clicking the same guide again deselects it) via new `handleSelectGuide` function
- **Layout adjustments**: Updated `FloatingHeader` and main content area margins to account for the collapsed sidebar state (52px when no guide, 360px when guide is active)
- **Control repositioning**: Moved pin and close buttons from the `ContentPanel` header to floating buttons positioned absolutely next to the icon rail, making them always accessible
- **Parent notification**: Added `onActiveGuideChange` callback to notify parent components when the active guide state changes, enabling proper layout margin adjustments
- **Component simplification**: Removed unnecessary props from `ContentPanel` (`onClose`, `pinned`, `onTogglePin`) since it now only renders when a guide is active
- **Hook addition**: Added `useEffect` to track active guide changes and notify parent component for responsive layout updates

## Implementation Details

- The sidebar now uses conditional width classes: `w-[360px] max-sm:w-[320px]` when a guide is active, otherwise `w-[52px]`
- The transition uses `transition-[width,transform]` to smoothly animate between collapsed and expanded states
- Pin/close buttons are now positioned absolutely at `left-[52px]` to float above the content panel
- The `FloatingHeader` and main content margins now check both `effectivelyPinned` and `hasActiveGuide` to determine proper spacing

https://claude.ai/code/session_013549HXTVjc4qPFv9idm9ZM