### PR TITLE
Improve command menu layout and sidebar animation

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -109,7 +109,7 @@ body.sidebar-open .sidebar-overlay {
   @apply opacity-100 pointer-events-auto;
 }
 body.sidebar-open .sidebar {
-  transform: translateX(0);
+  translate: 0;
 }
 body.pnpm .cmd-pnpm { display: inline; }
 body.pnpm .cmd-npm { display: none; }
@@ -125,7 +125,7 @@ body.pnpm .cmd-npm { display: none; }
   @apply max-h-80 overflow-y-auto p-2;
 }
 [cmdk-item] {
-  @apply flex items-center justify-between px-3 py-2 text-sm rounded-lg cursor-pointer text-slate-700 dark:text-slate-300 transition-colors duration-150;
+  @apply flex items-center px-3 py-2 text-sm rounded-lg cursor-pointer text-slate-700 dark:text-slate-300 transition-colors duration-150;
 }
 [cmdk-item][data-selected="true"] {
   @apply bg-blue-50 dark:bg-blue-500/10 text-blue-600 dark:text-blue-400;

--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -20,8 +20,8 @@ function PageItem({ id, onSelect }: { id: string; onSelect: (id: string) => void
 
   return (
     <Command.Item value={title} keywords={[id]} onSelect={() => onSelect(id)}>
-      <span>{text}</span>
-      {icon && <span className="ml-2 text-base opacity-70">{icon}</span>}
+      <span className="flex-1 min-w-0 truncate">{text}</span>
+      {icon && <span className="text-base opacity-70 shrink-0">{icon}</span>}
     </Command.Item>
   )
 }
@@ -137,9 +137,9 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                 keywords={[term.term, cat.category, 'glossary', 'definition']}
                 onSelect={() => handleGlossaryTerm(term.term)}
               >
-                <span className="mr-2 text-base opacity-70">{'\u{1F4D6}'}</span>
-                <span>{term.term}</span>
-                <span className="ml-2 text-xs text-slate-400 dark:text-slate-500">{cat.category}</span>
+                <span className="mr-2 text-base opacity-70 shrink-0">{'\u{1F4D6}'}</span>
+                <span className="flex-1 min-w-0 truncate">{term.term}</span>
+                <span className="ml-2 text-xs text-slate-400 dark:text-slate-500 shrink-0">{cat.category}</span>
               </Command.Item>
             ))
           )}
@@ -154,9 +154,9 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                 keywords={[item.name, ...item.tags, group.category, 'resource', 'external']}
                 onSelect={() => handleExternalResource(item.url)}
               >
-                <span className="mr-2 text-base opacity-70">{'\u{1F517}'}</span>
-                <span>{item.name}</span>
-                <span className="ml-2 text-xs text-slate-400 dark:text-slate-500">{group.category}</span>
+                <span className="mr-2 text-base opacity-70 shrink-0">{'\u{1F517}'}</span>
+                <span className="flex-1 min-w-0 truncate">{item.name}</span>
+                <span className="ml-2 text-xs text-slate-400 dark:text-slate-500 shrink-0">{group.category}</span>
               </Command.Item>
             ))
           )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -263,9 +263,9 @@ export function Sidebar({ open, onClose, pinned, onTogglePin, onActiveGuideChang
     <div
       data-testid="sidebar"
       className={clsx(
-        'sidebar relative fixed top-0 left-0 bottom-0 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 z-100 flex flex-row overflow-hidden transition-[width,transform] duration-250 -translate-x-full',
+        'sidebar relative fixed top-0 left-0 bottom-0 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 z-100 flex flex-row overflow-hidden transition-[width,translate] duration-250',
         activeGuide ? 'w-[360px] max-sm:w-[320px]' : 'w-[52px]',
-        open && 'translate-x-0'
+        open ? 'translate-x-0' : '-translate-x-full'
       )}
     >
       <IconRail


### PR DESCRIPTION
## Summary
This PR improves the layout and styling of the command menu items and refines the sidebar animation implementation for better text handling and modern CSS practices.

## Key Changes

- **Command Menu Layout Improvements**
  - Added `flex-1 min-w-0 truncate` classes to text spans in command items to enable proper text truncation when content overflows
  - Added `shrink-0` class to icon and category spans to prevent them from shrinking
  - Applied consistent layout fixes across PageItem, glossary terms, and external resources sections

- **CSS Modernization**
  - Replaced `transform: translateX(0)` with `translate: 0` in sidebar open state for cleaner, more modern CSS
  - Updated sidebar transition property from `transition-[width,transform]` to `transition-[width,translate]` to match the new translate property
  - Removed `justify-between` from `[cmdk-item]` base styles as it's no longer needed with the new flex layout

- **Sidebar Animation Refinement**
  - Simplified sidebar transform classes by using conditional ternary operator for clarity
  - Maintained `-translate-x-full` for closed state and `translate-x-0` for open state

## Implementation Details
The changes ensure that command menu items properly handle long text content by truncating it while keeping icons and category labels visible and properly sized. The sidebar animation now uses the modern `translate` CSS property instead of `transform`, which is more performant and aligns with current CSS best practices.

https://claude.ai/code/session_016ZStfaeAzTJEdzL8muNypD