### PR TITLE
Remove redundant relative positioning from Sidebar

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -263,7 +263,7 @@ export function Sidebar({ open, onClose, pinned, onTogglePin, onActiveGuideChang
     <div
       data-testid="sidebar"
       className={clsx(
-        'sidebar relative fixed top-0 left-0 bottom-0 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 z-100 flex flex-row overflow-hidden transition-[width,translate] duration-250',
+        'sidebar fixed top-0 left-0 bottom-0 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 z-100 flex flex-row overflow-hidden transition-[width,translate] duration-250',
         activeGuide ? 'w-[360px] max-sm:w-[320px]' : 'w-[52px]',
         open ? 'translate-x-0' : '-translate-x-full'
       )}


### PR DESCRIPTION
## Summary
Removed the redundant `relative` CSS class from the Sidebar component's root element, as it conflicts with the `fixed` positioning already applied.

## Key Changes
- Removed `relative` class from the sidebar container's className string
- The `fixed` positioning is the intended layout behavior and takes precedence; `relative` was unnecessary and could cause unintended layout side effects

## Implementation Details
The sidebar uses `fixed` positioning to anchor it to the viewport edges (`top-0 left-0 bottom-0`). The `relative` class was redundant in this context and has been removed to ensure clean, predictable CSS behavior without conflicting positioning values.

https://claude.ai/code/session_01MF6mzYLV3ZpLVbjGocD7vd