### PR TITLE
Move pin/close buttons from icon rail to content panel header

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -168,18 +168,41 @@ function ContentPanel({
   guide,
   currentId,
   onNav,
+  pinned,
+  onTogglePin,
+  onClose,
 }: {
   guide: GuideDefinition
   currentId: string
   onNav: (id: string) => void
+  pinned: boolean
+  onTogglePin: () => void
+  onClose: () => void
 }) {
   return (
     <div className="flex-1 flex flex-col min-w-0">
       {/* Header */}
-      <div className="flex items-center px-4 pl-16 h-11 border-b border-slate-200 dark:border-slate-700 shrink-0">
+      <div className="flex items-center justify-between px-4 h-11 border-b border-slate-200 dark:border-slate-700 shrink-0">
         <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
           {guide.title}
         </span>
+        <div className="flex items-center gap-0.5 shrink-0 ml-2">
+          <button
+            className="hidden lg:flex items-center justify-center w-7 h-7 rounded-md cursor-pointer text-gray-400 dark:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-600 dark:hover:text-slate-300 transition-colors duration-150"
+            onClick={onTogglePin}
+            title={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+            data-testid="sidebar-pin"
+          >
+            <PinIcon pinned={pinned} />
+          </button>
+          <button
+            className="flex items-center justify-center w-7 h-7 rounded-md cursor-pointer text-lg text-gray-400 dark:text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-600 dark:hover:text-slate-300 transition-colors duration-150"
+            onClick={onClose}
+            data-testid="sidebar-close"
+          >
+            &#x2715;
+          </button>
+        </div>
       </div>
 
       {/* Navigation links */}
@@ -276,30 +299,35 @@ export function Sidebar({ open, onClose, pinned, onTogglePin, onActiveGuideChang
         currentId={currentId}
       />
 
-      {/* Floating Pin/Close buttons — positioned to the right of the Home icon */}
-      <div className="absolute top-3 left-[52px] flex items-center gap-0.5 z-10">
-        <button
-          className="hidden lg:flex items-center justify-center w-7 h-7 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 cursor-pointer rounded-md hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors duration-150 shadow-sm"
-          onClick={onTogglePin}
-          title={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
-          data-testid="sidebar-pin"
-        >
-          <PinIcon pinned={pinned} />
-        </button>
-        <button
-          className="flex items-center justify-center w-7 h-7 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 cursor-pointer text-lg text-gray-400 dark:text-slate-500 rounded-md hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-600 dark:hover:text-slate-300 transition-colors duration-150 shadow-sm"
-          onClick={onClose}
-          data-testid="sidebar-close"
-        >
-          &#x2715;
-        </button>
-      </div>
+      {/* Floating Pin/Close buttons — only when icon rail is shown without content panel */}
+      {!activeGuide && (
+        <div className="absolute top-3 left-[52px] flex items-center gap-0.5 z-10">
+          <button
+            className="hidden lg:flex items-center justify-center w-7 h-7 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 cursor-pointer rounded-md hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors duration-150 shadow-sm"
+            onClick={onTogglePin}
+            title={pinned ? 'Unpin sidebar' : 'Pin sidebar'}
+            data-testid="sidebar-pin"
+          >
+            <PinIcon pinned={pinned} />
+          </button>
+          <button
+            className="flex items-center justify-center w-7 h-7 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 cursor-pointer text-lg text-gray-400 dark:text-slate-500 rounded-md hover:bg-slate-100 dark:hover:bg-slate-700 hover:text-slate-600 dark:hover:text-slate-300 transition-colors duration-150 shadow-sm"
+            onClick={onClose}
+            data-testid="sidebar-close"
+          >
+            &#x2715;
+          </button>
+        </div>
+      )}
 
       {activeGuide && (
         <ContentPanel
           guide={activeGuide}
           currentId={currentId}
           onNav={handleNav}
+          pinned={pinned}
+          onTogglePin={onTogglePin}
+          onClose={onClose}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
Refactored the sidebar UI to relocate the pin and close buttons from the floating icon rail to the content panel header, improving the layout and UX when a guide is active.

## Key Changes
- **Moved pin/close buttons**: Relocated from the absolute-positioned floating buttons next to the home icon to the content panel header
- **Updated ContentPanel component**: Added `pinned`, `onTogglePin`, and `onClose` props to enable button functionality in the header
- **Conditional floating buttons**: The floating buttons now only display when no active guide is shown (`!activeGuide`), reducing visual clutter when content is displayed
- **Header layout improvements**: 
  - Changed header flex layout to use `justify-between` for better spacing
  - Removed `pl-16` padding that was needed for the floating buttons
  - Added button container with proper styling and spacing in the header

## Implementation Details
- The pin button remains hidden on smaller screens (`hidden lg:flex`) to maintain responsive design
- Button styling was adjusted for the header context (removed border and background, using hover states instead)
- Both buttons maintain their test IDs (`sidebar-pin` and `sidebar-close`) for testing purposes
- The close button uses the same X character entity (`&#x2715;`) for consistency

https://claude.ai/code/session_01NFMxDxiaNhgCGMTSDWJQbJ