### PR TITLE
Fix sidebar close behavior based on pinned state

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -282,6 +282,16 @@ export function Sidebar({ open, onClose, pinned, onTogglePin, onActiveGuideChang
     setActiveGuideId(prev => prev === guideId ? null : guideId)
   }
 
+  // When pinned, closing the content panel collapses to icon rail (stays pinned).
+  // When not pinned, closing the content panel closes the entire sidebar.
+  const handleContentPanelClose = () => {
+    if (pinned) {
+      setActiveGuideId(null)
+    } else {
+      onClose()
+    }
+  }
+
   return (
     <div
       data-testid="sidebar"
@@ -327,7 +337,7 @@ export function Sidebar({ open, onClose, pinned, onTogglePin, onActiveGuideChang
           onNav={handleNav}
           pinned={pinned}
           onTogglePin={onTogglePin}
-          onClose={onClose}
+          onClose={handleContentPanelClose}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
Updated the sidebar's content panel close behavior to respect the pinned state. When the sidebar is pinned, closing the content panel now collapses it to the icon rail while keeping the sidebar open. When unpinned, closing the content panel closes the entire sidebar.

## Changes
- Added `handleContentPanelClose` function that conditionally handles close actions based on the `pinned` prop
  - If pinned: clears the active guide ID (collapses to icon rail)
  - If not pinned: closes the entire sidebar via `onClose()`
- Updated the `SidebarContent` component's `onClose` prop to use the new handler instead of directly calling `onClose()`

## Implementation Details
This change improves the UX by maintaining the sidebar's pinned state as a persistent UI element while still allowing users to dismiss the expanded content panel. The logic is centralized in a single handler function for clarity and maintainability.

https://claude.ai/code/session_013zgLP5ewCuB7dEwi4hjCpW