### PR TITLE
Remove page headings and external resources from CMD+K menu

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -1,10 +1,8 @@
-import { Fragment } from 'react'
 import { Command } from 'cmdk'
 import { useNavigate } from '@tanstack/react-router'
 import { getNavTitle } from '../data/navigation'
-import { guides, getPageHeadings } from '../data/guideRegistry'
+import { guides } from '../data/guideRegistry'
 import { glossaryTerms } from '../data/glossaryTerms'
-import { overallResources } from '../data/overallResources'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
 
 interface CommandMenuProps {
@@ -26,25 +24,6 @@ function PageItem({ id, onSelect }: { id: string; onSelect: (id: string) => void
   )
 }
 
-function HeadingItem({ pageId, pageTitle, headingId, headingTitle, onSelect }: {
-  pageId: string
-  pageTitle: string
-  headingId: string
-  headingTitle: string
-  onSelect: (pageId: string, anchorId: string) => void
-}) {
-  return (
-    <Command.Item
-      value={`${pageTitle} \u203A ${headingTitle}`}
-      keywords={[pageId, headingId, headingTitle]}
-      onSelect={() => onSelect(pageId, headingId)}
-    >
-      <span className="ml-4 text-slate-400 dark:text-slate-500">#</span>
-      <span className="ml-1.5">{headingTitle}</span>
-    </Command.Item>
-  )
-}
-
 export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
   const navigate = useNavigate()
   const navigateToSection = useNavigateToSection()
@@ -52,11 +31,6 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
   const handleSelect = (id: string) => {
     onOpenChange(false)
     navigateToSection(id)
-  }
-
-  const handleHeadingSelect = (pageId: string, anchorId: string) => {
-    onOpenChange(false)
-    navigateToSection(pageId, anchorId)
   }
 
   const handleHome = () => {
@@ -71,11 +45,6 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
-  const handleExternalResource = (url: string) => {
-    onOpenChange(false)
-    window.open(url, '_blank', 'noopener,noreferrer')
-  }
-
   return (
     <Command.Dialog
       open={open}
@@ -85,7 +54,7 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
       overlayClassName="fixed inset-0 bg-slate-900/30 dark:bg-black/50 backdrop-blur-sm"
       contentClassName="fixed top-[20vh] left-1/2 -translate-x-1/2 w-[calc(100%-2rem)] max-w-lg bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl shadow-2xl overflow-hidden"
     >
-      <Command.Input placeholder="Search pages, headings, glossary..." />
+      <Command.Input placeholder="Search pages, glossary..." />
       <Command.List>
         <Command.Empty>No results found.</Command.Empty>
 
@@ -100,25 +69,9 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
               key={`${guide.id}-${sIdx}`}
               heading={section.label ? `${guide.title} \u203A ${section.label}` : guide.title}
             >
-              {section.ids.map(id => {
-                const headings = getPageHeadings(id)
-                const pageTitle = getNavTitle(id)
-                return (
-                  <Fragment key={id}>
-                    <PageItem id={id} onSelect={handleSelect} />
-                    {headings.map(h => (
-                      <HeadingItem
-                        key={`${id}-${h.id}`}
-                        pageId={id}
-                        pageTitle={pageTitle}
-                        headingId={h.id}
-                        headingTitle={h.title}
-                        onSelect={handleHeadingSelect}
-                      />
-                    ))}
-                  </Fragment>
-                )
-              })}
+              {section.ids.map(id => (
+                <PageItem key={id} id={id} onSelect={handleSelect} />
+              ))}
             </Command.Group>
           ))
         )}
@@ -140,23 +93,6 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
                 <span className="mr-2 text-base opacity-70 shrink-0">{'\u{1F4D6}'}</span>
                 <span className="flex-1 min-w-0 truncate">{term.term}</span>
                 <span className="ml-2 text-xs text-slate-400 dark:text-slate-500 shrink-0">{cat.category}</span>
-              </Command.Item>
-            ))
-          )}
-        </Command.Group>
-
-        <Command.Group heading="External Resources">
-          {overallResources.flatMap(group =>
-            group.items.map(item => (
-              <Command.Item
-                key={`resource-${item.name}`}
-                value={`Resource: ${item.name}`}
-                keywords={[item.name, ...item.tags, group.category, 'resource', 'external']}
-                onSelect={() => handleExternalResource(item.url)}
-              >
-                <span className="mr-2 text-base opacity-70 shrink-0">{'\u{1F517}'}</span>
-                <span className="flex-1 min-w-0 truncate">{item.name}</span>
-                <span className="ml-2 text-xs text-slate-400 dark:text-slate-500 shrink-0">{group.category}</span>
               </Command.Item>
             ))
           )}


### PR DESCRIPTION
Simplify the command menu by removing sub-page heading items and the
External Resources group. The menu now shows pages and glossary terms only.

https://claude.ai/code/session_01XxKzFLmZ9uoYoYXALCpf2R