### PR TITLE
Add 11 cross-guide NavLinks to connect related content across all four guides

### DIFF
--- a/src/content/architecture/arch-frameworks-intro.mdx
+++ b/src/content/architecture/arch-frameworks-intro.mdx
@@ -33,7 +33,7 @@ In the previous sections, you learned about **stacks** &mdash; collections of in
 <ColItem>**Server rendering** &mdash; generate HTML on the server for faster initial loads and better SEO<FnRef n={2} /></ColItem>
 <ColItem>**File-system routing** &mdash; your file structure automatically becomes your URL structure</ColItem>
 <ColItem>**Data fetching** &mdash; load data on the server before sending pages to the browser</ColItem>
-<ColItem>**Build optimization** &mdash; automatic code splitting, bundling, and asset optimization</ColItem>
+<ColItem>**Build optimization** &mdash; automatic code splitting, bundling, and asset optimization. For more on bundlers and build tools, see <NavLink to="build" /> in the NPM Package Guide.</ColItem>
 </SectionList>
 
 <SectionSubheading id="toc-stacks-vs-frameworks">{'\u{1F504}'} Stacks vs. frameworks</SectionSubheading>

--- a/src/content/ci/ci-linting.mdx
+++ b/src/content/ci/ci-linting.mdx
@@ -52,5 +52,5 @@ Most editors (VS Code, WebStorm, Cursor) can hook into your linter and formatter
   run: `}<Cmd npm="npx eslint . --max-warnings 0" pnpm="pnpm eslint . --max-warnings 0" /></CIYaml>
 
 <CITip>
-Use --max-warnings 0 to fail the build on any warning. This keeps your codebase clean over time instead of slowly accumulating 'harmless' warnings that hide real issues. Your CI should always run the same lint check that your IDE runs locally — no surprises.
+Use --max-warnings 0 to fail the build on any warning. This keeps your codebase clean over time instead of slowly accumulating 'harmless' warnings that hide real issues. Your CI should always run the same lint check that your IDE runs locally — no surprises. If you're using AI coding assistants, see <NavLink to="prompt-mistakes-style">Style & Formatting Drift</NavLink> in the Prompt Engineering Guide for common style issues in AI-generated code.
 </CITip>

--- a/src/content/ci/ci-testing.mdx
+++ b/src/content/ci/ci-testing.mdx
@@ -27,7 +27,7 @@ linkRefs:
 </Toc>
 
 <SectionIntro>
-Testing in the JS ecosystem falls into several categories, and understanding when to use each is key to a good test suite.
+Testing in the JS ecosystem falls into several categories, and understanding when to use each is key to a good test suite. For a deeper dive into testing fundamentals, see the <NavLink to="test-overview">Testing Pyramid</NavLink> in the Testing Guide.
 </SectionIntro>
 
 <CIStep heading={'\uD83E\uDDEA Unit Tests'} id="toc-unit">
@@ -75,6 +75,7 @@ Run E2E tests last in your CI pipeline — they're the slowest. If linting, buil
   <li>**Readable**<FnRef n={3} /> — someone new should understand what's being tested. Name tests clearly: <code>{"it('returns empty array when no items match filter')"}</code> is better than <code>{"it('test filter')"}</code>.</li>
   <li>**Behavior-focused**<FnRef n={4} /> — test what the code does, not how it does it. If you refactor internals, your tests should still pass.</li>
 </GoodTestsList>
+For a more detailed look at testing do's and don'ts, see <NavLink to="test-best-practices" /> in the Testing Guide.
 </CIStepText>
 </CIStep>
 

--- a/src/content/prompt-engineering/prompt-meta-tooling.mdx
+++ b/src/content/prompt-engineering/prompt-meta-tooling.mdx
@@ -31,6 +31,8 @@ The tooling and processes that surround your prompt engineering workflow<FnRef n
 
 <MetaTooling toolId="ci-integration" />
 
+For a full CI pipeline walkthrough with GitHub Actions YAML examples (linting, build, tests), see <NavLink to="ci-overview" /> in the NPM Package Guide.
+
 <SectionSubheading id="toc-versioning">{'\u{1F4CB}'} Prompt Versioning</SectionSubheading>
 
 <MetaTooling toolId="prompt-versioning" />

--- a/src/content/prompt-engineering/prompt-mistakes-style.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-style.mdx
@@ -15,7 +15,7 @@ linkRefs:
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
 <SectionIntro>
-Lower severity but still annoying &mdash; AI models can drift from your project&rsquo;s coding style, mixing naming conventions, adding unnecessary comments, or ignoring your linter and formatter configuration. Including style rules in your prompt or CLAUDE.md<FnRef n={1} /> keeps output consistent.
+Lower severity but still annoying &mdash; AI models can drift from your project&rsquo;s coding style, mixing naming conventions, adding unnecessary comments, or ignoring your linter and formatter configuration. Including style rules in your prompt or CLAUDE.md<FnRef n={1} /> keeps output consistent. For setting up ESLint and Prettier as your automated safety net, see <NavLink to="ci-linting" /> in the NPM Package Guide.
 </SectionIntro>
 
 <Toc>

--- a/src/content/prompt-engineering/prompt-testing.mdx
+++ b/src/content/prompt-engineering/prompt-testing.mdx
@@ -24,7 +24,7 @@ linkRefs:
 </Toc>
 
 <SectionIntro>
-AI coding assistants frequently generate tests that look correct but contain subtle mistakes &mdash; flaky E2E tests<FnRef n={3} />, implementation-coupled unit tests<FnRef n={2} />, and missing edge case coverage. This section documents the most common testing mistakes and how to prevent them with better prompts.
+AI coding assistants frequently generate tests that look correct but contain subtle mistakes &mdash; flaky E2E tests<FnRef n={3} />, implementation-coupled unit tests<FnRef n={2} />, and missing edge case coverage. This section documents the most common testing mistakes and how to prevent them with better prompts. New to frontend testing? See the <NavLink to="test-overview" /> for foundational concepts, and <NavLink to="test-best-practices" /> for general do's and don'ts.
 </SectionIntro>
 
 <TestingMistakes />

--- a/src/content/sections/build.mdx
+++ b/src/content/sections/build.mdx
@@ -25,7 +25,7 @@ linkRefs:
 <SectionSubheading id="toc-webapp">{'\u{1F310}'} Web App</SectionSubheading>
 <SectionList>
 <ColItem>You use a 'bundler' to combine all your code into optimized files the browser can run. The two most common ones are Vite<FnRef n={1} /> (fast, modern, recommended for new projects) and Webpack<FnRef n={3} /> (older, very configurable, still widely used).</ColItem>
-<ColItem>The output is HTML, CSS, and JavaScript files deployed to a web server or CDN — similar to deploying a backend to a cloud provider.</ColItem>
+<ColItem>The output is HTML, CSS, and JavaScript files deployed to a web server or CDN — similar to deploying a backend to a cloud provider. For how this fits into the bigger picture of web app architecture, see <NavLink to="arch-what-is-a-stack" /> in the Architecture Guide.</ColItem>
 <ColItem>You only need to target browsers, so one output format is fine. Vite and Webpack handle all the optimization for you.</ColItem>
 </SectionList>
 

--- a/src/content/testing/test-best-practices.mdx
+++ b/src/content/testing/test-best-practices.mdx
@@ -32,3 +32,5 @@ These guidelines apply across all test types. Follow them to write tests that ar
 <SectionSubheading id="toc-dont">{'\uD83D\uDEAB'} What to avoid</SectionSubheading>
 
 <TestPracticeCards type="dont" />
+
+If you're using AI coding assistants, see <NavLink to="prompt-testing">Unit/E2E Testing</NavLink> in the Prompt Engineering Guide for common testing mistakes that AI models make and how to prevent them with better prompts.

--- a/src/content/testing/test-tools.mdx
+++ b/src/content/testing/test-tools.mdx
@@ -40,6 +40,6 @@ Here are the most popular testing tools in the React and frontend ecosystem. Use
 <SectionList>
 <ColItem>**For a Vite project**, start with **Vitest**<FnRef n={1} /> for unit and component tests &mdash; it shares your Vite config, so setup is minimal. Add **React Testing Library**<FnRef n={3} /> for component tests and **Playwright**<FnRef n={4} /> for E2E.</ColItem>
 <ColItem>**For an existing Jest project**<FnRef n={2} />, there's no urgent need to migrate. Jest works great and has the largest ecosystem. Add RTL for components and Playwright or Cypress<FnRef n={5} /> for E2E.</ColItem>
-<ColItem>**For visual testing**, **Storybook**<FnRef n={6} /> lets you develop components in isolation and catch visual regressions. It complements your test runner rather than replacing it.</ColItem>
+<ColItem>**For visual testing**, **Storybook**<FnRef n={6} /> lets you develop components in isolation and catch visual regressions. It complements your test runner rather than replacing it. See the <NavLink to="storybook" /> page in the NPM Package Guide for a deeper look at how Storybook fits into development workflows.</ColItem>
 <ColItem>**For E2E**, **Playwright** is the current industry favorite &mdash; it's fast, reliable, and supports all major browsers. **Cypress** has a friendlier developer experience but less browser coverage.</ColItem>
 </SectionList>


### PR DESCRIPTION
Previously all NavLinks were intra-guide only. This adds bidirectional
cross-references between guides where topics overlap, creating a connected
learning experience without removing any existing content.

Links added:
- ci-testing → test-overview, test-best-practices (NPM → Testing)
- test-tools → storybook (Testing → NPM)
- test-best-practices → prompt-testing (Testing → Prompt)
- prompt-testing → test-overview, test-best-practices (Prompt → Testing)
- prompt-meta-tooling → ci-overview (Prompt → NPM)
- prompt-mistakes-style → ci-linting (Prompt → NPM)
- ci-linting → prompt-mistakes-style (NPM → Prompt)
- arch-frameworks-intro → build (Architecture → NPM)
- build → arch-what-is-a-stack (NPM → Architecture)

https://claude.ai/code/session_016Mo94X7Zdh6G4eJTLLZiYk