### PR TITLE
Fix sidebar overflow and improve pinned state behavior

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -179,7 +179,7 @@ function ContentPanel({
   onClose: () => void
 }) {
   return (
-    <div className="flex-1 flex flex-col min-w-0">
+    <div className="flex-1 flex flex-col min-w-0 overflow-hidden">
       {/* Header */}
       <div className="flex items-center justify-between px-4 h-11 border-b border-slate-200 dark:border-slate-700 shrink-0">
         <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
@@ -273,7 +273,7 @@ export function Sidebar({ open, onClose, pinned, onTogglePin, onActiveGuideChang
 
   const handleResourceClick = (id: string) => {
     setActiveGuideId(null)
-    onClose()
+    if (!pinned) onClose()
     navigateToSection(id)
   }
 
@@ -295,7 +295,7 @@ export function Sidebar({ open, onClose, pinned, onTogglePin, onActiveGuideChang
     <div
       data-testid="sidebar"
       className={clsx(
-        'sidebar fixed top-0 left-0 bottom-0 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 z-100 flex flex-row overflow-hidden transition-[width,translate] duration-250',
+        'sidebar fixed top-0 left-0 bottom-0 bg-white dark:bg-slate-900 border-r border-slate-200 dark:border-slate-700 z-100 flex flex-row transition-[width,translate] duration-250',
         activeGuide ? 'w-[360px] max-sm:w-[320px]' : 'w-[52px]',
         open ? 'translate-x-0' : '-translate-x-full'
       )}


### PR DESCRIPTION
## Summary
This PR fixes layout overflow issues in the sidebar and improves the user experience when the sidebar is pinned by preventing unwanted closure on resource navigation.

## Key Changes
- **Added overflow containment**: Added `overflow-hidden` class to the ContentPanel to prevent content from overflowing its container
- **Removed redundant overflow class**: Removed `overflow-hidden` from the main sidebar container as it was causing layout issues with the transition animations
- **Improved pinned sidebar behavior**: Modified `handleResourceClick` to only close the sidebar when it's not pinned, allowing users to keep the sidebar open while navigating resources

## Implementation Details
- The ContentPanel now properly constrains its child content with `overflow-hidden`, ensuring the flex layout works correctly
- The sidebar's main container no longer has `overflow-hidden`, allowing smooth CSS transitions for the slide-in/slide-out animation
- When the sidebar is pinned (`pinned === true`), clicking on a resource will navigate to it without closing the sidebar, improving workflow efficiency

https://claude.ai/code/session_019KpNyLsXCuLx5NwHYPpQ7Q