### PR TITLE
Add Storybook link to guides, command menu, and sidebar

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -5,6 +5,8 @@ import { guides } from '../data/guideRegistry'
 import { glossaryTerms } from '../data/glossaryTerms'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
 import { parseTitle } from '../helpers/parseTitle'
+import { STORYBOOK_URL } from '../data/navigation'
+import { ExternalLinkIcon } from './ExternalLinkIcon'
 
 interface CommandMenuProps {
   open: boolean
@@ -78,6 +80,17 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
         <Command.Group heading="Resources">
           <PageItem id="external-resources" onSelect={handleSelect} />
           <PageItem id="glossary" onSelect={handleSelect} />
+          <Command.Item
+            value="Storybook"
+            keywords={['storybook', 'components', 'stories']}
+            onSelect={() => {
+              onOpenChange(false)
+              window.open(STORYBOOK_URL, '_blank', 'noopener,noreferrer')
+            }}
+          >
+            <span className="flex-1 min-w-0 truncate">Storybook</span>
+            <ExternalLinkIcon className="w-3.5 h-3.5 opacity-50 shrink-0" />
+          </Command.Item>
         </Command.Group>
 
         <Command.Group heading="Glossary">

--- a/src/components/GuidesIndexPage.tsx
+++ b/src/components/GuidesIndexPage.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from '@tanstack/react-router'
 import { guides } from '../data/guideRegistry'
+import { STORYBOOK_URL } from '../data/navigation'
+import { ExternalLinkIcon } from './ExternalLinkIcon'
 
 interface ResourceTile {
   sectionId: string
@@ -100,6 +102,21 @@ export function GuidesIndexPage() {
               </p>
             </button>
           ))}
+          <a
+            href={STORYBOOK_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="flex flex-col items-start text-left p-5 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl cursor-pointer transition-all duration-150 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 hover:-translate-y-0.5 no-underline"
+          >
+            <span className="text-2xl mb-2">{'\u{1F3A8}'}</span>
+            <h3 className="text-base font-bold text-slate-900 dark:text-slate-100 mb-1 flex items-center gap-1.5">
+              Storybook
+              <ExternalLinkIcon className="w-3.5 h-3.5 text-slate-400 dark:text-slate-500" />
+            </h3>
+            <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+              Browse interactive component stories for this app — built with Storybook.
+            </p>
+          </a>
         </div>
       </div>
     </div>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -4,6 +4,7 @@ import clsx from 'clsx'
 import { guides, getGuideForPage, type GuideDefinition } from '../data/guideRegistry'
 import { getNavTitle } from '../data/navigation'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
+import { STORYBOOK_URL } from '../data/navigation'
 import { parseTitle } from '../helpers/parseTitle'
 import { OptionsDropdown } from './OptionsDropdown'
 
@@ -129,6 +130,14 @@ function IconRail({
       >
         <span className="text-lg leading-none">{'\u{1F4D6}'}</span>
         <span className={tooltipCls}>Glossary</span>
+      </button>
+      <button
+        className={clsx(iconBtnCls, inactiveCls)}
+        onClick={() => window.open(STORYBOOK_URL, '_blank', 'noopener,noreferrer')}
+        data-testid="sidebar-icon-storybook"
+      >
+        <span className="text-lg leading-none">{'\u{1F3A8}'}</span>
+        <span className={tooltipCls}>Storybook</span>
       </button>
 
       <div className="w-6 h-px bg-slate-200 dark:bg-slate-700 my-1.5" />

--- a/src/data/navigation.ts
+++ b/src/data/navigation.ts
@@ -1,6 +1,8 @@
 import { contentPages } from '../content/registry'
 import { getNavOrderForPage } from './guideRegistry'
 
+export const STORYBOOK_URL = 'https://emilyserven.net/npm-package-guide/storybook'
+
 // Titles for non-MDX pages that can't be derived from the content registry.
 const staticTitles: Record<string, string> = {
   'external-resources': 'External Resources \u{1F4DA}',


### PR DESCRIPTION
## Summary
This PR adds a Storybook link across multiple navigation surfaces in the application, making it easily discoverable for users who want to browse interactive component stories.

## Key Changes
- **GuidesIndexPage**: Added a new tile card linking to Storybook with a palette emoji icon and description
- **CommandMenu**: Added a Storybook command item in the Resources group with external link icon and keyboard searchability
- **Sidebar**: Added a Storybook button in the icon rail with tooltip, opening in a new window
- **Navigation data**: Exported `STORYBOOK_URL` constant pointing to the Storybook deployment

## Implementation Details
- The Storybook URL is centralized in `src/data/navigation.ts` for easy maintenance
- All external links use `target="_blank"` with `rel="noopener noreferrer"` for security
- The `ExternalLinkIcon` component is consistently used to indicate external links
- Styling matches existing design patterns with hover effects and dark mode support
- Command menu item includes relevant keywords ('storybook', 'components', 'stories') for discoverability

https://claude.ai/code/session_01LgCr2YHLAvHhuMdHWsNzRV