### PR TITLE
Add Storybook stories for MDX components

### DIFF
--- a/.storybook/decorators.tsx
+++ b/.storybook/decorators.tsx
@@ -1,6 +1,14 @@
+/* eslint-disable react-refresh/only-export-components */
 import { useEffect, type ReactNode } from 'react'
 import { ThemeProvider, useTheme } from '../src/hooks/useTheme'
 import { PMProvider } from '../src/hooks/usePMContext'
+import {
+  createRouter,
+  createRoute,
+  createRootRoute,
+  createMemoryHistory,
+  RouterProvider,
+} from '@tanstack/react-router'
 
 /**
  * Syncs the ThemeProvider's internal state with the body class
@@ -34,4 +42,26 @@ export function AppProviders({ children }: { children: ReactNode }) {
       </ThemeSync>
     </ThemeProvider>
   )
+}
+
+/**
+ * Storybook decorator that wraps a story in a minimal TanStack Router context.
+ * Needed for components that use useNavigate() or useNavigateToSection().
+ */
+export function withRouter(Story: () => ReactNode) {
+  const rootRoute = createRootRoute({
+    component: () => <>{Story()}</>,
+  })
+  const sectionRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/$sectionId',
+    component: () => null,
+  })
+  const routeTree = rootRoute.addChildren([sectionRoute])
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: ['/'] }),
+  })
+
+  return <RouterProvider router={router} />
 }

--- a/src/components/mdx/Cmd.stories.tsx
+++ b/src/components/mdx/Cmd.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { Cmd } from './Cmd'
+
+const meta: Meta<typeof Cmd> = {
+  title: 'MDX/Cmd',
+  component: Cmd,
+}
+
+export default meta
+type Story = StoryObj<typeof Cmd>
+
+export const NpmInstall: Story = {
+  args: { npm: 'npm install lodash' },
+}
+
+export const WithExplicitPnpm: Story = {
+  args: { npm: 'npm publish', pnpm: 'pnpm publish --no-git-checks' },
+}

--- a/src/components/mdx/FnRef.stories.tsx
+++ b/src/components/mdx/FnRef.stories.tsx
@@ -1,0 +1,36 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { FnRef } from './FnRef'
+import { FootnoteContext } from './FootnoteContext'
+import type { SectionLink } from '../../helpers/renderFootnotes'
+
+const MOCK_LINKS: SectionLink[] = [
+  { label: 'npm Documentation', url: 'https://docs.npmjs.com/', source: 'npm', note: 'Official npm docs' },
+  { label: 'MDN Web Docs', url: 'https://developer.mozilla.org/', source: 'MDN' },
+  { label: 'TypeScript Handbook', url: 'https://www.typescriptlang.org/docs/', source: 'TypeScript', note: 'TS handbook' },
+]
+
+const meta: Meta = {
+  title: 'MDX/FnRef',
+}
+
+export default meta
+
+export const SingleFootnote: StoryObj = {
+  render: () => (
+    <FootnoteContext.Provider value={MOCK_LINKS}>
+      <p>
+        This is a paragraph with a footnote reference <FnRef n={1} /> inline.
+      </p>
+    </FootnoteContext.Provider>
+  ),
+}
+
+export const MultipleFootnotes: StoryObj = {
+  render: () => (
+    <FootnoteContext.Provider value={MOCK_LINKS}>
+      <p>
+        First reference <FnRef n={1} />, second reference <FnRef n={2} />, and third <FnRef n={3} />.
+      </p>
+    </FootnoteContext.Provider>
+  ),
+}

--- a/src/components/mdx/GuideStartContent.stories.tsx
+++ b/src/components/mdx/GuideStartContent.stories.tsx
@@ -1,0 +1,20 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { GuideStartContent } from './GuideStartContent'
+import { withRouter } from '../../../.storybook/decorators'
+
+const meta: Meta<typeof GuideStartContent> = {
+  title: 'MDX/GuideStartContent',
+  component: GuideStartContent,
+  decorators: [withRouter],
+}
+
+export default meta
+type Story = StoryObj<typeof GuideStartContent>
+
+export const NPMPackage: Story = { args: { guideId: 'npm-package' } }
+
+export const Architecture: Story = { args: { guideId: 'architecture' } }
+
+export const Testing: Story = { args: { guideId: 'testing' } }
+
+export const PromptEngineering: Story = { args: { guideId: 'prompt-engineering' } }

--- a/src/components/mdx/NavLink.stories.tsx
+++ b/src/components/mdx/NavLink.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { NavLink, NavPill } from './NavLink'
+import { withRouter } from '../../../.storybook/decorators'
+
+const meta: Meta = {
+  title: 'MDX/NavLink',
+  decorators: [withRouter],
+}
+
+export default meta
+
+export const AutoTitle: StoryObj = {
+  render: () => <NavLink to="build" />,
+}
+
+export const CustomChildren: StoryObj = {
+  render: () => <NavLink to="build">bundlers and build tools</NavLink>,
+}
+
+export const Pill: StoryObj = {
+  render: () => <NavPill to="deps">dependency management</NavPill>,
+}

--- a/src/components/mdx/StepJump.stories.tsx
+++ b/src/components/mdx/StepJump.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { StepJump } from './StepJump'
+import { withRouter } from '../../../.storybook/decorators'
+
+const meta: Meta = {
+  title: 'MDX/StepJump',
+  decorators: [withRouter],
+}
+
+export default meta
+
+export const Default: StoryObj = {
+  render: () => <StepJump to="build">Go to Build section</StepJump>,
+}

--- a/src/components/mdx/architecture/DataFlowDiagram.stories.tsx
+++ b/src/components/mdx/architecture/DataFlowDiagram.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { DataFlowDiagram } from './DataFlowDiagram'
+
+const meta: Meta<typeof DataFlowDiagram> = {
+  title: 'MDX/Architecture/DataFlowDiagram',
+  component: DataFlowDiagram,
+}
+
+export default meta
+type Story = StoryObj<typeof DataFlowDiagram>
+
+export const Default: Story = {}

--- a/src/components/mdx/architecture/FrameworkExplorer.stories.tsx
+++ b/src/components/mdx/architecture/FrameworkExplorer.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { FrameworkExplorer } from './FrameworkExplorer'
+
+const meta: Meta<typeof FrameworkExplorer> = {
+  title: 'MDX/Architecture/FrameworkExplorer',
+  component: FrameworkExplorer,
+}
+
+export default meta
+type Story = StoryObj<typeof FrameworkExplorer>
+
+export const NextJS: Story = { args: { frameworkId: 'nextjs' } }
+
+export const ReactRouter: Story = { args: { frameworkId: 'react-router' } }

--- a/src/components/mdx/architecture/FrameworkProsCons.stories.tsx
+++ b/src/components/mdx/architecture/FrameworkProsCons.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { FrameworkProsCons } from './FrameworkProsCons'
+
+const meta: Meta<typeof FrameworkProsCons> = {
+  title: 'MDX/Architecture/FrameworkProsCons',
+  component: FrameworkProsCons,
+}
+
+export default meta
+type Story = StoryObj<typeof FrameworkProsCons>
+
+export const NextJS: Story = { args: { frameworkId: 'nextjs' } }
+
+export const ReactRouter: Story = { args: { frameworkId: 'react-router' } }

--- a/src/components/mdx/architecture/LayerDiagram.stories.tsx
+++ b/src/components/mdx/architecture/LayerDiagram.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { LayerDiagram } from './LayerDiagram'
+
+const meta: Meta<typeof LayerDiagram> = {
+  title: 'MDX/Architecture/LayerDiagram',
+  component: LayerDiagram,
+}
+
+export default meta
+type Story = StoryObj<typeof LayerDiagram>
+
+export const Default: Story = {}

--- a/src/components/mdx/architecture/StackProsCons.stories.tsx
+++ b/src/components/mdx/architecture/StackProsCons.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { StackProsCons } from './StackProsCons'
+
+const meta: Meta<typeof StackProsCons> = {
+  title: 'MDX/Architecture/StackProsCons',
+  component: StackProsCons,
+}
+
+export default meta
+type Story = StoryObj<typeof StackProsCons>
+
+export const MERN: Story = { args: { stackId: 'mern' } }
+
+export const LAMP: Story = { args: { stackId: 'lamp' } }

--- a/src/components/mdx/auth/AuthChecklist.stories.tsx
+++ b/src/components/mdx/auth/AuthChecklist.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { AuthChecklist } from './AuthChecklist'
+
+const meta: Meta<typeof AuthChecklist> = {
+  title: 'MDX/Auth/AuthChecklist',
+  component: AuthChecklist,
+}
+
+export default meta
+type Story = StoryObj<typeof AuthChecklist>
+
+export const Default: Story = {}

--- a/src/components/mdx/auth/AuthPatterns.stories.tsx
+++ b/src/components/mdx/auth/AuthPatterns.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { AuthPatterns } from './AuthPatterns'
+
+const meta: Meta<typeof AuthPatterns> = {
+  title: 'MDX/Auth/AuthPatterns',
+  component: AuthPatterns,
+}
+
+export default meta
+type Story = StoryObj<typeof AuthPatterns>
+
+export const Default: Story = {}

--- a/src/components/mdx/auth/AuthQuiz.stories.tsx
+++ b/src/components/mdx/auth/AuthQuiz.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { AuthQuiz } from './AuthQuiz'
+
+const meta: Meta<typeof AuthQuiz> = {
+  title: 'MDX/Auth/AuthQuiz',
+  component: AuthQuiz,
+}
+
+export default meta
+type Story = StoryObj<typeof AuthQuiz>
+
+export const Default: Story = {}

--- a/src/components/mdx/auth/ConceptCards.stories.tsx
+++ b/src/components/mdx/auth/ConceptCards.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ConceptCards } from './ConceptCards'
+
+const meta: Meta<typeof ConceptCards> = {
+  title: 'MDX/Auth/ConceptCards',
+  component: ConceptCards,
+}
+
+export default meta
+type Story = StoryObj<typeof ConceptCards>
+
+export const CoreConcepts: Story = { args: { sectionId: 'core' } }
+
+export const TokenConcepts: Story = { args: { sectionId: 'tokens' } }

--- a/src/components/mdx/auth/JwtParts.stories.tsx
+++ b/src/components/mdx/auth/JwtParts.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { JwtParts } from './JwtParts'
+
+const meta: Meta<typeof JwtParts> = {
+  title: 'MDX/Auth/JwtParts',
+  component: JwtParts,
+}
+
+export default meta
+type Story = StoryObj<typeof JwtParts>
+
+export const Default: Story = {}

--- a/src/components/mdx/auth/OAuthFlow.stories.tsx
+++ b/src/components/mdx/auth/OAuthFlow.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { OAuthFlow } from './OAuthFlow'
+
+const meta: Meta<typeof OAuthFlow> = {
+  title: 'MDX/Auth/OAuthFlow',
+  component: OAuthFlow,
+}
+
+export default meta
+type Story = StoryObj<typeof OAuthFlow>
+
+export const Default: Story = {}

--- a/src/components/mdx/auth/SecurityThreats.stories.tsx
+++ b/src/components/mdx/auth/SecurityThreats.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { SecurityThreats } from './SecurityThreats'
+
+const meta: Meta<typeof SecurityThreats> = {
+  title: 'MDX/Auth/SecurityThreats',
+  component: SecurityThreats,
+}
+
+export default meta
+type Story = StoryObj<typeof SecurityThreats>
+
+export const Default: Story = {}

--- a/src/components/mdx/ci-cd/GotchaAccordion.stories.tsx
+++ b/src/components/mdx/ci-cd/GotchaAccordion.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { GotchaAccordion } from './GotchaAccordion'
+
+const meta: Meta<typeof GotchaAccordion> = {
+  title: 'MDX/CI-CD/GotchaAccordion',
+  component: GotchaAccordion,
+}
+
+export default meta
+type Story = StoryObj<typeof GotchaAccordion>
+
+export const Default: Story = {}

--- a/src/components/mdx/ci-cd/PatternCards.stories.tsx
+++ b/src/components/mdx/ci-cd/PatternCards.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { PatternCards } from './PatternCards'
+
+const meta: Meta<typeof PatternCards> = {
+  title: 'MDX/CI-CD/PatternCards',
+  component: PatternCards,
+}
+
+export default meta
+type Story = StoryObj<typeof PatternCards>
+
+export const Default: Story = {}

--- a/src/components/mdx/ci-cd/PipelineStages.stories.tsx
+++ b/src/components/mdx/ci-cd/PipelineStages.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { PipelineStages } from './PipelineStages'
+
+const meta: Meta<typeof PipelineStages> = {
+  title: 'MDX/CI-CD/PipelineStages',
+  component: PipelineStages,
+}
+
+export default meta
+type Story = StoryObj<typeof PipelineStages>
+
+export const Default: Story = {}

--- a/src/components/mdx/ci-cd/YamlExplorer.stories.tsx
+++ b/src/components/mdx/ci-cd/YamlExplorer.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { YamlExplorer } from './YamlExplorer'
+
+const meta: Meta<typeof YamlExplorer> = {
+  title: 'MDX/CI-CD/YamlExplorer',
+  component: YamlExplorer,
+}
+
+export default meta
+type Story = StoryObj<typeof YamlExplorer>
+
+export const Default: Story = {}

--- a/src/components/mdx/npm-package/CILayout.stories.tsx
+++ b/src/components/mdx/npm-package/CILayout.stories.tsx
@@ -1,0 +1,90 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import {
+  CIStep, CIStepText, CIYaml, YamlHeading, CITip,
+  CIOverviewCards, CIOverviewCard, CIFullExample,
+  AiPromptsAccordion, MaintenanceTool, GoodTestsList,
+} from './CILayout'
+
+const meta: Meta = {
+  title: 'MDX/NPM Package/CILayout',
+}
+
+export default meta
+
+export const ComposedCIStep: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 720 }}>
+      <CIStep heading="Install Dependencies" id="toc-install">
+        <CIStepText>
+          Install all project dependencies before running any CI checks.
+        </CIStepText>
+        <YamlHeading />
+        <CIYaml>
+          {'- name: Install\n  run: npm ci'}
+        </CIYaml>
+        <CITip>
+          Use <code>npm ci</code> instead of <code>npm install</code> for deterministic builds.
+        </CITip>
+      </CIStep>
+    </div>
+  ),
+}
+
+export const OverviewCards: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 720 }}>
+      <CIOverviewCards>
+        <CIOverviewCard num={1} title="Lint" yaml="run: npm run lint" />
+        <CIOverviewCard num={2} title="Test" yaml="run: npm test" />
+        <CIOverviewCard num={3} title="Build" />
+      </CIOverviewCards>
+    </div>
+  ),
+}
+
+export const FullExample: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 720 }}>
+      <CIFullExample>
+        {'name: CI\non:\n  push:\n    branches: [main]\njobs:\n  build:\n    runs-on: ubuntu-latest\n    steps:\n      - uses: actions/checkout@v4\n      - run: npm ci\n      - run: npm test\n      - run: npm run build'}
+      </CIFullExample>
+    </div>
+  ),
+}
+
+export const AiPrompts: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 720 }}>
+      <AiPromptsAccordion prompts={[
+        { label: 'Write unit tests', prompt: 'Write unit tests for the UserService class covering all public methods.' },
+        { label: 'Add integration test', prompt: 'Write an integration test that verifies the user creation flow end-to-end.' },
+      ]} />
+    </div>
+  ),
+}
+
+export const MaintenanceToolExample: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 720 }}>
+      <MaintenanceTool
+        name="Renovate"
+        emoji={'\u{1F916}'}
+        desc={<>Automated dependency update tool that creates PRs for outdated packages.</>}
+        why={<>Keeps dependencies secure and up-to-date without manual tracking.</>}
+        yaml={'- name: Renovate\n  uses: renovatebot/github-action@v40'}
+      />
+    </div>
+  ),
+}
+
+export const GoodTestsListExample: StoryObj = {
+  render: () => (
+    <div style={{ maxWidth: 720 }}>
+      <GoodTestsList>
+        <li>Tests pass in CI consistently</li>
+        <li>Tests are independent of each other</li>
+        <li>Tests run in under 5 minutes total</li>
+      </GoodTestsList>
+    </div>
+  ),
+}

--- a/src/components/mdx/npm-package/PublishChecklist.stories.tsx
+++ b/src/components/mdx/npm-package/PublishChecklist.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { PublishChecklist } from './PublishChecklist'
+
+const meta: Meta<typeof PublishChecklist> = {
+  title: 'MDX/NPM Package/PublishChecklist',
+  component: PublishChecklist,
+}
+
+export default meta
+type Story = StoryObj<typeof PublishChecklist>
+
+export const Default: Story = {}

--- a/src/components/mdx/npm-package/RoadmapSteps.stories.tsx
+++ b/src/components/mdx/npm-package/RoadmapSteps.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { RoadmapSteps } from './RoadmapSteps'
+import { withRouter } from '../../../../.storybook/decorators'
+
+const meta: Meta = {
+  title: 'MDX/NPM Package/RoadmapSteps',
+  decorators: [withRouter],
+}
+
+export default meta
+
+export const Default: StoryObj = {
+  render: () => <RoadmapSteps />,
+}

--- a/src/components/mdx/prompt-engineering/CLIReference.stories.tsx
+++ b/src/components/mdx/prompt-engineering/CLIReference.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CLIReference } from './CLIReference'
+
+const meta: Meta<typeof CLIReference> = {
+  title: 'MDX/Prompt Engineering/CLIReference',
+  component: CLIReference,
+}
+
+export default meta
+type Story = StoryObj<typeof CLIReference>
+
+export const Default: Story = {}

--- a/src/components/mdx/prompt-engineering/ClaudeMdChecklist.stories.tsx
+++ b/src/components/mdx/prompt-engineering/ClaudeMdChecklist.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ClaudeMdChecklist } from './ClaudeMdChecklist'
+
+const meta: Meta<typeof ClaudeMdChecklist> = {
+  title: 'MDX/Prompt Engineering/ClaudeMdChecklist',
+  component: ClaudeMdChecklist,
+}
+
+export default meta
+type Story = StoryObj<typeof ClaudeMdChecklist>
+
+export const Default: Story = {}

--- a/src/components/mdx/prompt-engineering/CodingToolExplorer.stories.tsx
+++ b/src/components/mdx/prompt-engineering/CodingToolExplorer.stories.tsx
@@ -1,0 +1,12 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { CodingToolExplorer } from './CodingToolExplorer'
+
+const meta: Meta<typeof CodingToolExplorer> = {
+  title: 'MDX/Prompt Engineering/CodingToolExplorer',
+  component: CodingToolExplorer,
+}
+
+export default meta
+type Story = StoryObj<typeof CodingToolExplorer>
+
+export const Default: Story = {}

--- a/src/components/mdx/prompt-engineering/MetaTooling.stories.tsx
+++ b/src/components/mdx/prompt-engineering/MetaTooling.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MetaTooling } from './MetaTooling'
+
+const meta: Meta<typeof MetaTooling> = {
+  title: 'MDX/Prompt Engineering/MetaTooling',
+  component: MetaTooling,
+}
+
+export default meta
+type Story = StoryObj<typeof MetaTooling>
+
+export const CIIntegration: Story = { args: { toolId: 'ci-integration' } }
+
+export const PromptVersioning: Story = { args: { toolId: 'prompt-versioning' } }

--- a/src/components/mdx/prompt-engineering/MistakeList.stories.tsx
+++ b/src/components/mdx/prompt-engineering/MistakeList.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { MistakeList } from './MistakeList'
+
+const meta: Meta<typeof MistakeList> = {
+  title: 'MDX/Prompt Engineering/MistakeList',
+  component: MistakeList,
+}
+
+export default meta
+type Story = StoryObj<typeof MistakeList>
+
+export const Logic: Story = { args: { categoryId: 'logic' } }
+
+export const APIs: Story = { args: { categoryId: 'apis' } }
+
+export const Structural: Story = { args: { categoryId: 'structural' } }

--- a/src/components/mdx/prompt-engineering/TechniqueDetail.stories.tsx
+++ b/src/components/mdx/prompt-engineering/TechniqueDetail.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TechniqueDetail } from './TechniqueDetail'
+
+const meta: Meta<typeof TechniqueDetail> = {
+  title: 'MDX/Prompt Engineering/TechniqueDetail',
+  component: TechniqueDetail,
+}
+
+export default meta
+type Story = StoryObj<typeof TechniqueDetail>
+
+export const ClaudeMd: Story = { args: { techniqueId: 'claude-md' } }
+
+export const FewShot: Story = { args: { techniqueId: 'few-shot' } }

--- a/src/components/mdx/prompt-engineering/TestingMistakes.stories.tsx
+++ b/src/components/mdx/prompt-engineering/TestingMistakes.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TestingMistakes } from './TestingMistakes'
+
+const meta: Meta<typeof TestingMistakes> = {
+  title: 'MDX/Prompt Engineering/TestingMistakes',
+  component: TestingMistakes,
+}
+
+export default meta
+type Story = StoryObj<typeof TestingMistakes>
+
+export const AllMistakes: Story = {}
+
+export const E2EOnly: Story = { args: { context: 'e2e' } }
+
+export const UnitOnly: Story = { args: { context: 'unit' } }

--- a/src/components/mdx/prompt-engineering/ToolDetail.stories.tsx
+++ b/src/components/mdx/prompt-engineering/ToolDetail.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { ToolDetail } from './ToolDetail'
+
+const meta: Meta<typeof ToolDetail> = {
+  title: 'MDX/Prompt Engineering/ToolDetail',
+  component: ToolDetail,
+}
+
+export default meta
+type Story = StoryObj<typeof ToolDetail>
+
+export const MCPServers: Story = { args: { toolId: 'mcp-servers' } }
+
+export const Skills: Story = { args: { toolId: 'skills' } }

--- a/src/components/mdx/testing/TestPracticeCards.stories.tsx
+++ b/src/components/mdx/testing/TestPracticeCards.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TestPracticeCards } from './TestPracticeCards'
+
+const meta: Meta<typeof TestPracticeCards> = {
+  title: 'MDX/Testing/TestPracticeCards',
+  component: TestPracticeCards,
+}
+
+export default meta
+type Story = StoryObj<typeof TestPracticeCards>
+
+export const DoCards: Story = { args: { type: 'do' } }
+
+export const DontCards: Story = { args: { type: 'dont' } }

--- a/src/components/mdx/testing/TestTypeDetail.stories.tsx
+++ b/src/components/mdx/testing/TestTypeDetail.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TestTypeDetail } from './TestTypeDetail'
+
+const meta: Meta<typeof TestTypeDetail> = {
+  title: 'MDX/Testing/TestTypeDetail',
+  component: TestTypeDetail,
+}
+
+export default meta
+type Story = StoryObj<typeof TestTypeDetail>
+
+export const Unit: Story = { args: { type: 'unit' } }
+
+export const Component: Story = { args: { type: 'component' } }
+
+export const E2E: Story = { args: { type: 'e2e' } }

--- a/src/components/mdx/testing/TestingPyramid.stories.tsx
+++ b/src/components/mdx/testing/TestingPyramid.stories.tsx
@@ -1,0 +1,14 @@
+import type { Meta, StoryObj } from '@storybook/react-vite'
+import { TestingPyramid } from './TestingPyramid'
+import { withRouter } from '../../../../.storybook/decorators'
+
+const meta: Meta = {
+  title: 'MDX/Testing/TestingPyramid',
+  decorators: [withRouter],
+}
+
+export default meta
+
+export const Default: StoryObj = {
+  render: () => <TestingPyramid />,
+}


### PR DESCRIPTION
## Summary
This PR adds comprehensive Storybook stories for MDX components across multiple feature areas, enabling visual testing and documentation of component behavior in isolation.

## Key Changes
- **CILayout stories**: Added 6 story variants showcasing CI/CD layout components including steps, YAML blocks, overview cards, and maintenance tools
- **FnRef stories**: Added stories for single and multiple footnote references with mock context
- **Router decorator**: Created `withRouter` decorator in `.storybook/decorators.tsx` to provide TanStack Router context for components using navigation hooks
- **Navigation components**: Added stories for `NavLink`, `NavPill`, `StepJump`, and `GuideStartContent` with router decorator
- **Command component**: Added stories for `Cmd` component with npm and pnpm variants
- **Architecture components**: Added stories for framework explorers, pros/cons comparisons, and diagrams (DataFlowDiagram, LayerDiagram)
- **Auth components**: Added stories for authentication-related components (ConceptCards, AuthChecklist, AuthPatterns, AuthQuiz, JwtParts, OAuthFlow, SecurityThreats)
- **Testing components**: Added stories for test type details, practice cards, and testing pyramid
- **Prompt Engineering components**: Added stories for mistake lists, testing mistakes, technique details, tool details, meta tooling, and CLI reference
- **CI-CD components**: Added stories for pipeline stages, pattern cards, YAML explorer, and gotcha accordion
- **NPM Package components**: Added stories for roadmap steps and publish checklist

## Implementation Details
- All stories follow Storybook 7+ conventions with TypeScript support
- Components requiring router context use the new `withRouter` decorator
- Stories are organized by feature area in the Storybook hierarchy (e.g., `MDX/Architecture/`, `MDX/Auth/`)
- Added ESLint disable comment in decorators file for Storybook-specific patterns

https://claude.ai/code/session_01QQwwkUcaASoiv77fc3AGS4