### PR TITLE
Refactor checklists as standalone pages with dedicated navigation

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -1,7 +1,7 @@
 import { Command } from 'cmdk'
 import { useNavigate } from '@tanstack/react-router'
 import { getNavTitle } from '../data/navigation'
-import { guides } from '../data/guideRegistry'
+import { guides, checklistPages } from '../data/guideRegistry'
 import { glossaryTerms } from '../data/glossaryTerms'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
 import { parseTitle } from '../helpers/parseTitle'
@@ -76,6 +76,12 @@ export function CommandMenu({ open, onOpenChange }: CommandMenuProps) {
             </Command.Group>
           ))
         )}
+
+        <Command.Group heading="Checklists">
+          {checklistPages.map(cp => (
+            <PageItem key={cp.id} id={cp.id} onSelect={handleSelect} />
+          ))}
+        </Command.Group>
 
         <Command.Group heading="Resources">
           <PageItem id="external-resources" onSelect={handleSelect} />

--- a/src/components/GuidesIndexPage.tsx
+++ b/src/components/GuidesIndexPage.tsx
@@ -1,5 +1,7 @@
 import { useNavigate } from '@tanstack/react-router'
-import { guides } from '../data/guideRegistry'
+import { guides, checklistPages } from '../data/guideRegistry'
+import { getNavTitle } from '../data/navigation'
+import { parseTitle } from '../helpers/parseTitle'
 import { STORYBOOK_URL } from '../data/navigation'
 import { ExternalLinkIcon } from './ExternalLinkIcon'
 
@@ -72,6 +74,40 @@ export function GuidesIndexPage() {
           <p className="text-sm text-slate-400 dark:text-slate-500 leading-relaxed">
             Additional guides are in the works. Stay tuned!
           </p>
+        </div>
+      </div>
+
+      {/* Checklists section */}
+      <div className="mt-12">
+        <h2 className="text-xl font-bold tracking-tight mb-1 text-slate-900 dark:text-slate-100">Checklists</h2>
+        <p className="text-gray-500 dark:text-slate-400 text-sm mb-5">
+          Implementation checklists extracted from individual guides.
+        </p>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          {checklistPages.map((cp) => {
+            const title = getNavTitle(cp.id)
+            const { text, icon } = parseTitle(title)
+            return (
+              <button
+                key={cp.id}
+                className="flex flex-col items-start text-left p-5 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl cursor-pointer transition-all duration-150 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 hover:-translate-y-0.5"
+                onClick={() =>
+                  navigate({
+                    to: '/$sectionId',
+                    params: { sectionId: cp.id },
+                  })
+                }
+              >
+                <span className="text-2xl mb-2">{icon}</span>
+                <h3 className="text-base font-bold text-slate-900 dark:text-slate-100 mb-1">
+                  {text}
+                </h3>
+                <p className="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
+                  From the {guides.find(g => g.id === cp.sourceGuideId)?.title ?? cp.sourceGuideId} guide.
+                </p>
+              </button>
+            )
+          })}
         </div>
       </div>
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { useParams, Link } from '@tanstack/react-router'
 import clsx from 'clsx'
-import { guides, getGuideForPage, type GuideDefinition } from '../data/guideRegistry'
+import { guides, getGuideForPage, checklistsNavDef, type GuideDefinition } from '../data/guideRegistry'
 import { getNavTitle } from '../data/navigation'
 import { useNavigateToSection } from '../hooks/useNavigateToSection'
 import { STORYBOOK_URL } from '../data/navigation'
@@ -117,6 +117,16 @@ function IconRail({
 
       {/* Spacer pushes resource icons + settings to bottom */}
       <div className="mt-auto" />
+
+      {/* Checklists icon */}
+      <button
+        className={clsx(iconBtnCls, activeGuideId === 'checklists' ? activeCls : inactiveCls)}
+        onClick={() => onSelectGuide('checklists')}
+        data-testid="sidebar-icon-checklists"
+      >
+        <span className="text-lg leading-none">{'\u2705'}</span>
+        <span className={tooltipCls}>Checklists</span>
+      </button>
 
       {/* Resource icons */}
       <button
@@ -409,7 +419,9 @@ export function Sidebar({ open, onClose, pinned, onTogglePin, onActiveGuideChang
     }
   }
 
-  const activeGuide = guides.find(g => g.id === activeGuideId) ?? null
+  const activeGuide = activeGuideId === 'checklists'
+    ? checklistsNavDef
+    : guides.find(g => g.id === activeGuideId) ?? null
   const hasExpandedPanel = activeGuide !== null || showSettings
 
   // Notify parent when expanded panel state changes (for layout margin adjustments)

--- a/src/components/mdx/auth/AuthChecklist.tsx
+++ b/src/components/mdx/auth/AuthChecklist.tsx
@@ -1,9 +1,8 @@
 import { useState } from 'react'
-import { useIsDark } from '../../../hooks/useTheme'
+import clsx from 'clsx'
 import { AUTH_CHECKLIST_ITEMS } from '../../../data/authData'
 
 export function AuthChecklist() {
-  const isDark = useIsDark()
   const [checked, setChecked] = useState<Set<number>>(new Set())
 
   const toggle = (idx: number) => {
@@ -21,10 +20,7 @@ export function AuthChecklist() {
     <div className="mb-7">
       {categories.map(cat => (
         <div key={cat} className="mb-5">
-          <h4
-            className="text-xs font-semibold uppercase tracking-wider mb-2.5 mt-0"
-            style={{ color: '#6366f1' }}
-          >
+          <h4 className="text-xs font-semibold uppercase tracking-wider mb-2.5 mt-0 text-indigo-500">
             {cat}
           </h4>
           {AUTH_CHECKLIST_ITEMS.map((item, idx) => ({ ...item, idx }))
@@ -35,34 +31,30 @@ export function AuthChecklist() {
                 <button
                   key={it.idx}
                   onClick={() => toggle(it.idx)}
-                  className="flex items-start gap-3 w-full p-2.5 mb-1 rounded-lg border text-left cursor-pointer transition-colors"
-                  style={{
-                    background: isChecked
-                      ? (isDark ? '#052e1622' : '#f0fdf4')
-                      : (isDark ? '#1e293b' : '#ffffff'),
-                    borderColor: isChecked
-                      ? (isDark ? '#22c55e33' : '#bbf7d0')
-                      : (isDark ? '#334155' : '#e2e8f0'),
-                  }}
+                  className={clsx(
+                    'flex items-start gap-3 w-full p-2.5 mb-1 rounded-lg border text-left cursor-pointer transition-colors',
+                    isChecked
+                      ? 'bg-green-50 dark:bg-green-950/20 border-green-200 dark:border-green-500/20'
+                      : 'bg-white dark:bg-slate-800 border-slate-200 dark:border-slate-700',
+                  )}
                 >
                   <span
-                    className="w-5 h-5 rounded shrink-0 mt-0.5 flex items-center justify-center text-xs font-bold"
-                    style={{
-                      border: isChecked ? 'none' : `2px solid ${isDark ? '#475569' : '#94a3b8'}`,
-                      background: isChecked ? '#22c55e' : 'transparent',
-                      color: '#ffffff',
-                    }}
+                    className={clsx(
+                      'w-5 h-5 rounded shrink-0 mt-0.5 flex items-center justify-center text-xs font-bold',
+                      isChecked
+                        ? 'bg-green-500 text-white border-0'
+                        : 'bg-transparent border-2 border-slate-400 dark:border-slate-600',
+                    )}
                   >
-                    {isChecked && '✓'}
+                    {isChecked && '\u2713'}
                   </span>
                   <span
-                    className="text-sm leading-relaxed"
-                    style={{
-                      color: isChecked
-                        ? '#22c55e'
-                        : (isDark ? '#94a3b8' : '#64748b'),
-                      textDecoration: isChecked ? 'line-through' : 'none',
-                    }}
+                    className={clsx(
+                      'text-sm leading-relaxed',
+                      isChecked
+                        ? 'text-green-500 line-through'
+                        : 'text-slate-500 dark:text-slate-400',
+                    )}
                   >
                     {it.text}
                   </span>
@@ -73,21 +65,12 @@ export function AuthChecklist() {
       ))}
 
       {/* Progress bar */}
-      <div
-        className="text-sm mt-3"
-        style={{ color: isDark ? '#64748b' : '#94a3b8' }}
-      >
+      <div className="text-sm mt-3 text-slate-400 dark:text-slate-500">
         {checked.size}/{AUTH_CHECKLIST_ITEMS.length} complete
-        <div
-          className="h-1 rounded-sm mt-2 overflow-hidden"
-          style={{ background: isDark ? '#334155' : '#e2e8f0' }}
-        >
+        <div className="h-2 rounded-full mt-2 overflow-hidden bg-slate-200 dark:bg-slate-700">
           <div
-            className="h-full rounded-sm transition-all duration-300"
-            style={{
-              width: `${(checked.size / AUTH_CHECKLIST_ITEMS.length) * 100}%`,
-              background: '#22c55e',
-            }}
+            className="h-full rounded-full transition-all duration-300 bg-green-500"
+            style={{ width: `${(checked.size / AUTH_CHECKLIST_ITEMS.length) * 100}%` }}
           />
         </div>
       </div>

--- a/src/content/auth/auth-checklist.mdx
+++ b/src/content/auth/auth-checklist.mdx
@@ -11,6 +11,8 @@ linkRefs:
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
+<NavPill to="auth-start">Back to Start Here</NavPill>
+
 <Toc>
   <TocLink id="toc-checklist">Your Auth Implementation Checklist</TocLink>
 </Toc>

--- a/src/content/prompt-engineering/prompt-claudemd-checklist.mdx
+++ b/src/content/prompt-engineering/prompt-claudemd-checklist.mdx
@@ -14,6 +14,8 @@ linkRefs:
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
+<NavPill to="prompt-start">Back to Start Here</NavPill>
+
 <SectionIntro>
 A comprehensive checklist of items to include in your project&rsquo;s CLAUDE.md<FnRef n={1} /> file. Check off each item as you add it &mdash; a well-maintained CLAUDE.md dramatically reduces AI mistakes by giving the model persistent context about your project.
 </SectionIntro>

--- a/src/content/sections/checklist.mdx
+++ b/src/content/sections/checklist.mdx
@@ -4,4 +4,6 @@ title: "Publish Checklist ✅"
 guide: "npm-package"
 ---
 
+<NavPill to="roadmap">Back to Start Here</NavPill>
+
 <PublishChecklist />

--- a/src/content/testing/test-review-checklist.mdx
+++ b/src/content/testing/test-review-checklist.mdx
@@ -14,6 +14,8 @@ linkRefs:
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
+<NavPill to="test-start">Back to Start Here</NavPill>
+
 <Toc>
   <TocLink id="toc-checklist">Review checklist</TocLink>
   <TocLink id="toc-explainer">How to use this checklist</TocLink>

--- a/src/data/archData/navigation.ts
+++ b/src/data/archData/navigation.ts
@@ -60,6 +60,25 @@ export const ARCH_START_PAGE_DATA: StartPageData = {
       description: 'Trace a user action through every layer of the stack \u2014 from button click to database query and back to the screen.',
       jumpTo: 'arch-how-it-connects',
     },
+    {
+      type: 'bonus',
+      title: 'Resources',
+      description: 'Documentation, articles, and tools for deeper learning about web architecture.',
+      customSubItems: [
+        {
+          title: '\u{1F4DA} External Resources',
+          description: 'Curated documentation, articles, and tools \u2014 filtered for the Architecture Guide.',
+          jumpTo: 'external-resources',
+          jumpType: 'guide-filter',
+        },
+        {
+          title: '\u{1F4D6} Glossary',
+          description: 'Key architecture and web development terms, with links to guide pages.',
+          jumpTo: 'glossary',
+          jumpType: 'guide-filter',
+        },
+      ],
+    },
   ],
 }
 

--- a/src/data/authData/navigation.ts
+++ b/src/data/authData/navigation.ts
@@ -5,7 +5,7 @@ export const AUTH_GUIDE_SECTIONS: GuideSection[] = [
   { label: null, ids: ['auth-start'] },
   { label: 'Foundations', ids: ['auth-core', 'auth-tokens', 'auth-jwt'] },
   { label: 'Protocols & Patterns', ids: ['auth-oauth', 'auth-frontend'] },
-  { label: 'Security & Review', ids: ['auth-security', 'auth-checklist', 'auth-quiz'] },
+  { label: 'Security & Review', ids: ['auth-security', 'auth-quiz'] },
 ]
 
 // ── Start page data ──────────────────────────────────────────────────
@@ -56,9 +56,32 @@ export const AUTH_START_PAGE_DATA: StartPageData = {
       sectionLabel: 'Security & Review',
       subItemDescriptions: {
         'auth-security': 'XSS, CSRF, token theft, and open redirects \u2014 the attacks that target auth and how to defend against them.',
-        'auth-checklist': 'A categorized checklist covering storage, tokens, architecture, OAuth, and security best practices.',
         'auth-quiz': 'Five questions to test what you\u2019ve learned across the guide.',
       },
+    },
+    {
+      type: 'bonus',
+      title: 'Resources',
+      description: 'Checklists, documentation, and tools for authentication implementation.',
+      customSubItems: [
+        {
+          title: '\u2705 Implementation Checklist',
+          description: 'A categorized checklist covering storage, tokens, architecture, OAuth, and security best practices.',
+          jumpTo: 'auth-checklist',
+        },
+        {
+          title: '\u{1F4DA} External Resources',
+          description: 'Curated auth documentation, articles, and tools.',
+          jumpTo: 'external-resources',
+          jumpType: 'guide-filter',
+        },
+        {
+          title: '\u{1F4D6} Glossary',
+          description: 'Key authentication and authorization terms.',
+          jumpTo: 'glossary',
+          jumpType: 'guide-filter',
+        },
+      ],
     },
   ],
 }

--- a/src/data/cicdData.ts
+++ b/src/data/cicdData.ts
@@ -284,5 +284,24 @@ export const CICD_START_PAGE_DATA: StartPageData = {
       description: 'The things that trip people up: npm ci vs install, YAML indentation, fork PR secrets, and more.',
       jumpTo: 'cicd-gotchas',
     },
+    {
+      type: 'bonus',
+      title: 'Resources',
+      description: 'Documentation and tools for CI/CD and GitHub Actions.',
+      customSubItems: [
+        {
+          title: '\u{1F4DA} External Resources',
+          description: 'Curated CI/CD documentation, articles, and tools.',
+          jumpTo: 'external-resources',
+          jumpType: 'guide-filter',
+        },
+        {
+          title: '\u{1F4D6} Glossary',
+          description: 'Key CI/CD and GitHub Actions terms.',
+          jumpTo: 'glossary',
+          jumpType: 'guide-filter',
+        },
+      ],
+    },
   ],
 }

--- a/src/data/guideRegistry.ts
+++ b/src/data/guideRegistry.ts
@@ -67,6 +67,24 @@ export const guides: GuideDefinition[] = [
   },
 ]
 
+// ── Checklists (extracted from individual guides) ───────────────────
+
+export const checklistPages = [
+  { id: 'checklist', sourceGuideId: 'npm-package' },
+  { id: 'test-review-checklist', sourceGuideId: 'testing' },
+  { id: 'prompt-claudemd-checklist', sourceGuideId: 'prompt-engineering' },
+  { id: 'auth-checklist', sourceGuideId: 'auth' },
+]
+
+export const checklistsNavDef: GuideDefinition = {
+  id: 'checklists',
+  icon: '\u2705',        // ✅
+  title: 'Checklists',
+  startPageId: 'checklist',
+  description: 'Implementation checklists from all guides.',
+  sections: [{ label: null, ids: checklistPages.map(p => p.id) }],
+}
+
 // ── Derived lookups ─────────────────────────────────────────────────
 
 const pageToGuide = new Map<string, string>()
@@ -79,9 +97,14 @@ for (const guide of guides) {
 }
 // Legacy route: #/architecture renders ArchStartPage
 pageToGuide.set('architecture', 'architecture')
+// Checklist pages map to the checklists nav def for sidebar auto-sync
+for (const cp of checklistPages) {
+  pageToGuide.set(cp.id, 'checklists')
+}
 
 export function getGuideForPage(pageId: string): GuideDefinition | undefined {
   const guideId = pageToGuide.get(pageId)
+  if (guideId === 'checklists') return checklistsNavDef
   return guideId ? guides.find(g => g.id === guideId) : undefined
 }
 

--- a/src/data/npmPackageData.ts
+++ b/src/data/npmPackageData.ts
@@ -11,7 +11,6 @@ export const NPM_GUIDE_SECTIONS: GuideSection[] = [
     'ci-overview', 'ci-linting', 'ci-build', 'ci-testing', 'ci-repo-maintenance',
   ]},
   { label: 'Developer Experience', ids: ['storybook'] },
-  { label: 'Learning Resources', ids: ['checklist'] },
 ]
 
 // ── Start page data ──────────────────────────────────────────────────
@@ -58,7 +57,7 @@ export const NPM_START_PAGE_DATA: StartPageData = {
     },
     {
       type: 'bonus',
-      title: 'Bonus: Learning Resources',
+      title: 'Resources',
       description: 'Documentation, articles, courses, and tools to go deeper on frontend development, npm packages, and the JavaScript ecosystem.',
       customSubItems: [
         {

--- a/src/data/promptData/navigation.ts
+++ b/src/data/promptData/navigation.ts
@@ -75,7 +75,6 @@ export const PROMPT_GUIDE_SECTIONS: GuideSection[] = [
   { label: 'Context Management', ids: [
     'prompt-ctx-system-prompt', 'prompt-ctx-claude-md', 'prompt-ctx-chaining',
     'prompt-ctx-few-shot', 'prompt-ctx-window', 'prompt-ctx-thinking',
-    'prompt-claudemd-checklist',
   ]},
   { label: 'Tooling & Reference', ids: [
     'prompt-coding-tools', 'prompt-cli-reference', 'prompt-meta-tooling',
@@ -122,7 +121,6 @@ export const PROMPT_START_PAGE_DATA: StartPageData = {
         'prompt-ctx-few-shot': 'Show 2\u20133 examples of desired output to establish a clear pattern.',
         'prompt-ctx-window': 'Keep your context lean and high-signal for better model performance.',
         'prompt-ctx-thinking': 'Ask the model to reason step-by-step before acting.',
-        'prompt-claudemd-checklist': 'A comprehensive checklist for building effective CLAUDE.md files.',
       },
     },
     {
@@ -161,6 +159,30 @@ export const PROMPT_START_PAGE_DATA: StartPageData = {
         'prompt-tools-hooks': 'Automate workflows with event-driven shell command hooks.',
         'prompt-tools-optimization': 'Headless mode, batch processing, and context management strategies.',
       },
+    },
+    {
+      type: 'bonus',
+      title: 'Resources',
+      description: 'Checklists, documentation, and reference material for AI-assisted development.',
+      customSubItems: [
+        {
+          title: '\u2705 CLAUDE.md Checklist',
+          description: 'A comprehensive checklist for building effective CLAUDE.md files.',
+          jumpTo: 'prompt-claudemd-checklist',
+        },
+        {
+          title: '\u{1F4DA} External Resources',
+          description: 'Curated prompt engineering documentation, articles, and tools.',
+          jumpTo: 'external-resources',
+          jumpType: 'guide-filter',
+        },
+        {
+          title: '\u{1F4D6} Glossary',
+          description: 'Key prompt engineering and AI coding tool terms.',
+          jumpTo: 'glossary',
+          jumpType: 'guide-filter',
+        },
+      ],
     },
   ],
 }

--- a/src/data/testingData.ts
+++ b/src/data/testingData.ts
@@ -303,7 +303,7 @@ export const TESTING_GUIDE_SECTIONS: GuideSection[] = [
   { label: null, ids: ['test-start'] },
   { label: 'Testing Fundamentals', ids: ['test-overview', 'test-unit', 'test-component', 'test-e2e'] },
   { label: 'Comparing Tests', ids: ['test-comparison', 'test-best-practices'] },
-  { label: 'Checklists & Tools', ids: ['test-review-checklist', 'test-tools'] },
+  { label: 'Reference', ids: ['test-tools'] },
 ]
 
 // ── Start page data ──────────────────────────────────────────────────
@@ -356,6 +356,30 @@ export const TESTING_START_PAGE_DATA: StartPageData = {
       title: 'Popular Tools',
       description: 'A filterable directory of the most popular testing tools in the React ecosystem, with guidance on when to use each one.',
       jumpTo: 'test-tools',
+    },
+    {
+      type: 'bonus',
+      title: 'Resources',
+      description: 'Checklists, documentation, and tools for frontend testing.',
+      customSubItems: [
+        {
+          title: '\u2705 Quick Test Review',
+          description: 'An interactive checklist for reviewing test code in pull requests.',
+          jumpTo: 'test-review-checklist',
+        },
+        {
+          title: '\u{1F4DA} External Resources',
+          description: 'Curated testing documentation, articles, and tools.',
+          jumpTo: 'external-resources',
+          jumpType: 'guide-filter',
+        },
+        {
+          title: '\u{1F4D6} Glossary',
+          description: 'Key testing terms and tool definitions.',
+          jumpTo: 'glossary',
+          jumpType: 'guide-filter',
+        },
+      ],
     },
   ],
 }


### PR DESCRIPTION
## Summary
This PR restructures checklists across all guides (auth, testing, prompt engineering, npm package) as standalone, independently navigable pages rather than embedded guide sections. A new "Checklists" hub is added to the sidebar, and checklists are promoted to the start page "Resources" section of each guide.

## Key Changes

**Checklist Architecture**
- Created `checklistPages` array and `checklistsNavDef` in `guideRegistry.ts` to define checklists as a separate navigable collection
- Removed checklist pages from individual guide section definitions (e.g., `auth-security`, `prompt-ctx-window`, `test-comparison`)
- Updated `getGuideForPage()` to map checklist page IDs to the new `checklistsNavDef`

**Navigation & UI**
- Added "Checklists" icon button to sidebar icon rail with tooltip
- Updated sidebar logic to recognize and display the checklists nav definition
- Added checklists group to command menu for quick access
- Moved checklists to a new "Resources" bonus section in each guide's start page data (auth, testing, prompt engineering, architecture, CI/CD, npm package)

**Component Refactoring**
- Refactored `AuthChecklist.tsx` to use Tailwind CSS classes with `clsx` instead of inline styles
- Removed `useIsDark()` hook dependency; dark mode now handled via Tailwind's `dark:` prefix
- Improved checkbox styling with semantic color classes (`bg-green-50`, `border-green-200`, etc.)
- Enhanced progress bar with rounded corners and better visual hierarchy

**Content Updates**
- Added "Back to Start Here" navigation pills to all checklist pages for easier navigation back to guide start pages
- Updated guide section definitions to remove checklist references from main content flow

## Implementation Details
- Checklists maintain their source guide association via `sourceGuideId` for context in the checklists hub
- The new "Resources" bonus section in start pages includes checklists alongside external resources and glossary
- Sidebar auto-sync works by mapping checklist page IDs to the checklists guide definition
- All styling changes use Tailwind's dark mode utilities for consistent theme support

https://claude.ai/code/session_01DrdWN8iUQENKxna4u18HpR