### PR TITLE
Extract add-guide skill from CLAUDE.md and condense root docs

### DIFF
--- a/.claude/skills/add-guide/SKILL.md
+++ b/.claude/skills/add-guide/SKILL.md
@@ -1,0 +1,173 @@
+---
+description: Convert a Claude artifact into a multi-page MDX guide with data files, interactive components, glossary terms, and link registry entries. Covers the full 9-step workflow, MDX and component templates, glossary editorial guidance, and common pitfalls.
+---
+
+# Adding a New Guide
+
+Claude artifacts are typically monolithic JSX or HTML files with embedded data and inline styles. Every guide in this app originates as a Claude artifact. This skill describes how to decompose an artifact into the multi-page MDX architecture used by this app. The Architecture Guide conversion is the canonical example: the original single-component `ArchitecturePage.tsx` (504 lines) was split into 8 MDX pages, 4 interactive components, and a centralized data file.
+
+> For conventions referenced below (link registry format, MDX frontmatter fields, dark mode helper, navigation formatting), see root `CLAUDE.md`.
+
+## Conversion steps
+
+| Step | Action | Files |
+|------|--------|-------|
+| 1. Identify content boundaries | Find natural page breaks in the monolithic component. Each distinct topic or section heading becomes its own MDX page. | (analysis only) |
+| 2. Create data file | Move inline constants, arrays, and objects into a new typed `.ts` file. Define TypeScript interfaces for data shapes. Import `GuideSection` from `src/data/guideTypes.ts`. Export `<GUIDE>_GUIDE_SECTIONS: GuideSection[]` with labeled section groups. | `src/data/<guide>Data.ts` |
+| 3. Register the guide | Import `<GUIDE>_GUIDE_SECTIONS` from your data file. Add a new entry to the `guides` array in `src/data/guideRegistry.ts` with `id`, `icon`, `title`, `startPageId`, `description`, `sections`. | `src/data/guideRegistry.ts` |
+| 4. Create MDX content pages | One `.mdx` file per page with frontmatter (`id`, `title` with emoji suffix, `guide`). Use existing MDX components (`SectionIntro`, `Toc`, `TocLink`, `ColItem`, `Explainer`, etc.). Pages are auto-discovered by `src/content/registry.ts` — no manual import needed. | `src/content/<guide>/*.mdx` |
+| 5. Create Start page data + MDX file | Export `<GUIDE>_START_PAGE_DATA: StartPageData` from the guide's data file. Define `subtitle`, `tip`, and `steps` array with `sectionLabel` references matching the `*_GUIDE_SECTIONS` labels — this makes the learning path auto-derive sub-items from section page lists. Then create `src/content/<guide>/<start-page-id>.mdx` with frontmatter and `<GuideStartContent guideId="<guide-id>" />`. See **Start page MDX template** below. | `src/data/<guide>Data.ts`, `src/content/<guide>/<start>.mdx` |
+| 6. Register start page data | Import the `*_START_PAGE_DATA` in `src/data/guideRegistry.ts` and add it to `startPageDataMap`. The MDX file auto-routes via content registry — no `componentPages.tsx` changes needed. | `src/data/guideRegistry.ts` |
+| 7. Extract interactive components | Stateful or interactive UI (explorers, diagrams, accordions) becomes a standalone component in `src/components/mdx/<guide-id>/` that reads data from `src/data/` via a prop (e.g., `<StackExplorer stackId="mern" />`). Register it in `src/components/mdx/index.ts`. See **Interactive MDX Component Template** below. | `src/components/mdx/<guide-id>/` |
+| 8. Add glossary terms | Add relevant terms to the appropriate file in `src/data/glossaryTerms/` following the glossary conventions below. Ensure each `linkId` exists in the link registry. | `src/data/glossaryTerms/`, `src/data/linkRegistry/` |
+| 9. Verify | Run `pnpm validate` (runs `validate:data` + `lint` + `build`). This catches broken link references, invalid page headings, and TypeScript errors. | — |
+
+## MDX page template
+
+```mdx
+---
+id: "guide-page-id"
+title: "Page Title 🔹"
+guide: "guide-id"
+---
+
+<SectionTitle>{frontmatter.title}</SectionTitle>
+
+<Toc>
+  <TocLink id="toc-first">First section</TocLink>
+</Toc>
+
+<SectionIntro>
+Brief intro paragraph.
+</SectionIntro>
+
+<SectionSubheading id="toc-first">First section</SectionSubheading>
+
+<SectionList>
+<ColItem>Content here.</ColItem>
+</SectionList>
+```
+
+## Start page MDX template
+
+```mdx
+---
+id: "<guide>-start"
+title: "Start Here 🔹"
+guide: "<guide-id>"
+---
+
+<GuideStartContent guideId="<guide-id>" />
+```
+
+The `GuideStartContent` component reads `StartPageData` from `guideRegistry.ts` and renders the learning path automatically. Sub-items are auto-derived from guide sections via `sectionLabel` references. Per-item descriptions are provided via `subItemDescriptions` in the start page data. For items not derivable from sections (cross-guide links, resource page links), use `customSubItems`.
+
+## Interactive MDX Component Template
+
+Minimal template for a new interactive MDX component with dark mode support.
+
+### Component file: `src/components/mdx/<guide-id>/MyComponent.tsx`
+
+```tsx
+import { useState } from 'react'
+import { useTheme } from '../../../hooks/useTheme'
+import { ds } from '../../../helpers/darkStyle'
+import { MY_DATA } from '../../../data/myGuideData'
+import type { MyDataItem } from '../../../data/myGuideData'
+
+export function MyComponent({ itemId }: { itemId: string }) {
+  const { theme } = useTheme()
+  const isDark = theme === 'dark'
+  const [activeId, setActiveId] = useState<string | null>(null)
+
+  const item = MY_DATA.find((d: MyDataItem) => d.id === itemId)
+  if (!item) return null
+
+  return (
+    <div
+      style={{
+        background: ds(item.accent, item.darkAccent, isDark),
+        borderColor: ds(item.color, item.color, isDark),
+      }}
+      className="rounded-xl border p-6 mb-6"
+    >
+      <button onClick={() => setActiveId(activeId === itemId ? null : itemId)}>
+        {item.name}
+      </button>
+    </div>
+  )
+}
+```
+
+### Registration: `src/components/mdx/index.ts`
+
+```tsx
+import { MyComponent } from './<guide-id>/MyComponent'
+// Add to the mdxComponents object:
+MyComponent,
+```
+
+### Usage in MDX
+
+```mdx
+<MyComponent itemId="example-id" />
+```
+
+### Component conventions
+
+- Import data from `src/data/`, never inline in the component
+- Use `useTheme()` + `ds()` for dynamic inline styles with dark mode
+- Use Tailwind `dark:` variants for class-based styling
+- Data interfaces should include `darkAccent` field when components use dynamic accent colors
+- Standard dark palette: backgrounds `#1e293b`, text `#e2e8f0`, borders `#334155`
+
+## Common pitfalls
+
+- Use `className`, not `class` — MDX is JSX, not HTML.
+- Use self-closing JSX tags: `<br />`, `<img />`, not `<br>`, `<img>`.
+- Normalize inline styles and CSS classes into Tailwind utility classes. Prefer Tailwind's built-in scale over arbitrary values (e.g., use `text-sm` instead of `text-[13px]`).
+- Keep data in `src/data/`, not inline in MDX files or components.
+- Start pages use `<GuideStartContent guideId="..." />` — do not build start page layouts manually. Add `StartPageData` to the guide's data file instead.
+- Export `*_GUIDE_SECTIONS` from the data file. Register the guide in `src/data/guideRegistry.ts`.
+- Place new guide-specific interactive MDX components in `src/components/mdx/<guide-id>/`, not at the top level. Register them in `src/components/mdx/index.ts` with the subfolder import path.
+- Register any new interactive MDX components in `src/components/mdx/index.ts` or they won't be available in MDX files.
+- Interactive components with inline styles must support dark mode. Use `useTheme()` and `ds()` helper for theme-conditional values. Add `darkAccent` fields to data interfaces when components use dynamic accent colors.
+- Every MDX page `title` must end with an emoji suffix (see root CLAUDE.md **Navigation Item Formatting**).
+
+## What updates automatically
+
+- **Sidebar**: reads `guides` array from `guideRegistry.ts` — new guide appears automatically
+- **Command menu**: reads `guides` array — new guide sections appear automatically
+- **Home page**: reads `guides` array — new guide tile appears automatically
+- **Navigation (prev/next)**: derived from guide sections — works automatically
+- **Content registry**: auto-discovers new MDX files in `src/content/`
+- **Start page sub-items**: derived from guide sections via `sectionLabel` in `StartPageData` — adding/removing pages from a section automatically updates the start page learning path
+- **Start page header**: title, description, and icon read from `guideRegistry.ts` — changing them updates the start page automatically
+- **Router**: resolves MDX pages via auto-discovery and component pages via `componentPages.tsx` registry — no `router.tsx` edits needed
+
+## Glossary editorial guidance
+
+### What should be a glossary term
+
+Add a glossary entry for:
+- **Technical terms introduced or explained in a guide page** — e.g., "Tree Shaking", "Peer Dependency", "Mocking"
+- **Acronyms and abbreviations** — e.g., "ESM", "CJS", "CI", "ORM"
+- **Tools, libraries, and frameworks** referenced across guides — e.g., "Vitest", "Storybook", "Playwright"
+- **Concepts a backend engineer might not know** — the target audience is backend developers learning frontend; if a term would need a sidebar explanation, it deserves a glossary entry
+
+Do NOT add glossary entries for generic programming terms that any developer would know (e.g., "variable", "function", "loop") unless a guide gives them a specialized frontend meaning.
+
+### Category conventions
+
+Terms are grouped into `GlossaryCategory` objects. Current categories: Package Management, Dependencies, Build & Bundling, TypeScript, Package Configuration, Development Workflow, Web Architecture, Databases, Full-Stack Frameworks, Testing Fundamentals, Prompt Engineering, AI Coding Tools.
+
+When adding a new category:
+- Pick a name that describes the domain, not a specific guide (categories can span guides).
+- Add a corresponding `cat:<slug>` entry to the `badgeMap` in `src/data/overallResources.ts` so the category filter badge renders on the Glossary page. The slug convention is the category name lowercased with spaces replaced by hyphens and `&` dropped (e.g., `"Build & Bundling"` → `cat:build-bundling`).
+
+## Post-creation checklist
+
+After creating a new guide, also:
+- Add a per-guide `CLAUDE.md` in the content directory (see existing guides for template)
+- Update the Guides table in root `CLAUDE.md` with the new guide ID, title, and start page
+- Create link registry and glossary terms files for the guide

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,52 +6,32 @@ Educational single-page application (SPA) with multiple guides for backend engin
 
 ## Guides
 
-The site contains four independent guides, each with its own Start Here page, navigation order, and Previous/Next links, plus top-level resource pages shared across all guides. All guide metadata (id, icon, title, sections) is centralized in `src/data/guideRegistry.ts`.
+Eight independent guides plus top-level resource pages. All metadata centralized in `src/data/guideRegistry.ts`. Each guide has its own `CLAUDE.md` in its content directory with guide-specific audience info, section conventions, interactive component usage, and data file locations.
 
-### NPM Package Guide (`Web App vs. NPM Package`)
-- **Start page:** `roadmap` (MDX: `src/content/sections/roadmap.mdx`, data: `NPM_START_PAGE_DATA` in `src/data/npmPackageData.ts`)
-- **Content pages:** MDX files in `src/content/sections/`, `src/content/ci/`, `src/content/bonus/`
-- **Data:** `src/data/npmPackageData.ts` (`NPM_GUIDE_SECTIONS`, `NPM_START_PAGE_DATA`), `src/data/roadmapSteps.ts`
-- **Interactive MDX components:** `src/components/mdx/npm-package/` (`CILayout.tsx`, `RoadmapSteps.tsx`, `PublishChecklist.tsx`)
+| Guide ID | Title | Start Page |
+|----------|-------|------------|
+| `npm-package` | Web App vs. NPM Package | `roadmap` |
+| `architecture` | Architecture Guide | `arch-start` |
+| `testing` | Testing Guide | `test-start` |
+| `prompt-engineering` | Prompt Engineering | `prompt-start` |
+| `ci-cd` | CI/CD & GitHub Actions | `cicd-start` |
+| `auth` | Auth for Frontend Engineers | `auth-start` |
+| `kubernetes` | Kubernetes & Helm | `k8s-start` |
+| `ai-infra` | AI Infrastructure | `ai-start` |
 
-### Architecture Guide
-- **Start page:** `arch-start` (MDX: `src/content/architecture/arch-start.mdx`, data: `ARCH_START_PAGE_DATA` in `src/data/archData/navigation.ts`)
-- **Content pages:** MDX files in `src/content/architecture/`
-- **Data:** `src/data/archData/` (stacks, frameworks, layer colors, data flow, `ARCH_GUIDE_SECTIONS`, `ARCH_START_PAGE_DATA`)
-- **Interactive MDX components:** `src/components/mdx/architecture/` (`StackExplorer.tsx`, `StackProsCons.tsx`, `DataFlowDiagram.tsx`, `LayerDiagram.tsx`, `FrameworkExplorer.tsx`, `FrameworkProsCons.tsx`)
-
-### Testing Guide
-- **Start page:** `test-start` (MDX: `src/content/testing/test-start.mdx`, data: `TESTING_START_PAGE_DATA` in `src/data/testingData.ts`)
-- **Content pages:** MDX files in `src/content/testing/`
-- **Data:** `src/data/testingData.ts` (pyramid levels, comparison rows, practice cards, `TESTING_GUIDE_SECTIONS`, `TESTING_START_PAGE_DATA`)
-- **Interactive MDX components:** `src/components/mdx/testing/` (`TestingPyramid.tsx`, `TestTypeDetail.tsx`, `TestPracticeCards.tsx`, `TestChecklist.tsx`, `TestToolsGrid.tsx`)
-
-### Prompt Engineering Guide
-- **Start page:** `prompt-start` (MDX: `src/content/prompt-engineering/prompt-start.mdx`, data: `PROMPT_START_PAGE_DATA` in `src/data/promptData/navigation.ts`)
-- **Content pages:** MDX files in `src/content/prompt-engineering/`
-- **Data:** `src/data/promptData/` (mistakes, techniques, CLI reference, `PROMPT_GUIDE_SECTIONS`, `PROMPT_START_PAGE_DATA`)
-- **Interactive MDX components:** `src/components/mdx/prompt-engineering/` (`MistakeList.tsx`, `TechniqueDetail.tsx`, `CLIReference.tsx`, `TestingMistakes.tsx`, `ClaudeMdChecklist.tsx`, `ToolDetail.tsx`, `MetaTooling.tsx`)
+Each guide follows the same structure:
+- **Data:** `src/data/<guideId>Data.ts` (or `src/data/<guideId>Data/` directory)
+- **Content pages:** `src/content/<guide-id>/*.mdx`
+- **Interactive components:** `src/components/mdx/<guide-id>/`
+- **Glossary terms:** `src/data/glossaryTerms/<guideId>Terms.ts`
+- **Link registry:** `src/data/linkRegistry/<guideId>Links.ts`
+- **Guide-specific docs:** `src/content/<guide-id>/CLAUDE.md`
 
 ### Top-Level Resources
-- **External Resources** (`src/components/ExternalResourcesPage.tsx`) — searchable, filterable table of documentation, articles, courses, and tools. Tagged with Guide, Type, and Topic filters. Data in `src/data/overallResources.ts`.
+- **External Resources** (`src/components/ExternalResourcesPage.tsx`) — searchable, filterable table. Data in `src/data/overallResources.ts`.
 - **Glossary** (`src/components/GlossaryPage.tsx`) — searchable glossary with Guide and Category filters. Data in `src/data/glossaryTerms/`.
-- Both pages support a `?guide=` URL search param to pre-select a guide filter (e.g., `/#/glossary?guide=npm-package`). The Glossary also supports `?search=` to prefill the search bar (used by CMD-K glossary term navigation). Links from within guides use these params to show guide-relevant content by default.
-- These pages appear in the sidebar under a dedicated "Resources" icon, in the command menu under a "Resources" group, and on the home page in a "Resources" section.
-
-### Per-Guide CLAUDE.md Files
-
-Each guide has its own `CLAUDE.md` in its primary content directory with guide-specific audience info, section conventions, interactive component usage, and data file locations. These complement (not duplicate) this root file.
-
-| Guide | CLAUDE.md Location |
-|-------|-------------------|
-| NPM Package | `src/content/sections/CLAUDE.md` |
-| Architecture | `src/content/architecture/CLAUDE.md` |
-| Testing | `src/content/testing/CLAUDE.md` |
-| Prompt Engineering | `src/content/prompt-engineering/CLAUDE.md` |
-| CI/CD | `src/content/ci-cd/CLAUDE.md` |
-| Auth | `src/content/auth/CLAUDE.md` |
-| Kubernetes | `src/content/kubernetes/CLAUDE.md` |
-| AI Infrastructure | `src/content/ai-infra/CLAUDE.md` |
+- Both support `?guide=` URL param to pre-select a guide filter. Glossary also supports `?search=` for CMD-K term navigation.
+- Appear in the sidebar under "Resources" icon, command menu under "Resources" group, and on the home page.
 
 ## Tech Stack
 
@@ -77,23 +57,13 @@ Each guide has its own `CLAUDE.md` in its primary content directory with guide-s
 
 - `src/components/` — Shared React functional components (TSX)
 - `src/components/mdx/` — Shared MDX-available components (registered in `src/components/mdx/index.ts`)
-  - `src/components/mdx/npm-package/` — NPM Package Guide MDX components
-  - `src/components/mdx/architecture/` — Architecture Guide MDX components
-  - `src/components/mdx/testing/` — Testing Guide MDX components
-  - `src/components/mdx/prompt-engineering/` — Prompt Engineering Guide MDX components
+  - `src/components/mdx/<guide-id>/` — Per-guide interactive MDX components
 - `src/content/` — MDX content pages, auto-discovered by `src/content/registry.ts`
-  - `src/content/sections/` — NPM Package Guide main sections
-  - `src/content/ci/` — NPM Package Guide CI pipeline sections
-  - `src/content/bonus/` — NPM Package Guide bonus sections
-  - `src/content/architecture/` — Architecture Guide pages
-  - `src/content/testing/` — Testing Guide pages
-  - `src/content/prompt-engineering/` — Prompt Engineering Guide pages
+  - `src/content/<guide-id>/` — Per-guide MDX pages (see **Guides** table above)
 - `src/data/` — Content stored as TypeScript objects (roadmap steps, architecture data, checklists, etc.)
-  - `src/data/linkRegistry/` — External URL registry, split by guide (`npmPackageLinks.ts`, `architectureLinks.ts`, `testingLinks.ts`, `promptLinks.ts`); barrel `index.ts` re-exports merged array + lookup maps
-  - `src/data/glossaryTerms/` — Glossary terms, split by guide (`npmPackageTerms.ts`, `architectureTerms.ts`, `testingTerms.ts`, `promptTerms.ts`); barrel `index.ts` re-exports merged array
-  - `src/data/archData/` — Architecture guide data (`types.ts`, `stacks.ts`, `frameworks.ts`, `navigation.ts`); barrel `index.ts` re-exports all
-  - `src/data/promptData/` — Prompt engineering guide data (`types.ts`, `mistakes.ts`, `techniques.ts`, `cli.ts`, `navigation.ts`); barrel `index.ts` re-exports all
-  - `src/data/npmPackageData.ts` — NPM Package guide section definitions (`NPM_GUIDE_SECTIONS`)
+  - `src/data/linkRegistry/` — External URL registry, split by guide; barrel `index.ts` re-exports merged array + lookup maps
+  - `src/data/glossaryTerms/` — Glossary terms, split by guide; barrel `index.ts` re-exports merged array
+  - `src/data/<guideId>Data.ts` (or `<guideId>Data/` directory) — Per-guide data with `*_GUIDE_SECTIONS` and `*_START_PAGE_DATA`
   - `src/data/guideTypes.ts` — Shared `GuideSection` and `GuideDefinition` interfaces
   - `src/data/guideRegistry.ts` — Central guide registry (all guide metadata, section definitions, lookup helpers)
   - `src/data/componentPages.tsx` — Registry of component-rendered (non-MDX) pages, mapping page IDs to components for the router
@@ -174,7 +144,7 @@ Run `pnpm validate:data` to check these, or `pnpm validate` for the full pipelin
 All external URLs are managed centrally in `src/data/linkRegistry/`. This is the single source of truth for link metadata (URL, label, source, description, tags). Other systems reference the registry by ID instead of duplicating URL metadata. Entries are split by guide into separate files; the barrel `index.ts` re-exports the merged array and lookup maps so all existing imports work unchanged.
 
 ### Adding a new link
-1. Add a `RegistryLink` entry to the appropriate guide file in `src/data/linkRegistry/` (`npmPackageLinks.ts`, `architectureLinks.ts`, `testingLinks.ts`, or `promptLinks.ts`) with a slug ID following the `{source}-{topic}` convention (e.g., `"npm-package-json-deps"`, `"mdn-tree-shaking"`). Choose the file matching the entry's `guide:*` tag.
+1. Add a `RegistryLink` entry to the appropriate guide file in `src/data/linkRegistry/<guideId>Links.ts` with a slug ID following the `{source}-{topic}` convention (e.g., `"npm-package-json-deps"`, `"mdn-tree-shaking"`). Choose the file matching the entry's `guide:*` tag.
 2. Reference it from MDX frontmatter via `linkRefs`:
    ```yaml
    linkRefs:
@@ -205,41 +175,25 @@ Both should include descriptions (`note` field in `linkRefs`) when possible to h
 
 The Glossary page (`src/components/GlossaryPage.tsx`) displays a searchable, filterable table of technical terms drawn from `src/data/glossaryTerms/`. Each term links to its official documentation (via the link registry) and optionally to the guide page where the concept is taught. Terms are split by guide into separate files; the barrel `index.ts` re-exports the merged array.
 
-### What should be a glossary term
-
-Add a glossary entry for:
-- **Technical terms introduced or explained in a guide page** — e.g., "Tree Shaking", "Peer Dependency", "Mocking"
-- **Acronyms and abbreviations** — e.g., "ESM", "CJS", "CI", "ORM"
-- **Tools, libraries, and frameworks** referenced across guides — e.g., "Vitest", "Storybook", "Playwright"
-- **Concepts a backend engineer might not know** — the target audience is backend developers learning frontend; if a term would need a sidebar explanation, it deserves a glossary entry
-
-Do NOT add glossary entries for generic programming terms that any developer would know (e.g., "variable", "function", "loop") unless a guide gives them a specialized frontend meaning.
-
 ### GlossaryTerm fields
 
 Each term is defined in the `GlossaryTerm` interface (`src/data/glossaryTerms/index.ts`):
 
 | Field | Required | Description |
 |-------|----------|-------------|
-| `term` | Yes | Display name. Use title-case for proper nouns (`"React Server Components"`), lowercase for general concepts (`"dependency"`). Use the most recognizable form of the name. |
-| `definition` | Yes | One to two sentences explaining the term for a backend engineer. Use `<code>` tags for inline code (e.g., `<code>package.json</code>`). Keep it self-contained — the reader should understand the term without visiting the linked docs. |
-| `linkId` | Yes | The `id` of a `RegistryLink` in `src/data/linkRegistry/`. This provides the "source docs" link displayed below the definition. The link must already exist in the registry (add one first if needed — see **Link Registry** above). |
-| `sectionId` | No | The `id` of a content page where this concept is taught. When present, a "go to guide page" link appears next to the docs link. Use the page where the term is most thoroughly explained. |
+| `term` | Yes | Display name. Title-case for proper nouns, lowercase for general concepts. |
+| `definition` | Yes | One to two sentences for a backend engineer. Use `<code>` tags for inline code. Self-contained. |
+| `linkId` | Yes | `id` of a `RegistryLink` in `src/data/linkRegistry/`. Must already exist in the registry. |
+| `sectionId` | No | `id` of a content page where this concept is taught. Shows a "go to guide page" link. |
 
 ### Adding a glossary term
 
-1. **Ensure the link exists** — Check `src/data/linkRegistry/` for a `RegistryLink` whose `id` matches the documentation you want to link. If none exists, add one to the appropriate guide file following the Link Registry conventions above.
+1. **Ensure the link exists** — Check `src/data/linkRegistry/` for a matching `RegistryLink`. If none exists, add one following the Link Registry conventions above.
 2. **Add the term** — In `src/data/glossaryTerms/`, find the appropriate guide file and `GlossaryCategory` object, then add a new `GlossaryTerm` to its `terms` array.
 3. **Set `sectionId`** — If the term is explained on a guide page, set `sectionId` to that page's `id`.
-4. **Verify** — Run `pnpm lint && pnpm build` to catch any broken `linkId` references (the registry throws at build time for unknown IDs).
+4. **Verify** — Run `pnpm validate` to catch any broken `linkId` references.
 
-### Category conventions
-
-Terms are grouped into `GlossaryCategory` objects. Current categories: Package Management, Dependencies, Build & Bundling, TypeScript, Package Configuration, Development Workflow, Web Architecture, Databases, Full-Stack Frameworks, Testing Fundamentals, Prompt Engineering, AI Coding Tools.
-
-When adding a new category:
-- Pick a name that describes the domain, not a specific guide (categories can span guides).
-- Add a corresponding `cat:<slug>` entry to the `badgeMap` in `src/data/overallResources.ts` so the category filter badge renders on the Glossary page. The slug convention is the category name lowercased with spaces replaced by hyphens and `&` dropped (e.g., `"Build & Bundling"` → `cat:build-bundling`).
+For editorial guidance on what qualifies as a glossary term and how to add new categories, see the `/add-guide` skill.
 
 ## TypeScript Configuration
 
@@ -295,87 +249,9 @@ The command menu (`src/components/CommandMenu.tsx`) provides searchable access t
 
 Prefer the self-closing form (`<NavLink to="..." />`) when linking to a page by its title. Use custom children only when the surrounding sentence needs different wording for readability.
 
-## Adapting Claude Artifacts into Guides
+## Adding a New Guide
 
-Claude artifacts are typically monolithic JSX or HTML files with embedded data and inline styles. Every guide in this app originates as a Claude artifact. This section describes how to decompose an artifact into the multi-page MDX architecture used by this app. The Architecture Guide conversion is the canonical example: the original single-component `ArchitecturePage.tsx` (504 lines) was split into 8 MDX pages, 4 interactive components, and a centralized data file.
-
-### Conversion steps
-
-| Step | Action | Files |
-|------|--------|-------|
-| 1. Identify content boundaries | Find natural page breaks in the monolithic component. Each distinct topic or section heading becomes its own MDX page. | (analysis only) |
-| 2. Create data file | Move inline constants, arrays, and objects into a new typed `.ts` file. Define TypeScript interfaces for data shapes. Import `GuideSection` from `src/data/guideTypes.ts`. Export `<GUIDE>_GUIDE_SECTIONS: GuideSection[]` with labeled section groups. | `src/data/<guide>Data.ts` |
-| 3. Register the guide | Import `<GUIDE>_GUIDE_SECTIONS` from your data file. Add a new entry to the `guides` array in `src/data/guideRegistry.ts` with `id`, `icon`, `title`, `startPageId`, `description`, `sections`. | `src/data/guideRegistry.ts` |
-| 4. Create MDX content pages | One `.mdx` file per page with frontmatter (`id`, `title` with emoji suffix, `guide`). Use existing MDX components (`SectionIntro`, `Toc`, `TocLink`, `ColItem`, `Explainer`, etc.). Pages are auto-discovered by `src/content/registry.ts` — no manual import needed. | `src/content/<guide>/*.mdx` |
-| 5. Create Start page data + MDX file | Export `<GUIDE>_START_PAGE_DATA: StartPageData` from the guide's data file. Define `subtitle`, `tip`, and `steps` array with `sectionLabel` references matching the `*_GUIDE_SECTIONS` labels — this makes the learning path auto-derive sub-items from section page lists. Then create `src/content/<guide>/<start-page-id>.mdx` with frontmatter and `<GuideStartContent guideId="<guide-id>" />`. See **Start page MDX template** below. | `src/data/<guide>Data.ts`, `src/content/<guide>/<start>.mdx` |
-| 6. Register start page data | Import the `*_START_PAGE_DATA` in `src/data/guideRegistry.ts` and add it to `startPageDataMap`. The MDX file auto-routes via content registry — no `componentPages.tsx` changes needed. | `src/data/guideRegistry.ts` |
-| 7. Extract interactive components | Stateful or interactive UI (explorers, diagrams, accordions) becomes a standalone component in `src/components/mdx/<guide-id>/` that reads data from `src/data/` via a prop (e.g., `<StackExplorer stackId="mern" />`). Register it in `src/components/mdx/index.ts`. See **Interactive MDX Component Template** below. | `src/components/mdx/<guide-id>/` |
-| 8. Add glossary terms | Add relevant terms to the appropriate file in `src/data/glossaryTerms/` following the conventions in the **Glossary** section above. Ensure each `linkId` exists in the link registry. | `src/data/glossaryTerms/`, `src/data/linkRegistry/` |
-| 9. Verify | Run `pnpm validate` (runs `validate:data` + `lint` + `build`). This catches broken link references, invalid page headings, and TypeScript errors. | — |
-
-### MDX page template
-
-```mdx
----
-id: "guide-page-id"
-title: "Page Title 🔹"
-guide: "guide-id"
----
-
-<SectionTitle>{frontmatter.title}</SectionTitle>
-
-<Toc>
-  <TocLink id="toc-first">First section</TocLink>
-</Toc>
-
-<SectionIntro>
-Brief intro paragraph.
-</SectionIntro>
-
-<SectionSubheading id="toc-first">First section</SectionSubheading>
-
-<SectionList>
-<ColItem>Content here.</ColItem>
-</SectionList>
-```
-
-### Start page MDX template
-
-```mdx
----
-id: "<guide>-start"
-title: "Start Here 🔹"
-guide: "<guide-id>"
----
-
-<GuideStartContent guideId="<guide-id>" />
-```
-
-The `GuideStartContent` component reads `StartPageData` from `guideRegistry.ts` and renders the learning path automatically. Sub-items are auto-derived from guide sections via `sectionLabel` references. Per-item descriptions are provided via `subItemDescriptions` in the start page data. For items not derivable from sections (cross-guide links, resource page links), use `customSubItems`.
-
-### Common pitfalls
-
-- Use `className`, not `class` — MDX is JSX, not HTML.
-- Use self-closing JSX tags: `<br />`, `<img />`, not `<br>`, `<img>`.
-- Normalize inline styles and CSS classes into Tailwind utility classes. Prefer Tailwind's built-in scale over arbitrary values (e.g., use `text-sm` instead of `text-[13px]`).
-- Keep data in `src/data/`, not inline in MDX files or components.
-- Start pages use `<GuideStartContent guideId="..." />` — do not build start page layouts manually. Add `StartPageData` to the guide's data file instead.
-- Export `*_GUIDE_SECTIONS` from the data file. Register the guide in `src/data/guideRegistry.ts`.
-- Place new guide-specific interactive MDX components in `src/components/mdx/<guide-id>/`, not at the top level. Register them in `src/components/mdx/index.ts` with the subfolder import path.
-- Register any new interactive MDX components in `src/components/mdx/index.ts` or they won't be available in MDX files.
-- Interactive components with inline styles must support dark mode. Use `useTheme()` and `ds()` helper for theme-conditional values. Add `darkAccent` fields to data interfaces when components use dynamic accent colors.
-- Every MDX page `title` must end with an emoji suffix (see **Navigation Item Formatting**).
-
-### What updates automatically
-
-- **Sidebar**: reads `guides` array from `guideRegistry.ts` — new guide appears automatically
-- **Command menu**: reads `guides` array — new guide sections appear automatically
-- **Home page**: reads `guides` array — new guide tile appears automatically
-- **Navigation (prev/next)**: derived from guide sections — works automatically
-- **Content registry**: auto-discovers new MDX files in `src/content/`
-- **Start page sub-items**: derived from guide sections via `sectionLabel` in `StartPageData` — adding/removing pages from a section automatically updates the start page learning path
-- **Start page header**: title, description, and icon read from `guideRegistry.ts` — changing them updates the start page automatically
-- **Router**: resolves MDX pages via auto-discovery and component pages via `componentPages.tsx` registry — no `router.tsx` edits needed
+Use the `/add-guide` skill for the full 9-step conversion workflow, MDX page and component templates, glossary editorial guidance, and common pitfalls.
 
 ## Navigation Item Formatting
 
@@ -388,71 +264,12 @@ Layout rules for navigation items:
 - The parent container uses `justify-between` so text aligns left and icons/badges align to the right edge.
 - New pages must follow this emoji-suffix pattern for consistency across all guides.
 
-## Interactive MDX Component Template
-
-Minimal template for a new interactive MDX component with dark mode support.
-
-### Component file: `src/components/mdx/<guide-id>/MyComponent.tsx`
-
-```tsx
-import { useState } from 'react'
-import { useTheme } from '../../../hooks/useTheme'
-import { ds } from '../../../helpers/darkStyle'
-import { MY_DATA } from '../../../data/myGuideData'
-import type { MyDataItem } from '../../../data/myGuideData'
-
-export function MyComponent({ itemId }: { itemId: string }) {
-  const { theme } = useTheme()
-  const isDark = theme === 'dark'
-  const [activeId, setActiveId] = useState<string | null>(null)
-
-  const item = MY_DATA.find((d: MyDataItem) => d.id === itemId)
-  if (!item) return null
-
-  return (
-    <div
-      style={{
-        background: ds(item.accent, item.darkAccent, isDark),
-        borderColor: ds(item.color, item.color, isDark),
-      }}
-      className="rounded-xl border p-6 mb-6"
-    >
-      <button onClick={() => setActiveId(activeId === itemId ? null : itemId)}>
-        {item.name}
-      </button>
-    </div>
-  )
-}
-```
-
-### Registration: `src/components/mdx/index.ts`
-
-```tsx
-import { MyComponent } from './<guide-id>/MyComponent'
-// Add to the mdxComponents object:
-MyComponent,
-```
-
-### Usage in MDX
-
-```mdx
-<MyComponent itemId="example-id" />
-```
-
-### Key conventions
-
-- Import data from `src/data/`, never inline in the component
-- Use `useTheme()` + `ds()` for dynamic inline styles with dark mode
-- Use Tailwind `dark:` variants for class-based styling
-- Data interfaces should include `darkAccent` field when components use dynamic accent colors
-- Standard dark palette: backgrounds `#1e293b`, text `#e2e8f0`, borders `#334155`
-
 ## Error Troubleshooting
 
 | Error | Cause | Fix |
 |-------|-------|-----|
 | `Duplicate page ID "foo"` | Two MDX files have the same `id` in frontmatter | Change one of the IDs to be unique |
-| `unknown guide "bar"` | MDX frontmatter `guide` field doesn't match a registered guide ID | Use one of: `npm-package`, `architecture`, `testing`, `prompt-engineering` |
+| `unknown guide "bar"` | MDX frontmatter `guide` field doesn't match a registered guide ID | Use a valid guide ID from the **Guides** table above |
 | `Unknown link ID "baz"` | `linkRefs` in MDX frontmatter references an ID that doesn't exist in `src/data/linkRegistry/` | Add the link entry to the appropriate guide file in `src/data/linkRegistry/` |
 | `startPageId not in sections` | Guide's `startPageId` isn't listed in its `*_GUIDE_SECTIONS` array | Add the start page ID to the first section of the guide |
 | Sidebar shows raw page ID instead of title | Page title missing emoji suffix, or page not in `staticTitles`/`contentPages` | Ensure the MDX `title` ends with an emoji, or add a `staticTitles` entry for non-MDX pages |


### PR DESCRIPTION
Move the "Adapting Claude Artifacts into Guides" workflow (9-step
conversion, MDX/component templates, common pitfalls) and glossary
editorial policy into a new `/add-guide` Claude Skill that loads
on-demand. Condense root CLAUDE.md from 464 to 281 lines by:
- Replacing per-guide bullet blocks with a compact 8-guide table
- Using pattern-based paths instead of per-guide directory listings
- Trimming glossary section (editorial policy moved to skill)
- Updating stale content (error troubleshooting, link registry paths)

https://claude.ai/code/session_013P2zvBt1NRQUfxiKVDaPbk