### PR TITLE
Refactor severity badges: replace emoji with badges in Common AI Mistakes nav, move badges under page headers

### DIFF
--- a/src/components/CommandMenu.tsx
+++ b/src/components/CommandMenu.tsx
@@ -13,14 +13,32 @@ interface CommandMenuProps {
   onOpenChange: (open: boolean) => void
 }
 
+// Severity badge lookup for Common AI Mistakes pages (replaces emoji in command menu)
+const severityBadges: Record<string, { letter: string; cls: string }> = {
+  'prompt-mistakes-logic': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
+  'prompt-mistakes-apis': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
+  'prompt-mistakes-react': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
+  'prompt-mistakes-security': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
+  'prompt-mistakes-structural': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
+  'prompt-mistakes-design': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
+  'prompt-mistakes-tailwind': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
+  'prompt-testing': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
+  'prompt-mistakes-style': { letter: 'L', cls: 'bg-blue-100 dark:bg-blue-500/20 text-blue-600 dark:text-blue-400' },
+}
+
 function PageItem({ id, onSelect }: { id: string; onSelect: (id: string) => void }) {
   const title = getNavTitle(id)
   const { text, icon } = parseTitle(title)
+  const badge = severityBadges[id]
 
   return (
     <Command.Item value={title} keywords={[id]} onSelect={() => onSelect(id)}>
       <span className="flex-1 min-w-0 truncate">{text}</span>
-      {icon && <span className="text-base opacity-70 shrink-0">{icon}</span>}
+      {badge ? (
+        <span className={`w-5 h-5 flex items-center justify-center rounded text-[10px] font-bold shrink-0 ${badge.cls}`}>{badge.letter}</span>
+      ) : icon ? (
+        <span className="text-base opacity-70 shrink-0">{icon}</span>
+      ) : null}
     </Command.Item>
   )
 }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -33,9 +33,13 @@ function resolveItems(ids: string[]) {
 const severityBadges: Record<string, { letter: string; cls: string }> = {
   'prompt-mistakes-logic': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
   'prompt-mistakes-apis': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
+  'prompt-mistakes-react': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
+  'prompt-mistakes-security': { letter: 'H', cls: 'bg-red-100 dark:bg-red-500/20 text-red-600 dark:text-red-400' },
   'prompt-mistakes-structural': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
-  'prompt-mistakes-style': { letter: 'L', cls: 'bg-blue-100 dark:bg-blue-500/20 text-blue-600 dark:text-blue-400' },
+  'prompt-mistakes-design': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
+  'prompt-mistakes-tailwind': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
   'prompt-testing': { letter: 'M', cls: 'bg-amber-100 dark:bg-amber-500/20 text-amber-600 dark:text-amber-400' },
+  'prompt-mistakes-style': { letter: 'L', cls: 'bg-blue-100 dark:bg-blue-500/20 text-blue-600 dark:text-blue-400' },
 }
 
 function SidebarItem({ id, title, active, onClick }: { id: string; title: string; active: boolean; onClick: (id: string) => void }) {

--- a/src/components/mdx/index.ts
+++ b/src/components/mdx/index.ts
@@ -26,6 +26,7 @@ import { TestPracticeCards } from './testing/TestPracticeCards'
 import { TestChecklist } from './testing/TestChecklist'
 import { TestToolsGrid } from './testing/TestToolsGrid'
 // prompt-engineering
+import { SeverityBadge } from './prompt-engineering/SeverityBadge'
 import { MistakeList } from './prompt-engineering/MistakeList'
 import { TechniqueDetail } from './prompt-engineering/TechniqueDetail'
 import { CLIReference } from './prompt-engineering/CLIReference'
@@ -98,6 +99,7 @@ export const mdxComponents: MDXComponents = {
   TestPracticeCards,
   TestChecklist,
   TestToolsGrid,
+  SeverityBadge,
   MistakeList,
   TechniqueDetail,
   CLIReference,

--- a/src/components/mdx/prompt-engineering/MistakeList.tsx
+++ b/src/components/mdx/prompt-engineering/MistakeList.tsx
@@ -1,47 +1,25 @@
-import { MISTAKE_CATEGORIES, SEVERITY_COLORS } from '../../../data/promptData'
-import { useIsDark } from '../../../hooks/useTheme'
+import { MISTAKE_CATEGORIES } from '../../../data/promptData'
 
 export function MistakeList({ categoryId }: { categoryId: string }) {
-  const isDark = useIsDark()
-
   const category = MISTAKE_CATEGORIES.find(c => c.id === categoryId)
   if (!category) return null
 
-  const colors = SEVERITY_COLORS[category.severity]
-  const t = isDark ? colors.dark : colors.light
-
   return (
-    <div>
-      {/* Severity badge — directly under header */}
-      <div className="-mt-3 mb-6 flex items-center gap-2">
-        <span
-          className="text-xs font-semibold uppercase tracking-wide rounded-full px-2.5 py-0.5"
-          style={{
-            background: `${t.badge}33`,
-            color: t.text,
-          }}
-        >
-          {category.severity} severity
-        </span>
-      </div>
-
-      {/* Mistake items — no boxes, proper headings */}
-      <div className="flex flex-col gap-5">
-        {category.items.map(item => (
-          <div key={item.id}>
-            <h3 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mb-2 mt-0" id={item.id}>
-              {item.mistake}
-            </h3>
-            <div className="text-xs font-mono text-slate-500 dark:text-slate-400 mb-2 px-3 py-2 bg-slate-100 dark:bg-slate-800 rounded-md overflow-x-auto">
-              {item.example}
-            </div>
-            <div className="text-sm text-blue-600 dark:text-cyan-400 flex gap-1.5 items-start">
-              <span className="shrink-0">{'\u{1F4A1}'}</span>
-              <span>{item.fix}</span>
-            </div>
+    <div className="flex flex-col gap-5">
+      {category.items.map(item => (
+        <div key={item.id}>
+          <h3 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mb-2 mt-0" id={item.id}>
+            {item.mistake}
+          </h3>
+          <div className="text-xs font-mono text-slate-500 dark:text-slate-400 mb-2 px-3 py-2 bg-slate-100 dark:bg-slate-800 rounded-md overflow-x-auto">
+            {item.example}
           </div>
-        ))}
-      </div>
+          <div className="text-sm text-blue-600 dark:text-cyan-400 flex gap-1.5 items-start">
+            <span className="shrink-0">{'\u{1F4A1}'}</span>
+            <span>{item.fix}</span>
+          </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/components/mdx/prompt-engineering/SeverityBadge.tsx
+++ b/src/components/mdx/prompt-engineering/SeverityBadge.tsx
@@ -1,0 +1,26 @@
+import { MISTAKE_CATEGORIES, SEVERITY_COLORS } from '../../../data/promptData'
+import { useIsDark } from '../../../hooks/useTheme'
+
+export function SeverityBadge({ categoryId }: { categoryId: string }) {
+  const isDark = useIsDark()
+
+  const category = MISTAKE_CATEGORIES.find(c => c.id === categoryId)
+  if (!category) return null
+
+  const colors = SEVERITY_COLORS[category.severity]
+  const t = isDark ? colors.dark : colors.light
+
+  return (
+    <div className="-mt-3 mb-6 flex items-center gap-2">
+      <span
+        className="text-xs font-semibold uppercase tracking-wide rounded-full px-2.5 py-0.5"
+        style={{
+          background: `${t.badge}33`,
+          color: t.text,
+        }}
+      >
+        {category.severity} severity
+      </span>
+    </div>
+  )
+}

--- a/src/content/prompt-engineering/CLAUDE.md
+++ b/src/content/prompt-engineering/CLAUDE.md
@@ -40,7 +40,8 @@ Defined in `PROMPT_GUIDE_SECTIONS` in `src/data/promptData/navigation.ts`.
 
 | Component | Props | Data Source | Purpose |
 |-----------|-------|-------------|---------|
-| `MistakeList` | `categoryId: string` | `MISTAKE_CATEGORIES` in `mistakes.ts` | Renders mistakes for a category with severity badge |
+| `SeverityBadge` | `categoryId: string` | `MISTAKE_CATEGORIES` in `mistakes.ts` | Renders the severity level badge (high/medium/low) for a mistake category |
+| `MistakeList` | `categoryId: string` | `MISTAKE_CATEGORIES` in `mistakes.ts` | Renders mistake items for a category (no badge — use `SeverityBadge` separately) |
 | `TechniqueDetail` | `techniqueId: string` | `CONTEXT_TECHNIQUES` in `techniques.ts` | Deep-dive technique explainer with code example |
 | `CLIReference` | *(none)* | `CLI_GROUPS` in `cli.ts` | Searchable, filterable CLI command table |
 | `TestingMistakes` | `context?: 'e2e' \| 'unit'` | `TESTING_MISTAKES` in `mistakes.ts` | Testing-specific mistake cards, optionally filtered |
@@ -53,7 +54,13 @@ Defined in `PROMPT_GUIDE_SECTIONS` in `src/data/promptData/navigation.ts`.
 
 ### Mistake category pages
 
-Pages in "Common AI Mistakes" use `<MistakeList categoryId="..." />`. Each `MistakeCategory` in `mistakes.ts` has a `severity` level (`high`, `medium`, `low`) that controls badge color. The `SEVERITY_COLORS` object defines light/dark theme colors for each level.
+Pages in "Common AI Mistakes" use severity badges instead of emoji. This is an exception to the project-wide emoji-suffix convention for page titles.
+
+**Title convention:** Common AI Mistakes pages do NOT have emoji suffixes in their MDX frontmatter `title`. Instead, they use severity level badges (H/M/L) in the sidebar and command menu, and a `<SeverityBadge>` component on the page.
+
+**Page layout:** Every mistake category page must place `<SeverityBadge categoryId="..." />` immediately after `<SectionTitle>`, before `<SectionIntro>`. The `<MistakeList>` component renders only the mistake items — it does not include the severity badge.
+
+Each `MistakeCategory` in `mistakes.ts` has a `severity` level (`high`, `medium`, `low`) that controls badge color. The `SEVERITY_COLORS` object defines light/dark theme colors for each level. When adding a new mistake page, also add its severity badge entry to `severityBadges` in both `Sidebar.tsx` and `CommandMenu.tsx`.
 
 ### Technique detail pages
 
@@ -70,8 +77,9 @@ Context management pages use `<TechniqueDetail techniqueId="..." />`. Each techn
 ### Adding a new mistake category
 
 1. Add a `MistakeCategory` to `MISTAKE_CATEGORIES` in `src/data/promptData/mistakes.ts`.
-2. Create `src/content/prompt-engineering/prompt-mistakes-<slug>.mdx` using `<MistakeList categoryId="..." />`.
+2. Create `src/content/prompt-engineering/prompt-mistakes-<slug>.mdx` — the title must **not** have an emoji suffix. Place `<SeverityBadge categoryId="..." />` right after `<SectionTitle>`, then `<SectionIntro>`, `<Toc>`, and `<MistakeList categoryId="..." />`.
 3. Add the page ID to `PROMPT_GUIDE_SECTIONS` under "Common AI Mistakes" in `navigation.ts`.
+4. Add a severity badge entry for the page ID to `severityBadges` in both `src/components/Sidebar.tsx` and `src/components/CommandMenu.tsx`.
 
 ### Adding a new technique
 

--- a/src/content/prompt-engineering/prompt-mistakes-apis.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-apis.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-mistakes-apis"
-title: "Hallucinated APIs & Packages 👻"
+title: "Hallucinated APIs & Packages"
 guide: "prompt-engineering"
 usedFootnotes: [1]
 linkRefs:
@@ -13,6 +13,7 @@ linkRefs:
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+<SeverityBadge categoryId="apis" />
 
 <SectionIntro>
 AI models sometimes invent APIs, packages, or methods that don&rsquo;t exist &mdash; or use deprecated ones from older versions. These hallucinations<FnRef n={1} /> can waste hours of debugging if you don&rsquo;t catch them early. Being explicit about your versions and libraries is the best defense.

--- a/src/content/prompt-engineering/prompt-mistakes-design.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-design.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-mistakes-design"
-title: "Design & UI Implementation 📐"
+title: "Design & UI Implementation"
 guide: "prompt-engineering"
 usedFootnotes: [1]
 linkRefs:
@@ -13,6 +13,7 @@ linkRefs:
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+<SeverityBadge categoryId="design" />
 
 <SectionIntro>
 AI models struggle with visual precision<FnRef n={1} /> — they generate hardcoded pixel values instead of responsive units, skip accessibility attributes, drift from design system tokens, and create z-index chaos. The fundamental issue is that AI doesn&rsquo;t see your design specs unless you provide them explicitly. Adding design system constraints to your prompt or CLAUDE.md dramatically improves output quality.

--- a/src/content/prompt-engineering/prompt-mistakes-logic.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-logic.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-mistakes-logic"
-title: "Logic & Condition Errors ⚡"
+title: "Logic & Condition Errors"
 guide: "prompt-engineering"
 usedFootnotes: [1]
 linkRefs:
@@ -11,6 +11,7 @@ linkRefs:
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+<SeverityBadge categoryId="logic" />
 
 <SectionIntro>
 AI models frequently produce subtle logic errors<FnRef n={1} /> &mdash; off-by-one loops, inverted boolean conditions, missed edge cases, and incorrect math formulas. These are the most common and dangerous mistakes because they compile and run without errors but produce wrong results.

--- a/src/content/prompt-engineering/prompt-mistakes-react.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-react.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-mistakes-react"
-title: "React Component Errors ⚛️"
+title: "React Component Errors"
 guide: "prompt-engineering"
 usedFootnotes: [1]
 linkRefs:
@@ -13,6 +13,7 @@ linkRefs:
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+<SeverityBadge categoryId="react" />
 
 <SectionIntro>
 AI models frequently generate React code with subtle runtime bugs — stale closures in effects, broken hook rules, incorrect key props, and over-reliance on prop drilling. These mistakes compile and render without errors but cause hard-to-trace bugs like infinite re-renders, lost state, and phantom UI updates. Specifying your React version<FnRef n={1} /> and component conventions in CLAUDE.md is the best defense.

--- a/src/content/prompt-engineering/prompt-mistakes-security.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-security.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-mistakes-security"
-title: "App Security Mistakes 🔒"
+title: "App Security Mistakes"
 guide: "prompt-engineering"
 usedFootnotes: [1, 2]
 linkRefs:
@@ -15,6 +15,7 @@ linkRefs:
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+<SeverityBadge categoryId="security" />
 
 <SectionIntro>
 Security mistakes in AI-generated code are especially dangerous because the code often looks correct and passes basic testing. AI models routinely generate XSS vectors<FnRef n={1} />, expose secrets in client bundles, use insecure auth patterns, and build queries with string concatenation. Always include explicit security requirements<FnRef n={2} /> in your prompts and CLAUDE.md.

--- a/src/content/prompt-engineering/prompt-mistakes-structural.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-structural.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-mistakes-structural"
-title: "Structural & Architectural Issues 🏗️"
+title: "Structural & Architectural Issues"
 guide: "prompt-engineering"
 usedFootnotes: [2]
 linkRefs:
@@ -13,6 +13,7 @@ linkRefs:
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+<SeverityBadge categoryId="structural" />
 
 <SectionIntro>
 AI-generated code sometimes ignores your project&rsquo;s existing patterns, over-engineers simple solutions, leaves out critical pieces like imports and exports, or introduces security vulnerabilities. Explicit context about your codebase<FnRef n={2} /> prevents most of these issues.

--- a/src/content/prompt-engineering/prompt-mistakes-style.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-style.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-mistakes-style"
-title: "Style & Formatting Drift 🎨"
+title: "Style & Formatting Drift"
 guide: "prompt-engineering"
 usedFootnotes: [1]
 linkRefs:
@@ -13,6 +13,7 @@ linkRefs:
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+<SeverityBadge categoryId="style" />
 
 <SectionIntro>
 Lower severity but still annoying &mdash; AI models can drift from your project&rsquo;s coding style, mixing naming conventions, adding unnecessary comments, or ignoring your linter and formatter configuration. Including style rules in your prompt or CLAUDE.md<FnRef n={1} /> keeps output consistent. For setting up ESLint and Prettier as your automated safety net, see <NavLink to="ci-linting" /> in the NPM Package Guide.

--- a/src/content/prompt-engineering/prompt-mistakes-tailwind.mdx
+++ b/src/content/prompt-engineering/prompt-mistakes-tailwind.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-mistakes-tailwind"
-title: "Tailwind CSS Mistakes 💨"
+title: "Tailwind CSS Mistakes"
 guide: "prompt-engineering"
 usedFootnotes: [1]
 linkRefs:
@@ -13,6 +13,7 @@ linkRefs:
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>
+<SeverityBadge categoryId="tailwind" />
 
 <SectionIntro>
 Tailwind CSS is one of the most common AI coding contexts, but models frequently make version-specific mistakes<FnRef n={1} /> — generating v3 configuration syntax for v4 projects, using arbitrary values instead of the built-in scale, constructing dynamic class names that get purged, and forgetting dark mode variants. Specifying your exact Tailwind version and conventions in CLAUDE.md prevents most of these issues.

--- a/src/content/prompt-engineering/prompt-testing.mdx
+++ b/src/content/prompt-engineering/prompt-testing.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-testing"
-title: "Unit/E2E Testing 🧪"
+title: "Unit/E2E Testing"
 guide: "prompt-engineering"
 usedFootnotes: [2, 3]
 linkRefs:


### PR DESCRIPTION
- Remove emoji suffixes from all 9 Common AI Mistakes page titles
- Complete severityBadges map in Sidebar.tsx for all mistake pages (was missing 4)
- Add severity badge rendering to CommandMenu.tsx for mistake pages
- Extract SeverityBadge into standalone MDX component, remove badge from MistakeList
- Place SeverityBadge directly after SectionTitle in each mistake MDX page
- Document severity badge conventions in guide-level CLAUDE.md

https://claude.ai/code/session_01PfiSSgwXtLJEazJah1eaPT