### PR TITLE
Add CI Pipeline & Checks section documentation for npm-package guide

### DIFF
--- a/src/content/ci/CLAUDE.md
+++ b/src/content/ci/CLAUDE.md
@@ -1,0 +1,64 @@
+# CI Pipeline & Checks — Content Directory CLAUDE.md
+
+> This directory contains CI-related pages for the **npm-package** guide. Root `/CLAUDE.md` covers project-wide patterns; `src/content/sections/CLAUDE.md` covers the full npm-package guide structure including this section.
+
+## Audience & Purpose
+
+Backend engineers who understand CI/CD concepts (Jenkins, GitLab CI) but need to learn what a JavaScript/TypeScript CI pipeline looks like. Teaches linting, build verification, testing (unit, E2E, component), and repo maintenance tools in the context of npm packages and web apps.
+
+## Pages in This Directory
+
+| Page ID | Title | Content |
+|---------|-------|---------|
+| `ci-overview` | CI Overview 🔄 | Overview of the 4 CI checks with numbered cards and a full workflow YAML example |
+| `ci-linting` | Linting & Formatting 🧹 | ESLint, Prettier, eslint-stylistic comparison, IDE integration |
+| `ci-build` | Build Verification 🔨 | TypeScript compilation and bundling as a CI step |
+| `ci-testing` | Testing 🧪 | Unit tests, E2E tests, component tests (Storybook), coverage, best practices |
+| `ci-repo-maintenance` | Repo Maintenance 🧹 | knip (unused code) and syncpack (dependency version consistency) |
+
+These pages belong to the **CI Pipeline & Checks** section in `NPM_GUIDE_SECTIONS` (defined in `src/data/npmPackageData.ts`).
+
+## Interactive Components
+
+All CI layout components are exported from `src/components/mdx/npm-package/CILayout.tsx`:
+
+| Component | Props | Purpose |
+|-----------|-------|---------|
+| `CIOverviewCards` | `children` | Grid container for numbered overview cards |
+| `CIFullExample` | `children` | Full workflow YAML example with emoji header and syntax-highlighted `<span>` elements |
+| `CIStep` | `heading: string`, `id?: string` | Section heading with optional TOC anchor |
+| `CIStepText` | `children` | Body text block within a `CIStep` |
+| `CIYaml` | `children` | Monospace YAML code block (dark background) |
+| `YamlHeading` | `children?` (default: "GitHub Actions Example") | Label above YAML blocks |
+| `CITip` | `children` | Blue callout box for tips and advice |
+| `MaintenanceTool` | `name`, `emoji`, `desc`, `why`, `yaml?`, `children?` | Tool card with description, rationale, and optional YAML |
+| `GoodTestsList` | `children` | Styled `<ul>` for test best practices |
+| `AiPromptsAccordion` | `prompts: { label, prompt }[]` | Collapsible accordion with copy-to-clipboard AI prompt examples |
+
+## Conventions
+
+### CI-specific layout
+
+Pages in this directory use the CI layout components above instead of the standard `SectionList`/`ColItem` pattern used elsewhere in the npm-package guide. Each page follows a consistent structure: `<SectionTitle>` → `<SectionIntro>` → content sections with `<YamlHeading>` + `<CIYaml>` blocks → `<CITip>`.
+
+### Package manager switching
+
+All CLI commands use `<Cmd npm="..." pnpm="..." />` — never hardcoded strings. This integrates with the global npm/pnpm toggle via `usePM()` context.
+
+### Cross-guide links
+
+CI pages link to related pages in other guides using `<NavLink>` and `<NavPill>`:
+- Testing Guide pages (e.g., `test-overview`, `test-best-practices`)
+- Prompt Engineering pages (e.g., `prompt-mistakes-style`)
+- npm-package main section pages (e.g., `build`, `storybook`)
+
+### Footnote usage
+
+CI pages use footnotes for tool documentation references. Set `usedFootnotes` in frontmatter and use `<FnRef n={N} />` markers in the MDX body.
+
+## Adding a New CI Page
+
+1. Create `src/content/ci/<page-id>.mdx` with frontmatter: `id`, `title` (with emoji suffix), `guide: "npm-package"`.
+2. Add the page ID to `NPM_GUIDE_SECTIONS` in `src/data/npmPackageData.ts` under the "CI Pipeline & Checks" section.
+3. Use CI layout components (`CIStep`, `CIYaml`, `CITip`, etc.) from `CILayout.tsx`.
+4. Add any new link registry entries to `src/data/linkRegistry/npmPackageLinks.ts`.


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation for the CI Pipeline & Checks section of the npm-package guide. It includes a new `CLAUDE.md` file that outlines the structure, purpose, and conventions for CI-related content pages.

## Key Changes

- **Added `src/content/ci/CLAUDE.md`**: A detailed guide documenting:
  - The audience and purpose of the CI section (backend engineers learning JavaScript/TypeScript CI pipelines)
  - Five planned pages covering CI overview, linting, build verification, testing, and repo maintenance
  - Complete inventory of interactive CI layout components exported from `CILayout.tsx` with their props and purposes
  - Established conventions for CI pages including layout patterns, package manager switching via `<Cmd>` components, cross-guide linking, and footnote usage
  - Instructions for adding new CI pages to the guide

## Notable Implementation Details

- Documents a specialized layout component system (`CIOverviewCards`, `CIStep`, `CIYaml`, `MaintenanceTool`, etc.) distinct from the standard `SectionList`/`ColItem` pattern used elsewhere in the npm-package guide
- Establishes integration points with existing guide infrastructure: the `usePM()` context for package manager toggling, `NavLink`/`NavPill` for cross-guide navigation, and the `NPM_GUIDE_SECTIONS` registry in `npmPackageData.ts`
- Provides a template for future CI page creation with specific frontmatter requirements and component usage patterns

https://claude.ai/code/session_01KAgcXKNGJsXpAXChDMb8Gw