### PR TITLE
Update e2e tests to match UI changes and refactor filter logic

### DIFF
--- a/e2e/glossary.spec.ts
+++ b/e2e/glossary.spec.ts
@@ -24,11 +24,8 @@ test.describe('Glossary Page', () => {
     const table = page.locator('[data-testid="data-table"]')
     const allRows = await table.locator('tbody tr').count()
 
-    // Click the "All" filter (should be active by default)
-    await expect(page.locator('[data-testid="glossary-filter-all"]')).toBeVisible()
-
     // Find and click a category filter (they are dynamically generated)
-    const filterButtons = page.locator('[data-testid^="glossary-filter-"]:not([data-testid="glossary-filter-all"])')
+    const filterButtons = page.locator('[data-testid^="glossary-filter-"]')
     const filterCount = await filterButtons.count()
     expect(filterCount).toBeGreaterThan(0)
 
@@ -38,16 +35,16 @@ test.describe('Glossary Page', () => {
     expect(filteredRows).toBeLessThanOrEqual(allRows)
   })
 
-  test('resets category filter when clicking All', async ({ page }) => {
+  test('resets category filter when clicking clear filters', async ({ page }) => {
     const table = page.locator('[data-testid="data-table"]')
     const allRows = await table.locator('tbody tr').count()
 
     // Apply a filter
-    const filterButtons = page.locator('[data-testid^="glossary-filter-"]:not([data-testid="glossary-filter-all"])')
+    const filterButtons = page.locator('[data-testid^="glossary-filter-"]')
     await filterButtons.first().click()
 
-    // Reset
-    await page.locator('[data-testid="glossary-filter-all"]').click()
+    // Reset via clear filters button
+    await page.locator('[data-testid="glossary-clear-filters"]').click()
     const resetRows = await table.locator('tbody tr').count()
     expect(resetRows).toBe(allRows)
   })

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -6,12 +6,12 @@ test.describe('Navigation', () => {
   })
 
   test('loads the home page by default', async ({ page }) => {
-    await expect(page.locator('h1')).toContainText('Web App vs. NPM Package Guide')
+    await expect(page.locator('h1')).toContainText('Dev Guides')
   })
 
   test('opens and closes sidebar via menu toggle', async ({ page }) => {
     const sidebar = page.locator('[data-testid="sidebar"]')
-    await expect(sidebar).toHaveCSS('transform', /translateX/)
+    await expect(sidebar).toHaveClass(/-translate-x-full/)
 
     // Open sidebar
     await page.locator('[data-testid="menu-toggle"]').click()
@@ -41,7 +41,7 @@ test.describe('Navigation', () => {
 
   test('navigates to checklist via sidebar', async ({ page }) => {
     await page.locator('[data-testid="menu-toggle"]').click()
-    await page.locator('[data-testid="sidebar-guide-icon-npm-package"]').click()
+    await page.locator('[data-testid="sidebar-icon-checklists"]').click()
     await page.locator('[data-testid="sidebar-item-checklist"]').click()
     await expect(page).toHaveURL(/#\/checklist/)
   })
@@ -82,6 +82,7 @@ test.describe('Navigation', () => {
   })
 
   test('roadmap page only shows next button, not previous', async ({ page }) => {
+    await page.goto('/#/roadmap')
     await expect(page.locator('[data-testid="nav-previous"]')).not.toBeVisible()
     await expect(page.locator('[data-testid="nav-next"]')).toBeVisible()
   })


### PR DESCRIPTION
## Summary
Updated end-to-end tests to reflect UI changes in the glossary filter system and navigation components. These changes align the test suite with recent refactoring of the filter mechanism and updates to page titles and selectors.

## Key Changes

**Glossary Filter Tests:**
- Removed the "All" filter button from glossary tests and replaced it with a dedicated "clear filters" button (`glossary-clear-filters`)
- Updated filter button selectors to include all filter buttons instead of excluding the "All" filter
- Renamed test case from "resets category filter when clicking All" to "resets category filter when clicking clear filters"
- Updated test logic to use the new clear filters button for resetting filters

**Navigation Tests:**
- Updated home page title assertion from "Web App vs. NPM Package Guide" to "Dev Guides"
- Changed sidebar visibility check from CSS transform property to class-based assertion using `-translate-x-full` class
- Updated sidebar navigation test to use `sidebar-icon-checklists` instead of `sidebar-guide-icon-npm-package`
- Added explicit navigation to roadmap page in the roadmap test to ensure proper test isolation

## Notable Details
These changes suggest a UI refactoring where:
- The glossary filter system was simplified by replacing an "All" button with a dedicated "clear filters" button
- Navigation structure was reorganized with updated icon selectors
- Page titles were updated to reflect new branding or content organization

https://claude.ai/code/session_01LvHLQXsukrEhv2UcC7TCoP