### PR TITLE
Rewrite AI Infrastructure guide for frontend engineers (#127)

### DIFF
--- a/src/components/mdx/ai-infra/InfraLayerExplorer.tsx
+++ b/src/components/mdx/ai-infra/InfraLayerExplorer.tsx
@@ -74,7 +74,7 @@ function ConceptCard({
               className="text-xs font-bold uppercase tracking-wider mb-1"
               style={{ color: layer.color }}
             >
-              Backend Analogy
+              Frontend Analogy
             </div>
             <p
               className="text-sm m-0 leading-relaxed"

--- a/src/content/ai-infra/CLAUDE.md
+++ b/src/content/ai-infra/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## Audience & Purpose
 
-Backend engineers learning AI infrastructure — from model serving and vector databases to GPU clusters and training pipelines. Each layer is explained with analogies to familiar backend concepts like load balancers, databases, and CI pipelines.
+Frontend engineers learning AI infrastructure — from model serving and vector databases to GPU clusters and training pipelines. Each layer is explained with analogies to familiar frontend concepts like Express middleware, React state, and data-fetching patterns.
 
 ## Section Structure
 
@@ -35,7 +35,7 @@ Defined in `AI_INFRA_GUIDE_SECTIONS` in `src/data/aiInfraData/navigation.ts`.
 
 | Component | Props | Data Source | Purpose |
 |-----------|-------|-------------|---------|
-| `InfraLayerExplorer` | `layerId: string` | `INFRA_LAYERS` in `layers.ts` | Interactive layer explorer with clickable concept cards showing name, description, backend analogy, and tools |
+| `InfraLayerExplorer` | `layerId: string` | `INFRA_LAYERS` in `layers.ts` | Interactive layer explorer with clickable concept cards showing name, description, frontend analogy, and tools |
 | `WorkflowExplorer` | *(none)* | `INFRA_WORKFLOWS` in `workflows.ts` | Interactive workflow selector showing all workflows with tab navigation |
 | `WorkflowDetail` | `workflowId: string` | `INFRA_WORKFLOWS` in `workflows.ts` | Single workflow step-by-step flow with layer badges |
 
@@ -48,11 +48,11 @@ The guide is organized around 5 infrastructure layers defined in `INFRA_LAYERS`.
 - `id`, `title`, `subtitle`, `icon` — Display metadata
 - `color`, `accent`, `darkAccent` — Theme colors for dark mode support
 - `summary` — Layer overview text
-- `concepts` — Array of `InfraConcept` objects, each with `name`, `what` (description), `analogy` (backend analogy), and `tools` (real-world tools list)
+- `concepts` — Array of `InfraConcept` objects, each with `name`, `what` (description), `analogy` (frontend analogy), and `tools` (real-world tools list)
 
-### Backend analogy pattern
+### Frontend analogy pattern
 
-Every `InfraConcept` includes an `analogy` field that maps the AI concept to a familiar backend equivalent. This is the primary teaching device of the guide.
+Every `InfraConcept` includes an `analogy` field that maps the AI concept to a familiar frontend equivalent. This is the primary teaching device of the guide.
 
 ### Workflow visualization
 
@@ -67,7 +67,7 @@ Workflow pages (`ai-wf-*.mdx`) follow a consistent structure:
 3. When to use this pattern
 4. `<WorkflowDetail workflowId="..." />`
 5. Key considerations
-6. Backend `<Explainer>` analogy box
+6. Frontend `<Explainer>` analogy box
 
 ### Key terms
 

--- a/src/content/ai-infra/ai-compute.mdx
+++ b/src/content/ai-infra/ai-compute.mdx
@@ -27,6 +27,6 @@ AI workloads need GPUs &mdash; lots of them. This layer handles provisioning, sc
 
 <SectionSubheading id="toc-concepts">Key Concepts</SectionSubheading>
 
-Click any concept to explore what it does, a backend analogy, and the tools you'd use.
+Click any concept to explore what it does, a frontend analogy, and the tools you'd use.
 
 <InfraLayerExplorer layerId="infra" />

--- a/src/content/ai-infra/ai-data.mdx
+++ b/src/content/ai-infra/ai-data.mdx
@@ -17,7 +17,7 @@ linkRefs:
 </Toc>
 
 <SectionIntro>
-AI apps need special databases. Vector databases store "embeddings" &mdash; numerical representations of text and images that let you find semantically similar content. If you've worked with search engines like Elasticsearch, you'll find the concepts familiar but the technique different.
+AI apps need special databases. Vector databases store "embeddings" &mdash; numerical representations of text and images that let you find semantically similar content. If you've used search tools like Fuse.js or Algolia in your frontend, you'll find the concepts familiar but the technique different.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">Overview</SectionSubheading>
@@ -29,6 +29,6 @@ AI apps need special databases. Vector databases store "embeddings" &mdash; nume
 
 <SectionSubheading id="toc-concepts">Key Concepts</SectionSubheading>
 
-Click any concept to explore what it does, a backend analogy, and the tools you'd use.
+Click any concept to explore what it does, a frontend analogy, and the tools you'd use.
 
 <InfraLayerExplorer layerId="data" />

--- a/src/content/ai-infra/ai-inference.mdx
+++ b/src/content/ai-infra/ai-inference.mdx
@@ -32,6 +32,6 @@ The inference layer is where your frontend connects to AI. When you call <code>f
 
 <SectionSubheading id="toc-concepts">Key Concepts</SectionSubheading>
 
-Click any concept to explore what it does, a backend analogy, and the tools you'd use.
+Click any concept to explore what it does, a frontend analogy, and the tools you'd use.
 
 <InfraLayerExplorer layerId="inference" />

--- a/src/content/ai-infra/ai-key-terms.mdx
+++ b/src/content/ai-infra/ai-key-terms.mdx
@@ -15,7 +15,7 @@ linkRefs:
 </Toc>
 
 <SectionIntro>
-Essential terminology for working with AI infrastructure. Each term includes a concise, backend-friendly explanation.
+Essential terminology for working with AI infrastructure. Each term includes a concise, frontend-friendly explanation.
 </SectionIntro>
 
 <SectionSubheading id="toc-cheat-sheet">Cheat Sheet</SectionSubheading>

--- a/src/content/ai-infra/ai-orchestration.mdx
+++ b/src/content/ai-infra/ai-orchestration.mdx
@@ -19,18 +19,18 @@ linkRefs:
 </Toc>
 
 <SectionIntro>
-This is where "just call the model" becomes a real product. The orchestration layer chains together retrieval, prompting, model calls, and post-processing into coherent workflows. If you've built middleware pipelines or service orchestration, you'll recognize the patterns.
+This is where "just call the model" becomes a real product. The orchestration layer chains together retrieval, prompting, model calls, and post-processing into coherent workflows. If you've built Express middleware chains or multi-step React data flows, you'll recognize the patterns.
 </SectionIntro>
 
 <SectionSubheading id="toc-overview">Overview</SectionSubheading>
 
 <SectionList>
 <ColItem>Raw model calls are like raw database queries &mdash; technically functional but not how you build applications. The orchestration layer adds the structure, validation, and business logic that turns model capabilities into reliable features.</ColItem>
-<ColItem>This layer is where most of the "AI engineering" happens in practice. You'll compose retrieval pipelines, manage prompt versions, build agent loops, and add safety guardrails &mdash; all using patterns that map directly to familiar backend concepts.</ColItem>
+<ColItem>This layer is where most of the "AI engineering" happens in practice. You'll compose retrieval pipelines, manage prompt versions, build agent loops, and add safety guardrails &mdash; all using patterns that map directly to familiar frontend concepts.</ColItem>
 </SectionList>
 
 <SectionSubheading id="toc-concepts">Key Concepts</SectionSubheading>
 
-Click any concept to explore what it does, a backend analogy, and the tools you'd use.
+Click any concept to explore what it does, a frontend analogy, and the tools you'd use.
 
 <InfraLayerExplorer layerId="orchestration" />

--- a/src/content/ai-infra/ai-overview.mdx
+++ b/src/content/ai-infra/ai-overview.mdx
@@ -23,7 +23,7 @@ Everything that happens between your <code>fetch("/api/chat")</code> and the AI 
 
 <SectionList>
 <ColItem>When you call an AI API from your frontend, the request passes through at least three infrastructure layers before a single token is generated. Understanding these layers helps you debug latency issues, architect better integrations, and have informed conversations with ML engineers.</ColItem>
-<ColItem>The AI backend stack has strong parallels to traditional backend architecture &mdash; API gateways, databases, CI/CD pipelines, and monitoring all have direct counterparts. The concepts are familiar, even if the specific technologies are new.</ColItem>
+<ColItem>The AI infrastructure stack has strong parallels to concepts frontend engineers already know &mdash; Express middleware, data-fetching patterns, and React state management all have direct counterparts. The concepts are familiar, even if the specific technologies are new.</ColItem>
 </SectionList>
 
 <SectionSubheading id="toc-five-layers">The Five Layers</SectionSubheading>
@@ -39,5 +39,5 @@ Everything that happens between your <code>fetch("/api/chat")</code> and the AI 
 <SectionSubheading id="toc-where-you-fit">Where You Fit In</SectionSubheading>
 
 <Explainer title="You're already closer than you think">
-As a backend engineer, you likely interact directly with the **inference layer** (calling AI APIs) and may touch the **orchestration layer** (building RAG pipelines or prompt management). The deeper layers &mdash; training and infrastructure &mdash; are typically handled by ML engineers, but understanding them helps you make better architectural decisions and debug production issues.
+As a frontend engineer, you interact with the **inference layer** every time your React app calls an AI API, and you may touch the **orchestration layer** when building features with RAG or prompt management. The deeper layers &mdash; training and infrastructure &mdash; are typically handled by ML engineers, but understanding them helps you debug latency issues, architect better integrations, and have informed conversations with your backend and ML teams.
 </Explainer>

--- a/src/content/ai-infra/ai-training.mdx
+++ b/src/content/ai-infra/ai-training.mdx
@@ -29,6 +29,6 @@ Foundation models are pre-trained on massive datasets by large labs. Fine-tuning
 
 <SectionSubheading id="toc-concepts">Key Concepts</SectionSubheading>
 
-Click any concept to explore what it does, a backend analogy, and the tools you'd use.
+Click any concept to explore what it does, a frontend analogy, and the tools you'd use.
 
 <InfraLayerExplorer layerId="training" />

--- a/src/content/ai-infra/ai-wf-agent.mdx
+++ b/src/content/ai-infra/ai-wf-agent.mdx
@@ -16,7 +16,7 @@ linkRefs:
   <TocLink id="toc-when">When to use this pattern</TocLink>
   <TocLink id="toc-flow">Step-by-step flow</TocLink>
   <TocLink id="toc-considerations">Key considerations</TocLink>
-  <TocLink id="toc-explainer">Backend analogy</TocLink>
+  <TocLink id="toc-explainer">Frontend analogy</TocLink>
 </Toc>
 
 <SectionIntro>
@@ -53,6 +53,6 @@ Trace this workflow through the infrastructure stack.
 <ColItem>**Error handling is harder** &mdash; when a tool call fails mid-loop, the agent needs to recover gracefully. Design tools to return clear error messages the model can reason about, and implement retry strategies at the orchestration level.</ColItem>
 </SectionList>
 
-<Explainer title="AI agent &mdash; a backend analogy">
-An agent workflow is like a workflow engine (Temporal, AWS Step Functions) where each step dynamically decides the next one. Instead of a predefined DAG of tasks, the &ldquo;orchestrator&rdquo; is the model itself &mdash; it inspects results, decides what tool to call next, and terminates when the goal is met. The key difference from traditional workflow engines is that the routing logic is learned, not coded.
+<Explainer title="AI agent &mdash; a frontend analogy">
+An agent workflow is like a complex <code>useReducer</code> flow or an Express middleware chain where each step dynamically decides the next one. Instead of a predefined sequence of actions, the &ldquo;dispatcher&rdquo; is the model itself &mdash; it inspects results, decides what tool to call next, and terminates when the goal is met. Think of how a multi-step checkout flow might branch into different paths (address validation, payment retry, fraud check) based on intermediate results, except the branching logic is learned, not coded.
 </Explainer>

--- a/src/content/ai-infra/ai-wf-finetune.mdx
+++ b/src/content/ai-infra/ai-wf-finetune.mdx
@@ -16,7 +16,7 @@ linkRefs:
   <TocLink id="toc-when">When to use this pattern</TocLink>
   <TocLink id="toc-flow">Step-by-step flow</TocLink>
   <TocLink id="toc-considerations">Key considerations</TocLink>
-  <TocLink id="toc-explainer">Backend analogy</TocLink>
+  <TocLink id="toc-explainer">Frontend analogy</TocLink>
 </Toc>
 
 <SectionIntro>
@@ -53,6 +53,6 @@ Trace this workflow through the infrastructure stack.
 <ColItem>**Ongoing maintenance** &mdash; fine-tuned models need retraining as your data, requirements, or base model versions change. This is an ongoing operational commitment, not a one-time task.</ColItem>
 </SectionList>
 
-<Explainer title="Fine-tuning &mdash; a backend analogy">
-Fine-tuning is like a CI/CD pipeline for your ML model. Training data goes in (like source code), the pipeline processes it through training runs (like build and test stages), and a trained model artifact comes out (like a deployable binary). If quality metrics pass (like tests passing), the artifact gets pushed to a model registry (like a container registry) and deployed to production. The key difference is that &ldquo;builds&rdquo; take hours on GPUs, not minutes on CPUs.
+<Explainer title="Fine-tuning &mdash; a frontend analogy">
+Fine-tuning is like your frontend build pipeline. Training data goes in (like source code), the pipeline processes it through training runs (like webpack/Vite build and test stages), and a trained model artifact comes out (like a production bundle). If quality metrics pass (like Lighthouse scores and tests passing), the artifact gets pushed to a model registry (like publishing to npm) and deployed to production. The key difference is that &ldquo;builds&rdquo; take hours on GPUs, not seconds on your laptop.
 </Explainer>

--- a/src/content/ai-infra/ai-wf-rag.mdx
+++ b/src/content/ai-infra/ai-wf-rag.mdx
@@ -18,7 +18,7 @@ linkRefs:
   <TocLink id="toc-when">When to use this pattern</TocLink>
   <TocLink id="toc-flow">Step-by-step flow</TocLink>
   <TocLink id="toc-considerations">Key considerations</TocLink>
-  <TocLink id="toc-explainer">Backend analogy</TocLink>
+  <TocLink id="toc-explainer">Frontend analogy</TocLink>
 </Toc>
 
 <SectionIntro>
@@ -55,6 +55,6 @@ Trace this workflow through the infrastructure stack.
 <ColItem>**Guardrails are important** &mdash; the <NavLink to="ai-orchestration">orchestration layer</NavLink> should validate that the model&apos;s response actually uses the retrieved context and doesn&apos;t hallucinate beyond it.</ColItem>
 </SectionList>
 
-<Explainer title="RAG &mdash; a backend analogy">
-RAG is like a search-then-render pattern. When a user asks a question, your backend first queries Elasticsearch (or another search engine) for relevant documents, then uses those results to build the response page. The search step is the vector database query; the render step is the model generating an answer with the retrieved context. Just as search quality determines page relevance, retrieval quality determines answer accuracy.
+<Explainer title="RAG &mdash; a frontend analogy">
+RAG is like a search-then-render pattern in a React app. When a user types a query, your Express API first queries a search index for relevant documents, then passes those results to the model to generate an answer. The search step is the vector database query; the render step is the model generating a response with the retrieved context. Just as search relevance determines what your users see on a results page, retrieval quality determines answer accuracy.
 </Explainer>

--- a/src/content/ai-infra/ai-wf-simple-chat.mdx
+++ b/src/content/ai-infra/ai-wf-simple-chat.mdx
@@ -16,7 +16,7 @@ linkRefs:
   <TocLink id="toc-when">When to use this pattern</TocLink>
   <TocLink id="toc-flow">Step-by-step flow</TocLink>
   <TocLink id="toc-considerations">Key considerations</TocLink>
-  <TocLink id="toc-explainer">Backend analogy</TocLink>
+  <TocLink id="toc-explainer">Frontend analogy</TocLink>
 </Toc>
 
 <SectionIntro>
@@ -53,6 +53,6 @@ Trace this workflow through the infrastructure stack.
 <ColItem>**Rate limiting and authentication** &mdash; even the simplest workflow needs an API gateway to handle auth, rate limiting, and usage tracking in production.</ColItem>
 </SectionList>
 
-<Explainer title="Simple chat completion &mdash; a backend analogy">
-This is like a simple REST API request-response cycle. Your client sends a POST request with a payload (the prompt), the server processes it and returns a response (the completion). The only infrastructure involved is the server itself &mdash; no database queries, no cache lookups, no message queues. Streaming tokens via SSE is analogous to streaming a large HTTP response body rather than buffering the entire result.
+<Explainer title="Simple chat completion &mdash; a frontend analogy">
+This is like a simple Express route handler. Your React app sends a POST request via <code>fetch()</code>, Express receives it and calls the model, then streams tokens back via SSE. No database queries, no Redis lookups, no message queues &mdash; just a single request and a streamed response. The streaming pattern is the same one you&apos;d use for real-time notifications or live updates in any Node.js app.
 </Explainer>

--- a/src/data/aiInfraData/layers.ts
+++ b/src/data/aiInfraData/layers.ts
@@ -15,14 +15,14 @@ export const INFRA_LAYERS: InfraLayer[] = [
       {
         name: 'API Gateway',
         what: 'The front door. Like an Express/Next.js API route, but purpose-built for routing, auth, and rate limiting.',
-        analogy: 'Think of it like your React Router, but for backend services.',
+        analogy: 'Like Express Router with middleware for auth and rate limiting, but routing requests to AI models instead of your own endpoints.',
         tools: ['AWS API Gateway', 'Kong', 'Nginx', 'Envoy'],
       },
       {
         name: 'Model Serving',
         what: 'A specialized server that loads a model into GPU memory and responds to prediction requests. It handles batching multiple requests together for efficiency.',
         analogy:
-          'Like a server-side rendering server, but instead of rendering HTML it runs math through a neural network.',
+          'Like a specialized Express server, but instead of rendering templates or serving JSON it runs math through a neural network.',
         tools: ['vLLM', 'TGI (HuggingFace)', 'NVIDIA Triton', 'TensorRT-LLM'],
       },
       {
@@ -104,14 +104,14 @@ export const INFRA_LAYERS: InfraLayer[] = [
         name: 'Vector Databases',
         what: "Specialized databases optimized for finding the nearest neighbors to a given vector. Regular databases can\u2019t do this efficiently.",
         analogy:
-          'Like a search index (Elasticsearch) but instead of keyword matching, it finds things by meaning.',
+          'Like a search autocomplete that matches by meaning instead of exact text \u2014 you query \u2018broken login\u2019 and it finds docs about \u2018authentication failures.\u2019',
         tools: ['Pinecone', 'Weaviate', 'Chroma', 'pgvector'],
       },
       {
         name: 'Document Processing',
         what: 'Raw documents (PDFs, web pages, code) get chunked into pieces, embedded, and stored. Chunk size and overlap strategy significantly affect quality.',
         analogy:
-          'Like building a search index \u2014 you parse, tokenize, and index content. Same idea, different technique.',
+          'Like preprocessing markdown files into searchable content for your app \u2014 you parse, chunk, and transform raw documents into indexed pieces ready for retrieval.',
         tools: ['Unstructured', 'LangChain loaders', 'Apache Tika'],
       },
       {

--- a/src/data/aiInfraData/navigation.ts
+++ b/src/data/aiInfraData/navigation.ts
@@ -30,22 +30,22 @@ export const AI_INFRA_GUIDE_SECTIONS: GuideSection[] = [
 
 export const AI_INFRA_START_PAGE_DATA: StartPageData = {
   subtitle:
-    'A backend engineer\u2019s map to AI infrastructure \u2014 from model serving to GPU clusters.',
-  tip: 'Each layer is explained with analogies to familiar backend concepts like load balancers, databases, and CI pipelines.',
+    'A frontend engineer\u2019s map to AI infrastructure \u2014 from model serving to GPU clusters.',
+  tip: 'Each layer is explained with analogies to familiar frontend concepts like Express middleware, React state, and data-fetching patterns.',
   steps: [
     {
       type: 'numbered',
       num: 1,
       title: 'The Big Picture',
       description:
-        'Understand the five layers of AI infrastructure and how they map to concepts you already know from backend engineering.',
+        'Understand the five layers of AI infrastructure and how they map to concepts you already know from frontend engineering.',
       jumpTo: 'ai-overview',
     },
     {
       type: 'bonus',
       title: 'The Stack',
       description:
-        'Explore each infrastructure layer in depth \u2014 what it does, key concepts, real-world tools, and backend analogies.',
+        'Explore each infrastructure layer in depth \u2014 what it does, key concepts, real-world tools, and frontend analogies.',
       sectionLabel: 'The Stack',
       subItemDescriptions: {
         'ai-inference':

--- a/src/data/guideRegistry.ts
+++ b/src/data/guideRegistry.ts
@@ -82,7 +82,7 @@ export const guides: GuideDefinition[] = [
     title: 'AI Infrastructure',
     startPageId: 'ai-start',
     description:
-      'Understand AI backend infrastructure \u2014 from model serving and vector databases to GPU clusters and training pipelines.',
+      'Understand AI infrastructure from a frontend engineer\u2019s perspective \u2014 from the API calls your React app makes to model serving, vector databases, and GPU clusters.',
     sections: AI_INFRA_GUIDE_SECTIONS,
   },
 ]


### PR DESCRIPTION
Reframe the AI Infrastructure guide from "A backend engineer's map"
to "A frontend engineer's map to AI infrastructure." All analogies
now reference frontend/MERN-stack concepts (Express middleware,
React state, data-fetching patterns) instead of backend concepts
(load balancers, Elasticsearch, workflow engines).

https://claude.ai/code/session_01VsYLBbkjdRpahRNavhwudc