### PR TITLE
Auto-populate Resources tiles on guide start pages (#128)

### DIFF
--- a/.claude/skills/add-guide/SKILL.md
+++ b/.claude/skills/add-guide/SKILL.md
@@ -60,7 +60,9 @@ guide: "<guide-id>"
 <GuideStartContent guideId="<guide-id>" />
 ```
 
-The `GuideStartContent` component reads `StartPageData` from `guideRegistry.ts` and renders the learning path automatically. Sub-items are auto-derived from guide sections via `sectionLabel` references. Per-item descriptions are provided via `subItemDescriptions` in the start page data. For items not derivable from sections (cross-guide links, resource page links), use `customSubItems`.
+The `GuideStartContent` component reads `StartPageData` from `guideRegistry.ts` and renders the learning path automatically. Sub-items are auto-derived from guide sections via `sectionLabel` references. Per-item descriptions are provided via `subItemDescriptions` in the start page data. For items not derivable from sections (cross-guide links), use `customSubItems`.
+
+The component also auto-renders a **Resources** section at the bottom of every start page with three tiles: External Resources (pre-filtered by guide), Glossary (pre-filtered by guide), and Checklist (links to the guide's checklist from `checklistPages` in `guideRegistry.ts`, or shows a "Coming Soon" placeholder if none exists). Do **not** add manual Resources bonus steps to `StartPageData` — they are handled automatically.
 
 ## Interactive MDX Component Template
 
@@ -142,6 +144,7 @@ MyComponent,
 - **Navigation (prev/next)**: derived from guide sections — works automatically
 - **Content registry**: auto-discovers new MDX files in `src/content/`
 - **Start page sub-items**: derived from guide sections via `sectionLabel` in `StartPageData` — adding/removing pages from a section automatically updates the start page learning path
+- **Start page Resources tiles**: External Resources, Glossary, and Checklist tiles auto-populate at the bottom of every start page — no manual `customSubItems` needed
 - **Start page header**: title, description, and icon read from `guideRegistry.ts` — changing them updates the start page automatically
 - **Router**: resolves MDX pages via auto-discovery and component pages via `componentPages.tsx` registry — no `router.tsx` edits needed
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,6 +223,8 @@ Each guide's page order is defined in **one place**: the `*_GUIDE_SECTIONS` arra
 
 Start pages use the data-driven `<GuideStartContent>` component, which auto-derives learning-path sub-items from the `*_GUIDE_SECTIONS` definition via `sectionLabel` references in `StartPageData`. No manual sync needed.
 
+`<GuideStartContent>` also auto-renders a **Resources** section at the bottom of every start page with three tiles (1/3 width each): **External Resources** (pre-filtered by guide), **Glossary** (pre-filtered by guide), and **Checklist** (links to the guide's checklist from `checklistPages`, or shows a "Coming Soon" placeholder if none exists). Do not add manual Resources bonus steps to `StartPageData` — they are handled automatically.
+
 **Top-level resource pages** (`external-resources`, `glossary`) are NOT part of any guide's navigation order. They appear in the sidebar under a dedicated "Resources" icon, in the command menu under a "Resources" group, and on the home page. They do not have Previous/Next navigation.
 
 When adding, removing, or reordering pages within a guide, update the `*_GUIDE_SECTIONS` array in the guide's data file. Everything else updates automatically.

--- a/src/components/mdx/GuideStartContent.tsx
+++ b/src/components/mdx/GuideStartContent.tsx
@@ -1,10 +1,11 @@
 import { useNavigate } from '@tanstack/react-router'
-import { guides, getStartPageData } from '../../data/guideRegistry'
+import { guides, getStartPageData, checklistPages } from '../../data/guideRegistry'
 import { contentPages } from '../../content/registry'
 import { getNavTitle } from '../../data/navigation'
 import { JumpButton, jumpBtnCls } from '../JumpButton'
 import { RoadmapSteps } from './npm-package/RoadmapSteps'
 import type { StartPageStep, StartPageSubItem } from '../../data/guideTypes'
+import { parseTitle } from '../../helpers/parseTitle'
 
 function GuideFilterButton({ sectionId, guideId, children }: { sectionId: string; guideId: string; children: React.ReactNode }) {
   const navigate = useNavigate()
@@ -121,6 +122,66 @@ function StepCard({ step, guide }: { step: StartPageStep; guide: { id: string; s
   )
 }
 
+const tileCls = 'flex flex-col items-start text-left p-5 bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl cursor-pointer transition-all duration-150 hover:border-blue-500 dark:hover:border-blue-400 hover:shadow-lg hover:shadow-blue-500/10 hover:-translate-y-0.5'
+const comingSoonCls = 'flex flex-col items-start text-left p-5 bg-slate-50 dark:bg-slate-800/50 border border-dashed border-slate-300 dark:border-slate-600 rounded-xl'
+
+function GuideStartResources({ guideId }: { guideId: string }) {
+  const navigate = useNavigate()
+  const checklist = checklistPages.find(cp => cp.sourceGuideId === guideId)
+  const checklistTitle = checklist
+    ? parseTitle(contentPages.get(checklist.id)?.title ?? getNavTitle(checklist.id))
+    : null
+
+  return (
+    <div className="mt-7 pt-6 border-t-2 border-dashed border-slate-300 dark:border-slate-600">
+      <h3 className="text-base font-bold text-slate-900 dark:text-slate-100 mb-4">{'\u{1F4CC}'} Resources</h3>
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <button
+          className={tileCls}
+          onClick={() => {
+            navigate({ to: '/$sectionId', params: { sectionId: 'external-resources' }, search: { guide: guideId } })
+            window.scrollTo({ top: 0, behavior: 'smooth' })
+          }}
+        >
+          <span className="text-2xl mb-2">{'\u{1F4DA}'}</span>
+          <span className="text-sm font-bold text-slate-900 dark:text-slate-100 mb-1">External Resources</span>
+          <span className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed">Curated documentation, articles, and tools.</span>
+        </button>
+        <button
+          className={tileCls}
+          onClick={() => {
+            navigate({ to: '/$sectionId', params: { sectionId: 'glossary' }, search: { guide: guideId } })
+            window.scrollTo({ top: 0, behavior: 'smooth' })
+          }}
+        >
+          <span className="text-2xl mb-2">{'\u{1F4D6}'}</span>
+          <span className="text-sm font-bold text-slate-900 dark:text-slate-100 mb-1">Glossary</span>
+          <span className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed">Key terms with links to guide pages and docs.</span>
+        </button>
+        {checklist && checklistTitle ? (
+          <button
+            className={tileCls}
+            onClick={() => {
+              navigate({ to: '/$sectionId', params: { sectionId: checklist.id } })
+              window.scrollTo({ top: 0, behavior: 'smooth' })
+            }}
+          >
+            <span className="text-2xl mb-2">{checklistTitle.icon || '\u2705'}</span>
+            <span className="text-sm font-bold text-slate-900 dark:text-slate-100 mb-1">{checklistTitle.text}</span>
+            <span className="text-xs text-slate-600 dark:text-slate-400 leading-relaxed">Interactive checklist for this guide.</span>
+          </button>
+        ) : (
+          <div className={comingSoonCls}>
+            <span className="text-2xl mb-2">{'\u2705'}</span>
+            <span className="text-sm font-bold text-slate-400 dark:text-slate-500 mb-1">Checklist</span>
+            <span className="text-xs text-slate-400 dark:text-slate-500 leading-relaxed">Coming soon.</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
 export function GuideStartContent({ guideId }: { guideId: string }) {
   const guide = guides.find(g => g.id === guideId)
   const startData = getStartPageData(guideId)
@@ -147,6 +208,8 @@ export function GuideStartContent({ guideId }: { guideId: string }) {
       {startData.steps.map((step, i) => (
         <StepCard key={i} step={step} guide={guide} />
       ))}
+
+      <GuideStartResources guideId={guideId} />
     </div>
   )
 }

--- a/src/content/checklist/auth-checklist.mdx
+++ b/src/content/checklist/auth-checklist.mdx
@@ -1,6 +1,6 @@
 ---
 id: "auth-checklist"
-title: "Implementation Checklist ✅"
+title: "Auth Checklist 🔐"
 linkRefs:
   - id: "auth0-pkce"
     note: "PKCE reference for the OAuth checklist items"

--- a/src/content/checklist/checklist.mdx
+++ b/src/content/checklist/checklist.mdx
@@ -1,6 +1,6 @@
 ---
 id: "checklist"
-title: "Publish Checklist ✅"
+title: "NPM Publish Checklist 📦"
 ---
 
 <SectionTitle>{frontmatter.title}</SectionTitle>

--- a/src/content/checklist/prompt-claudemd-checklist.mdx
+++ b/src/content/checklist/prompt-claudemd-checklist.mdx
@@ -1,6 +1,6 @@
 ---
 id: "prompt-claudemd-checklist"
-title: "CLAUDE.md Checklist ✅"
+title: "CLAUDE.md Checklist 🧠"
 usedFootnotes: [1]
 linkRefs:
   - id: "anthropic-claude-md"

--- a/src/content/checklist/test-review-checklist.mdx
+++ b/src/content/checklist/test-review-checklist.mdx
@@ -1,6 +1,6 @@
 ---
 id: "test-review-checklist"
-title: "Quick Test Review 📋"
+title: "Test Review Checklist 🧪"
 usedFootnotes: [1, 2]
 linkRefs:
   - id: "kentcdodds-write-tests"

--- a/src/data/archData/navigation.ts
+++ b/src/data/archData/navigation.ts
@@ -60,25 +60,6 @@ export const ARCH_START_PAGE_DATA: StartPageData = {
       description: 'Trace a user action through every layer of the stack \u2014 from button click to database query and back to the screen.',
       jumpTo: 'arch-how-it-connects',
     },
-    {
-      type: 'bonus',
-      title: 'Resources',
-      description: 'Documentation, articles, and tools for deeper learning about web architecture.',
-      customSubItems: [
-        {
-          title: '\u{1F4DA} External Resources',
-          description: 'Curated documentation, articles, and tools \u2014 filtered for the Architecture Guide.',
-          jumpTo: 'external-resources',
-          jumpType: 'guide-filter',
-        },
-        {
-          title: '\u{1F4D6} Glossary',
-          description: 'Key architecture and web development terms, with links to guide pages.',
-          jumpTo: 'glossary',
-          jumpType: 'guide-filter',
-        },
-      ],
-    },
   ],
 }
 

--- a/src/data/authData/navigation.ts
+++ b/src/data/authData/navigation.ts
@@ -59,29 +59,5 @@ export const AUTH_START_PAGE_DATA: StartPageData = {
         'auth-quiz': 'Five questions to test what you\u2019ve learned across the guide.',
       },
     },
-    {
-      type: 'bonus',
-      title: 'Resources',
-      description: 'Checklists, documentation, and tools for authentication implementation.',
-      customSubItems: [
-        {
-          title: '\u2705 Implementation Checklist',
-          description: 'A categorized checklist covering storage, tokens, architecture, OAuth, and security best practices.',
-          jumpTo: 'auth-checklist',
-        },
-        {
-          title: '\u{1F4DA} External Resources',
-          description: 'Curated auth documentation, articles, and tools.',
-          jumpTo: 'external-resources',
-          jumpType: 'guide-filter',
-        },
-        {
-          title: '\u{1F4D6} Glossary',
-          description: 'Key authentication and authorization terms.',
-          jumpTo: 'glossary',
-          jumpType: 'guide-filter',
-        },
-      ],
-    },
   ],
 }

--- a/src/data/cicdData.ts
+++ b/src/data/cicdData.ts
@@ -284,24 +284,5 @@ export const CICD_START_PAGE_DATA: StartPageData = {
       description: 'The things that trip people up: npm ci vs install, YAML indentation, fork PR secrets, and more.',
       jumpTo: 'cicd-gotchas',
     },
-    {
-      type: 'bonus',
-      title: 'Resources',
-      description: 'Documentation and tools for CI/CD and GitHub Actions.',
-      customSubItems: [
-        {
-          title: '\u{1F4DA} External Resources',
-          description: 'Curated CI/CD documentation, articles, and tools.',
-          jumpTo: 'external-resources',
-          jumpType: 'guide-filter',
-        },
-        {
-          title: '\u{1F4D6} Glossary',
-          description: 'Key CI/CD and GitHub Actions terms.',
-          jumpTo: 'glossary',
-          jumpType: 'guide-filter',
-        },
-      ],
-    },
   ],
 }

--- a/src/data/npmPackageData.ts
+++ b/src/data/npmPackageData.ts
@@ -55,29 +55,5 @@ export const NPM_START_PAGE_DATA: StartPageData = {
         },
       ],
     },
-    {
-      type: 'bonus',
-      title: 'Resources',
-      description: 'Documentation, articles, courses, and tools to go deeper on frontend development, npm packages, and the JavaScript ecosystem.',
-      customSubItems: [
-        {
-          title: '\u2705 Publish Checklist',
-          description: 'Go through this before every npm publish \u2014 trust us, it saves headaches.',
-          jumpTo: 'checklist',
-        },
-        {
-          title: '\u{1F4DA} External Resources',
-          description: 'Curated documentation, articles, courses, tools, and section references \u2014 all in one searchable, sortable table.',
-          jumpTo: 'external-resources',
-          jumpType: 'guide-filter',
-        },
-        {
-          title: '\u{1F4D6} Glossary',
-          description: 'Key terms you\u2019ll encounter when building and publishing npm packages, with links to the relevant sections in this guide.',
-          jumpTo: 'glossary',
-          jumpType: 'guide-filter',
-        },
-      ],
-    },
   ],
 }

--- a/src/data/promptData/navigation.ts
+++ b/src/data/promptData/navigation.ts
@@ -162,30 +162,6 @@ export const PROMPT_START_PAGE_DATA: StartPageData = {
         'prompt-tools-optimization': 'Headless mode, batch processing, and context management strategies.',
       },
     },
-    {
-      type: 'bonus',
-      title: 'Resources',
-      description: 'Checklists, documentation, and reference material for AI-assisted development.',
-      customSubItems: [
-        {
-          title: '\u2705 CLAUDE.md Checklist',
-          description: 'A comprehensive checklist for building effective CLAUDE.md files.',
-          jumpTo: 'prompt-claudemd-checklist',
-        },
-        {
-          title: '\u{1F4DA} External Resources',
-          description: 'Curated prompt engineering documentation, articles, and tools.',
-          jumpTo: 'external-resources',
-          jumpType: 'guide-filter',
-        },
-        {
-          title: '\u{1F4D6} Glossary',
-          description: 'Key prompt engineering and AI coding tool terms.',
-          jumpTo: 'glossary',
-          jumpType: 'guide-filter',
-        },
-      ],
-    },
   ],
 }
 

--- a/src/data/testingData.ts
+++ b/src/data/testingData.ts
@@ -357,30 +357,6 @@ export const TESTING_START_PAGE_DATA: StartPageData = {
       description: 'A filterable directory of the most popular testing tools in the React ecosystem, with guidance on when to use each one.',
       jumpTo: 'test-tools',
     },
-    {
-      type: 'bonus',
-      title: 'Resources',
-      description: 'Checklists, documentation, and tools for frontend testing.',
-      customSubItems: [
-        {
-          title: '\u2705 Quick Test Review',
-          description: 'An interactive checklist for reviewing test code in pull requests.',
-          jumpTo: 'test-review-checklist',
-        },
-        {
-          title: '\u{1F4DA} External Resources',
-          description: 'Curated testing documentation, articles, and tools.',
-          jumpTo: 'external-resources',
-          jumpType: 'guide-filter',
-        },
-        {
-          title: '\u{1F4D6} Glossary',
-          description: 'Key testing terms and tool definitions.',
-          jumpTo: 'glossary',
-          jumpType: 'guide-filter',
-        },
-      ],
-    },
   ],
 }
 


### PR DESCRIPTION
Replace manually defined Resources bonus steps on 6 guide start pages
with a reusable GuideStartResources component that auto-renders at the
bottom of every start page. Three 1/3-width tiles link to External
Resources (pre-filtered), Glossary (pre-filtered), and the guide's
checklist (or a "Coming Soon" placeholder). Kubernetes and AI Infra
guides now get Resources tiles automatically.

Also rename checklists to be more self-descriptive with unique icons:
- "Publish Checklist ✅" → "NPM Publish Checklist 📦"
- "Quick Test Review 📋" → "Test Review Checklist 🧪"
- "CLAUDE.md Checklist ✅" → "CLAUDE.md Checklist 🧠"
- "Implementation Checklist ✅" → "Auth Checklist 🔐"

https://claude.ai/code/session_01S8SJabspGeEMv4GwuSkz2V