### PR TITLE
Refactor guide navigation and add related guides section

### DIFF
--- a/src/components/mdx/npm-package/RoadmapSteps.tsx
+++ b/src/components/mdx/npm-package/RoadmapSteps.tsx
@@ -1,8 +1,11 @@
 import { roadmapSteps } from '../../../data/roadmapSteps'
 import { getNavTitle } from '../../../data/navigation'
 import { JumpButton } from '../../JumpButton'
+import { useNavigateToSection } from '../../../hooks/useNavigateToSection'
 
 export function RoadmapSteps() {
+  const navigateToSection = useNavigateToSection()
+
   return (
     <>
       {roadmapSteps.map(step => (
@@ -21,11 +24,13 @@ export function RoadmapSteps() {
             )}
             {step.substep && (
               <div className="mt-4 pl-3.5 border-l-2 border-slate-200 dark:border-slate-700">
-                <h3 className="text-sm font-bold text-slate-900 dark:text-slate-100 m-0 mb-0.5">{step.substep.title}</h3>
+                <h3
+                  className="text-sm font-bold text-slate-900 dark:text-slate-100 m-0 mb-0.5 cursor-pointer hover:text-blue-600 dark:hover:text-blue-400 transition-colors inline-flex items-center gap-1"
+                  onClick={() => navigateToSection(step.substep!.jumpTo)}
+                >
+                  {step.substep.title} <span className="text-blue-500 dark:text-blue-400">{'\u2192'}</span>
+                </h3>
                 <div className="text-sm text-slate-800 dark:text-slate-300 leading-relaxed">{step.substep.text}</div>
-                <JumpButton jumpTo={step.substep.jumpTo} style={{ marginTop: 4 }}>
-                  {'\u2192'} Deep dive: {getNavTitle(step.substep.jumpTo)}
-                </JumpButton>
               </div>
             )}
           </div>

--- a/src/data/guideTypes.ts
+++ b/src/data/guideTypes.ts
@@ -39,4 +39,5 @@ export interface StartPageData {
   headingText?: string
   headingDescription?: string
   steps: StartPageStep[]
+  relatedGuides?: string[]
 }

--- a/src/data/npmPackageData.ts
+++ b/src/data/npmPackageData.ts
@@ -20,6 +20,7 @@ export const NPM_START_PAGE_DATA: StartPageData = {
   tip: 'Look for the green "Explain it to me" dropdowns for backend-friendly analogies.',
   headingText: '\u{1F680} Building a Package: Step by Step',
   headingDescription: 'New to npm packages? Follow these steps in order. Each step links to a deeper explanation in the other tabs. This is the order you\u2019d actually set things up in a real project.',
+  relatedGuides: ['architecture'],
   steps: [
     {
       type: 'bonus',
@@ -42,18 +43,6 @@ export const NPM_START_PAGE_DATA: StartPageData = {
       subItemDescriptions: {
         'storybook': 'Storybook is a tool for building and testing UI components in isolation \u2014 outside of your app. Think of it like a visual unit test lab for your UI.',
       },
-    },
-    {
-      type: 'bonus',
-      title: 'Bonus: Developer Experience',
-      description: '',
-      customSubItems: [
-        {
-          title: '\u{1F3D7}\uFE0F Architecture Guide',
-          description: 'An interactive guide to web tech stacks \u2014 explore each layer of a modified MERN stack and compare popular alternatives like LAMP, Django, and Rails.',
-          jumpTo: 'arch-start',
-        },
-      ],
     },
   ],
 }


### PR DESCRIPTION
## Summary
This PR refactors the guide navigation system to use a unified `useNavigateToSection` hook and introduces a new "Related Guides" section to guide start pages. The changes simplify navigation logic and improve code reusability across components.

## Key Changes
- **Removed `GuideFilterButton` component**: Consolidated its logic into the `SubItem` component, eliminating duplicate navigation handling
- **Unified navigation approach**: Both `SubItem` and `RoadmapSteps` now use the `useNavigateToSection` hook for consistent navigation behavior
- **Made SubItem titles interactive**: Converted static titles to clickable elements with hover effects and arrow indicators, allowing direct navigation from item titles
- **Added `GuideStartRelatedGuides` component**: New section that displays related guides as interactive tiles with icons and descriptions
- **Updated `StartPageData` type**: Added optional `relatedGuides` field to support linking related guides
- **Refactored npm package data**: Moved the Architecture Guide from a bonus step into the new related guides system
- **Removed unused imports**: Cleaned up `jumpBtnCls` import that's no longer needed

## Implementation Details
- The `SubItem` component now handles both 'guide-filter' and regular navigation types through a unified `handleClick` handler
- Related guides are filtered and validated to ensure only existing guides are displayed
- The new related guides section uses a responsive grid layout (1 column on mobile, 3 columns on desktop)
- Navigation from SubItem titles and RoadmapSteps substeps now uses the same hook, ensuring consistent behavior across the application

https://claude.ai/code/session_01FkZDcZPyV4HhC3it2EyNrJ