### PR TITLE
Fix YAML indentation rendering in YamlExplorer

### DIFF
--- a/src/components/mdx/ci-cd/YamlExplorer.tsx
+++ b/src/components/mdx/ci-cd/YamlExplorer.tsx
@@ -19,7 +19,7 @@ export function YamlExplorer() {
             <div
               key={i}
               onClick={() => item.note ? setActiveLine(activeLine === i ? null : i) : undefined}
-              className="px-4 transition-all duration-150"
+              className="px-4 transition-all duration-150 whitespace-pre"
               style={{
                 cursor: item.note ? 'pointer' : 'default',
                 background: activeLine === i


### PR DESCRIPTION
Add whitespace-pre to preserve leading spaces in YAML lines.
HTML was collapsing the indentation spaces, making all lines
appear left-aligned despite correct data.

https://claude.ai/code/session_01RmLcXQfo2G1eBd43CHnp3x