### PR TITLE
Restyle Common AI Mistakes section pages for consistency

### DIFF
--- a/src/components/mdx/prompt-engineering/MistakeList.tsx
+++ b/src/components/mdx/prompt-engineering/MistakeList.tsx
@@ -9,13 +9,13 @@ export function MistakeList({ categoryId }: { categoryId: string }) {
     <div className="flex flex-col gap-5">
       {category.items.map(item => (
         <div key={item.id}>
-          <h3 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mb-2 mt-0" id={item.id}>
+          <h2 className="text-lg font-bold text-slate-900 dark:text-slate-100 mt-5 mb-2 first:mt-0" id={item.id}>
             {item.mistake}
-          </h3>
-          <div className="text-xs text-slate-600 dark:text-slate-400 mb-2 px-3 py-2 bg-slate-50 dark:bg-slate-800/50 rounded-md">
+          </h2>
+          <div className="text-sm text-slate-800 dark:text-slate-300 leading-relaxed mb-2">
             {parseInlineCode(item.example)}
           </div>
-          <div className="text-sm text-blue-600 dark:text-cyan-400 flex gap-1.5 items-start">
+          <div className="text-sm text-slate-800 dark:text-slate-300 leading-relaxed flex gap-1.5 items-start">
             <span className="shrink-0">{'\u{1F4A1}'}</span>
             <span>{item.fix}</span>
           </div>

--- a/src/components/mdx/prompt-engineering/PromptCollection.tsx
+++ b/src/components/mdx/prompt-engineering/PromptCollection.tsx
@@ -7,43 +7,43 @@ export function PromptCollection({ categoryId }: { categoryId: string }) {
   const category = MISTAKE_CATEGORIES.find(c => c.id === categoryId)
   if (!category) return null
 
+  const markdownText = category.items
+    .map((item, i) => `${i + 1}. ${item.fix}`)
+    .join('\n')
+
   const handleCopy = () => {
-    const text = category.items
-      .map((item, i) => `${i + 1}. ${item.fix}`)
-      .join('\n')
-    navigator.clipboard.writeText(text).then(() => {
+    navigator.clipboard.writeText(markdownText).then(() => {
       setCopied(true)
       setTimeout(() => setCopied(false), 2000)
     })
   }
 
   return (
-    <div id={`toc-${categoryId}-prompts`} className="mt-6 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
-      <div className="flex justify-between items-center py-2 px-3.5 bg-slate-50 dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700">
-        <span className="font-bold text-sm text-slate-900 dark:text-slate-100">
-          {'\u{1F4CB}'} All Prompts
-        </span>
+    <>
+      <h2
+        className="text-lg font-bold text-slate-900 dark:text-slate-100 mt-5 mb-2"
+        id={`toc-${categoryId}-prompts`}
+      >
+        {'\u{1F4CB}'} All Prompts
+      </h2>
+      <div className="relative border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
         <button
           className={clsx(
-            'font-sans text-xs font-semibold py-1 px-2.5 border rounded-md cursor-pointer transition-all duration-150 shrink-0',
+            'absolute top-2 right-2 z-10 font-sans text-xs font-semibold py-1 px-2.5 border rounded-md cursor-pointer transition-all duration-150 shrink-0',
             copied
               ? 'border-green-500 text-green-500 bg-green-50 dark:bg-green-500/10'
               : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-500 dark:text-slate-400 hover:border-blue-500 dark:hover:border-blue-400 hover:text-blue-500 dark:hover:text-blue-400'
           )}
           onClick={handleCopy}
         >
-          {copied ? '\u2713 Copied!' : '\u{1F4CB} Copy All'}
+          {copied ? '\u2713 Copied!' : '\u{1F4CB} Copy as Markdown'}
         </button>
+        <pre className="bg-slate-50 dark:bg-slate-900 p-4 pr-40 overflow-x-auto m-0">
+          <code className="text-sm text-slate-800 dark:text-slate-300 font-mono leading-relaxed whitespace-pre-wrap">
+            {markdownText}
+          </code>
+        </pre>
       </div>
-      <div className="p-4">
-        <ol className="list-decimal pl-5 flex flex-col gap-2 m-0">
-          {category.items.map(item => (
-            <li key={item.id} className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
-              {item.fix}
-            </li>
-          ))}
-        </ol>
-      </div>
-    </div>
+    </>
   )
 }

--- a/src/components/mdx/prompt-engineering/TestingMistakes.tsx
+++ b/src/components/mdx/prompt-engineering/TestingMistakes.tsx
@@ -13,19 +13,19 @@ export function TestingMistakes({ context }: { context?: 'e2e' | 'unit' }) {
     <div>
       {e2eItems.length > 0 && (
         <>
-          <h3 id="toc-e2e" className="text-base font-bold text-slate-900 dark:text-slate-100 mb-3 mt-6 first:mt-0">
+          <h2 id="toc-e2e" className="text-lg font-bold text-slate-900 dark:text-slate-100 mt-5 mb-2 first:mt-0">
             {'\u{1F310}'} End-to-End (E2E) Testing
-          </h3>
+          </h2>
           <div className="flex flex-col gap-3 mb-6">
             {e2eItems.map((item, i) => (
               <div key={i}>
-                <h4 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mb-2">
+                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100 mb-2">
                   {item.mistake}
-                </h4>
-                <div className="text-xs text-slate-600 dark:text-slate-400 mb-2 px-3 py-2 bg-slate-50 dark:bg-slate-800/50 rounded-md">
+                </h3>
+                <div className="text-sm text-slate-800 dark:text-slate-300 leading-relaxed mb-2">
                   {parseInlineCode(item.example)}
                 </div>
-                <div className="text-sm text-blue-600 dark:text-cyan-400 flex gap-1.5 items-start">
+                <div className="text-sm text-slate-800 dark:text-slate-300 leading-relaxed flex gap-1.5 items-start">
                   <span className="shrink-0">{'\u{1F4A1}'}</span>
                   <span>{item.fix}</span>
                 </div>
@@ -37,19 +37,19 @@ export function TestingMistakes({ context }: { context?: 'e2e' | 'unit' }) {
 
       {unitItems.length > 0 && (
         <>
-          <h3 id="toc-unit" className="text-base font-bold text-slate-900 dark:text-slate-100 mb-3 mt-6">
+          <h2 id="toc-unit" className="text-lg font-bold text-slate-900 dark:text-slate-100 mt-5 mb-2">
             {'\u{1F9EA}'} Unit Testing
-          </h3>
+          </h2>
           <div className="flex flex-col gap-3">
             {unitItems.map((item, i) => (
               <div key={i}>
-                <h4 className="font-semibold text-sm text-slate-900 dark:text-slate-100 mb-2">
+                <h3 className="text-base font-semibold text-slate-900 dark:text-slate-100 mb-2">
                   {item.mistake}
-                </h4>
-                <div className="text-xs text-slate-600 dark:text-slate-400 mb-2 px-3 py-2 bg-slate-50 dark:bg-slate-800/50 rounded-md">
+                </h3>
+                <div className="text-sm text-slate-800 dark:text-slate-300 leading-relaxed mb-2">
                   {parseInlineCode(item.example)}
                 </div>
-                <div className="text-sm text-blue-600 dark:text-cyan-400 flex gap-1.5 items-start">
+                <div className="text-sm text-slate-800 dark:text-slate-300 leading-relaxed flex gap-1.5 items-start">
                   <span className="shrink-0">{'\u{1F4A1}'}</span>
                   <span>{item.fix}</span>
                 </div>


### PR DESCRIPTION
- Promote mistake item headings to h2 with SectionSubheading styling
- Remove colored backgrounds from example text, use standard body text
- Move "All Prompts" heading outside box as h2, display as code block
- Rename copy button from "Copy All" to "Copy as Markdown"
- Apply same heading/text changes to TestingMistakes component

Resolves #150

https://claude.ai/code/session_01JYP9CrBFMnjczTyLkNmTdr