### PR TITLE
Add Next.js Abstractions guide and refactor documentation

### DIFF
--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,30 @@
+# Large data files - read on demand when working with specific guides
+# These files contain HTML content strings, URL metadata, and term definitions
+# that are rarely needed for general exploration
+
+# Link registry files (URL metadata, 300-900+ lines each)
+src/data/linkRegistry/npmPackageLinks.ts
+src/data/linkRegistry/architectureLinks.ts
+src/data/linkRegistry/promptLinks.ts
+src/data/linkRegistry/authLinks.ts
+src/data/linkRegistry/kubernetesLinks.ts
+src/data/linkRegistry/aiInfraLinks.ts
+src/data/linkRegistry/njaLinks.ts
+src/data/linkRegistry/testingLinks.ts
+src/data/linkRegistry/cicdLinks.ts
+
+# Glossary term files (term definitions, 100-350 lines each)
+src/data/glossaryTerms/npmPackageTerms.ts
+src/data/glossaryTerms/architectureTerms.ts
+src/data/glossaryTerms/promptTerms.ts
+src/data/glossaryTerms/authTerms.ts
+src/data/glossaryTerms/kubernetesTerms.ts
+src/data/glossaryTerms/aiInfraTerms.ts
+src/data/glossaryTerms/njaTerms.ts
+src/data/glossaryTerms/testingTerms.ts
+src/data/glossaryTerms/cicdTerms.ts
+
+# Large monolithic data files (300-2700 lines)
+src/data/npmPackageData.ts
+src/data/promptData/techniques.ts
+src/data/archData/stacks.ts

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ Educational single-page application (SPA) with multiple guides for backend engin
 
 ## Guides
 
-Eight independent guides plus top-level resource pages. All metadata centralized in `src/data/guideRegistry.ts`. Each guide has its own `CLAUDE.md` in its content directory with guide-specific audience info, section conventions, interactive component usage, and data file locations.
+Nine independent guides plus top-level resource pages. All metadata centralized in `src/data/guideRegistry.ts`. Each guide has its own `CLAUDE.md` in its content directory with guide-specific audience, conventions, and component usage.
 
 | Guide ID | Title | Start Page |
 |----------|-------|------------|
@@ -18,266 +18,69 @@ Eight independent guides plus top-level resource pages. All metadata centralized
 | `auth` | Auth for Frontend Engineers | `auth-start` |
 | `kubernetes` | Kubernetes & Helm | `k8s-start` |
 | `ai-infra` | AI Infrastructure | `ai-start` |
+| `nextjs-abstractions` | Next.js Abstractions | `nja-start` |
 
-Each guide follows the same structure:
+Every guide follows the same file layout:
 - **Data:** `src/data/<guideId>Data.ts` (or `src/data/<guideId>Data/` directory)
-- **Content pages:** `src/content/<guide-id>/*.mdx`
+- **Content pages:** `src/content/<guide-id>/*.mdx` (auto-discovered)
 - **Interactive components:** `src/components/mdx/<guide-id>/`
 - **Glossary terms:** `src/data/glossaryTerms/<guideId>Terms.ts`
 - **Link registry:** `src/data/linkRegistry/<guideId>Links.ts`
 - **Guide-specific docs:** `src/content/<guide-id>/CLAUDE.md`
 
 ### Top-Level Resources
-- **External Resources** (`src/components/ExternalResourcesPage.tsx`) — searchable, filterable table. Data in `src/data/overallResources.ts`.
-- **Glossary** (`src/components/GlossaryPage.tsx`) — searchable glossary with Guide and Category filters. Data in `src/data/glossaryTerms/`.
-- Both support `?guide=` URL param to pre-select a guide filter. Glossary also supports `?search=` for CMD-K term navigation.
-- Appear in the sidebar under "Resources" icon, command menu under "Resources" group, and on the home page.
+
+- **External Resources** (`src/components/ExternalResourcesPage.tsx`) — searchable, filterable table derived from `src/data/linkRegistry/`.
+- **Glossary** (`src/components/GlossaryPage.tsx`) — searchable glossary. Data in `src/data/glossaryTerms/`.
+- Both support `?guide=` URL param to pre-select a guide filter.
 
 ## Tech Stack
 
-- **Framework:** React 19 + TanStack Router (hash-based routing for GitHub Pages) + TanStack Table (External Resources, Glossary)
-- **Language:** TypeScript (strict mode)
-- **Build Tool:** Vite 7
-- **Package Manager:** pnpm
-- **Styling:** Tailwind CSS v4 (via `@tailwindcss/vite` plugin) + `clsx` for conditional classes
-- **Hosting:** GitHub Pages at `/npm-package-guide/` subpath
+React 19 · TanStack Router (hash-based) · TanStack Table · TypeScript (strict) · Vite 7 · pnpm · Tailwind CSS v4 + `clsx` · GitHub Pages at `/npm-package-guide/`
 
 ## Commands
 
 | Command | Purpose |
 |---------|---------|
 | `pnpm dev` | Start dev server |
-| `pnpm build` | TypeScript check (`tsc -b`) + Vite build |
+| `pnpm build` | TypeScript check + Vite build |
 | `pnpm lint` | Run ESLint |
-| `pnpm validate:data` | Cross-reference integrity checks (link IDs, glossary refs, guide sections) |
-| `pnpm validate` | Full validation pipeline: `validate:data` + `lint` + `build` |
-| `pnpm preview` | Preview production build |
+| `pnpm validate` | Full pipeline: `validate:data` + `lint` + `build` |
 
 ## Project Structure
 
-- `src/components/` — Shared React functional components (TSX)
-- `src/components/mdx/` — Shared MDX-available components (registered in `src/components/mdx/index.ts`)
-  - `src/components/mdx/<guide-id>/` — Per-guide interactive MDX components
-- `src/content/` — MDX content pages, auto-discovered by `src/content/registry.ts`
-  - `src/content/<guide-id>/` — Per-guide MDX pages (see **Guides** table above). **All guide content pages must live in `src/content/<guide-id>/`** where `<guide-id>` matches the guide's registered ID in `guideRegistry.ts`. Do not create separate subdirectories for sections within a guide.
-- `src/data/` — Content stored as TypeScript objects (roadmap steps, architecture data, checklists, etc.)
-  - `src/data/linkRegistry/` — External URL registry, split by guide; barrel `index.ts` re-exports merged array + lookup maps
-  - `src/data/glossaryTerms/` — Glossary terms, split by guide; barrel `index.ts` re-exports merged array
-  - `src/data/<guideId>Data.ts` (or `<guideId>Data/` directory) — Per-guide data with `*_GUIDE_SECTIONS` and `*_START_PAGE_DATA`
-  - `src/data/guideTypes.ts` — Shared `GuideSection` and `GuideDefinition` interfaces
-  - `src/data/guideRegistry.ts` — Central guide registry (all guide metadata, section definitions, lookup helpers)
-  - `src/data/componentPages.tsx` — Registry of component-rendered (non-MDX) pages, mapping page IDs to components for the router
-- `src/helpers/` — Utility functions (`cmd.ts` for package manager commands, `fnRef.ts` for footnotes, `darkStyle.ts` for theme-conditional values)
-- `src/hooks/` — Custom React hooks (`usePMContext.tsx` for npm/pnpm switching)
-- `src/router.tsx` — TanStack Router configuration; resolves pages via `componentPages` registry and MDX content auto-discovery
-- `src/main.tsx` — Application entry point
+- `src/components/` — Shared React components; `src/components/mdx/` has MDX-available components (register in `index.ts`)
+- `src/content/<guide-id>/` — MDX pages, auto-discovered by `src/content/registry.ts`
+- `src/data/` — TypeScript data objects; `linkRegistry/` and `glossaryTerms/` split by guide
+- `src/data/guideRegistry.ts` — Central guide registry (metadata, sections, lookup helpers)
+- `src/helpers/` — Utilities (`cmd.ts`, `fnRef.ts`, `darkStyle.ts`)
+- `src/hooks/` — Custom hooks (`usePMContext.tsx`, `useTheme.tsx`)
 
 ## Key Patterns
 
-- **Content as data:** Page content lives in `src/data/` as TypeScript objects with HTML strings, not inline JSX. Content updates go in data files, not components.
-- **HTML rendering:** Components use `HtmlContent` (wraps `dangerouslySetInnerHTML`) to render HTML strings from data files.
-- **Package manager context:** `usePM()` hook + `cmd()` helper handle npm/pnpm command display switching throughout the app.
-- **Functional components only:** No class components. Props typed with TypeScript interfaces.
-- **Interactive tables:** The External Resources page (`ExternalResourcesPage.tsx`) and Glossary page (`GlossaryPage.tsx`) use TanStack Table for sortable, filterable, searchable tables.
-- **Styling:** Use inline Tailwind utility classes on JSX elements. Prefer Tailwind utility classes over adding CSS rules whenever possible. Avoid defining component-level classes with `@apply` in `App.css`. CSS is only for things that genuinely require it: pseudo-elements (`::before`, `::after`), complex nested selectors, body-level toggles, animations/transitions, and third-party library attribute selectors (e.g., cmdk `[cmdk-input]`). Using `@apply` within those CSS-only rules is acceptable. Use Tailwind's built-in scale values; arbitrary values (e.g., `[360px]`) should only be used when strictly necessary (no built-in equivalent exists).
-- **Dark mode:** The app uses class-based dark mode via a `useTheme()` hook (`src/hooks/useTheme.tsx`) that toggles `.dark` on `<body>`. Tailwind's custom variant `@custom-variant dark (&:where(.dark, .dark *))` enables `dark:` utility classes. For components using Tailwind classes, use `dark:` variants directly (e.g., `dark:bg-slate-800 dark:text-slate-100`). For interactive components with dynamic inline styles (where colors come from data like `comp.color`), use the `useTheme()` hook + `ds()` helper from `src/helpers/darkStyle.ts` to select light/dark values. Standard dark palette: backgrounds `#1e293b` (slate-800), text `#e2e8f0` (slate-200), borders `#334155` (slate-700). All new interactive MDX components must support dark mode.
+- **Content as data:** Page content in `src/data/` as TypeScript objects with HTML strings, not inline JSX.
+- **Styling:** Tailwind utility classes. CSS only for pseudo-elements, animations, and third-party selectors.
+- **Dark mode:** Use Tailwind `dark:` variants for static colors. Use `ds()` from `src/helpers/darkStyle.ts` for dynamic inline styles from data. Dark palette: bg `#1e293b`, text `#e2e8f0`, borders `#334155`.
+- **Page ordering:** Each guide's `*_GUIDE_SECTIONS` array is the single source of truth — sidebar, command menu, prev/next, and home tiles derive automatically.
+- **MDX titles:** Every `title` must end with an emoji suffix (parsed by sidebar and command menu).
 
-## MDX Frontmatter Reference
+## Adding or Modifying Guide Pages
 
-Every MDX content page has YAML frontmatter with these fields:
+1. Create `src/content/<guide-id>/<page-id>.mdx` with frontmatter: `id`, `title` (emoji suffix), `guide`.
+2. Add the page ID to the guide's `*_GUIDE_SECTIONS` in its data file.
+3. Register any new components in `src/components/mdx/index.ts`.
+4. Add link entries to `src/data/linkRegistry/<guideId>Links.ts` as needed.
 
-| Field | Required | Type | Description |
-|-------|----------|------|-------------|
-| `id` | Yes | `string` | Unique page identifier (kebab-case). Must match the ID used in the guide's `*_GUIDE_SECTIONS` array. Duplicate IDs cause a build error. |
-| `title` | Yes | `string` | Display title with emoji suffix (e.g., `"Build & Output ⚙️"`). Must end with emoji — see **Navigation Item Formatting**. |
-| `guide` | No | `string` | Guide ID (e.g., `"npm-package"`, `"architecture"`, `"testing"`, `"prompt-engineering"`). Validated against known guide IDs at build time. |
-| `group` | No | `string` | Section grouping label within the guide (used for display grouping in some contexts). |
-| `linkRefs` | No | `array` | Array of `{id, note?}` objects referencing link registry entries. Resolved to `SectionLink[]` at build time — unknown IDs throw an error. |
-| `usedFootnotes` | No | `number[]` | Footnote numbers referenced in the MDX body via `<FnRef n={N} />`. Controls which links appear in the "Footnotes" section vs. "Further Reading". |
-
-## Dark Style Helper (`ds()`)
-
-The `ds()` function in `src/helpers/darkStyle.ts` selects between light and dark values for inline styles:
-
-```typescript
-ds(light: string, dark: string, isDark: boolean): string
-```
-
-**When to use `ds()`** — For interactive components with dynamic inline styles where colors come from data (e.g., `item.color`, `item.accent`). These can't use Tailwind `dark:` variants because the values aren't known at build time.
-
-**When to use Tailwind `dark:` variants** — For all other dark mode styling where values are static and known at build time (e.g., `dark:bg-slate-800 dark:text-slate-100`).
-
-```tsx
-// Dynamic colors from data → use ds()
-<div style={{ background: ds(item.accent, item.darkAccent, isDark) }}>
-
-// Static colors → use Tailwind dark: variants
-<div className="bg-white dark:bg-slate-800">
-```
-
-## Routing (Component Pages)
-
-The router resolves pages in this order:
-
-1. **Search-param pages** — `searchParamPages` in `src/data/componentPages.tsx` (pages that receive `?guide=` or `?search=` params, e.g., `external-resources`, `glossary`)
-2. **Simple component pages** — `simpleComponentPages` in `src/data/componentPages.tsx` (legacy `architecture` redirect)
-3. **MDX content pages** — auto-discovered via `import.meta.glob` in `src/content/registry.ts` (all guide pages including start pages)
-
-All guide start pages and content pages are MDX and auto-route via the content registry. Only non-MDX pages (search-param pages, legacy redirects) need `componentPages.tsx` entries.
-
-## Build Validation (`pnpm validate:data`)
-
-The validation script (`scripts/validate-data.ts`) runs cross-reference integrity checks that catch common mistakes before lint/build:
-
-| Check | What it catches |
-|-------|----------------|
-| Duplicate link registry IDs | Two entries with the same `id` in `src/data/linkRegistry/` |
-| Glossary `linkId` references | Glossary term pointing to a non-existent link registry entry |
-| Glossary `sectionId` references | Glossary term pointing to a non-existent page ID |
-| Duplicate page IDs across guides | Same page ID used in two different guides' section arrays |
-| `startPageId` not in sections | Guide's start page ID missing from its own `*_GUIDE_SECTIONS` |
-
-Run `pnpm validate:data` to check these, or `pnpm validate` for the full pipeline (`validate:data` + `lint` + `build`).
-
-## Link Registry
-
-All external URLs are managed centrally in `src/data/linkRegistry/`. This is the single source of truth for link metadata (URL, label, source, description, tags). Other systems reference the registry by ID instead of duplicating URL metadata. Entries are split by guide into separate files; the barrel `index.ts` re-exports the merged array and lookup maps so all existing imports work unchanged.
-
-### Adding a new link
-1. Add a `RegistryLink` entry to the appropriate guide file in `src/data/linkRegistry/<guideId>Links.ts` with a slug ID following the `{source}-{topic}` convention (e.g., `"npm-package-json-deps"`, `"mdn-tree-shaking"`). Choose the file matching the entry's `guide:*` tag.
-2. Reference it from MDX frontmatter via `linkRefs`:
-   ```yaml
-   linkRefs:
-     - id: "your-registry-id"
-     - id: "another-id"
-       note: "Page-specific context for this link"
-   usedFootnotes: [1, 2]
-   ```
-3. If it should appear on the External Resources page, add `resourceCategory` (e.g., `"Official Documentation"`) and `tags`/`desc` fields.
-4. For glossary terms, use the `linkId` field in `GlossaryTerm` to reference a registry entry.
-
-### How the registry connects to other systems
-- **MDX frontmatter** → `linkRefs` array of `{id, note?}` objects, resolved to `SectionLink[]` by `src/content/registry.ts`
-- **External Resources page** → curated entries have `resourceCategory`; all entries with `tags` appear on the page. Page associations are derived from `ContentPage.linkRefIds`.
-- **Glossary** → `GlossaryTerm.linkId` references a registry entry for the term's external documentation URL and source.
-- **`overallResources.ts`** → derives `ResourceGroup[]` from registry entries with `resourceCategory` (no longer hardcoded).
-
-## Footnotes & References
-
-Content pages can include two kinds of external links at the bottom, managed via `linkRefs` in each content page's MDX frontmatter:
-
-- **Footnotes** are numbered references tied to specific content via `<FnRef>` markers (e.g., `<FnRef n={1} />`). They appear in a "Footnotes" section with their number, link, source, and optional note. The `data-fn` attributes on `<FnRef>` elements are used by `FootnoteTooltip.tsx` for hover/click tooltip behavior.
-- **References** ("Further Reading") are supplemental links not tied to specific content — any link in the `linkRefs` array that is NOT referenced by a `<FnRef>` in the MDX body becomes a "Further Reading" entry.
-
-Both should include descriptions (`note` field in `linkRefs`) when possible to help readers understand relevance.
-
-## Glossary
-
-The Glossary page (`src/components/GlossaryPage.tsx`) displays a searchable, filterable table of technical terms drawn from `src/data/glossaryTerms/`. Each term links to its official documentation (via the link registry) and optionally to the guide page where the concept is taught. Terms are split by guide into separate files; the barrel `index.ts` re-exports the merged array.
-
-### GlossaryTerm fields
-
-Each term is defined in the `GlossaryTerm` interface (`src/data/glossaryTerms/index.ts`):
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `term` | Yes | Display name. Title-case for proper nouns, lowercase for general concepts. |
-| `definition` | Yes | One to two sentences for a backend engineer. Use `<code>` tags for inline code. Self-contained. |
-| `linkId` | Yes | `id` of a `RegistryLink` in `src/data/linkRegistry/`. Must already exist in the registry. |
-| `sectionId` | No | `id` of a content page where this concept is taught. Shows a "go to guide page" link. |
-
-### Adding a glossary term
-
-1. **Ensure the link exists** — Check `src/data/linkRegistry/` for a matching `RegistryLink`. If none exists, add one following the Link Registry conventions above.
-2. **Add the term** — In `src/data/glossaryTerms/`, find the appropriate guide file and `GlossaryCategory` object, then add a new `GlossaryTerm` to its `terms` array.
-3. **Set `sectionId`** — If the term is explained on a guide page, set `sectionId` to that page's `id`.
-4. **Verify** — Run `pnpm validate` to catch any broken `linkId` references.
-
-For editorial guidance on what qualifies as a glossary term and how to add new categories, see the `/add-guide` skill.
-
-## TypeScript Configuration
-
-Strict mode with additional checks enabled:
-- `noUnusedLocals`, `noUnusedParameters`
-- `noFallthroughCasesInSwitch`
-- `noUncheckedSideEffectImports`
-- `erasableSyntaxOnly`
-- Target: ES2022, JSX: react-jsx
-
-## Linting
-
-ESLint uses flat config format (`eslint.config.js`), extending:
-- `js.configs.recommended`
-- `tseslint.configs.recommended`
-- `reactHooks.configs.flat.recommended`
-- `reactRefresh.configs.vite`
-
-## Page Ordering (Guide Registration)
-
-Each guide's page order is defined in **one place**: the `*_GUIDE_SECTIONS` array in the guide's data file (e.g., `ARCH_GUIDE_SECTIONS` in `src/data/archData/navigation.ts`). This single definition automatically drives:
-
-1. **Navigation sidebar** — imported via `src/data/guideRegistry.ts`
-2. **Command menu** — imported via `src/data/guideRegistry.ts`
-3. **Previous/Next links** — derived via `getNavOrderForPage()` in `src/data/guideRegistry.ts`
-4. **Home page tiles** — imported via `src/data/guideRegistry.ts`
-
-Start pages use the data-driven `<GuideStartContent>` component, which auto-derives learning-path sub-items from the `*_GUIDE_SECTIONS` definition via `sectionLabel` references in `StartPageData`. No manual sync needed.
-
-`<GuideStartContent>` also auto-renders a **Resources** section at the bottom of every start page with three tiles (1/3 width each): **External Resources** (pre-filtered by guide), **Glossary** (pre-filtered by guide), and **Checklist** (links to the guide's checklist from `checklistPages`, or shows a "Coming Soon" placeholder if none exists). Do not add manual Resources bonus steps to `StartPageData` — they are handled automatically.
-
-**Top-level resource pages** (`external-resources`, `glossary`) are NOT part of any guide's navigation order. They appear in the sidebar under a dedicated "Resources" icon, in the command menu under a "Resources" group, and on the home page. They do not have Previous/Next navigation.
-
-When adding, removing, or reordering pages within a guide, update the `*_GUIDE_SECTIONS` array in the guide's data file. Everything else updates automatically.
-
-## Command Menu (CMD-K)
-
-The command menu (`src/components/CommandMenu.tsx`) provides searchable access to:
-
-1. **Pages** — all guide pages, grouped by guide section
-2. **Glossary terms** — all terms from `src/data/glossaryTerms/`. Selecting a term navigates to the Glossary page with the search bar prefilled.
-3. **External resources** — all resources from `src/data/overallResources.ts`. Selecting a resource opens the URL in a new tab.
-
-## Cross-Page Links (NavLink / NavPill)
-
-`NavLink` and `NavPill` (`src/components/mdx/NavLink.tsx`) create inline cross-page links in MDX content. Both components accept an optional `children` prop — when omitted, the link text auto-resolves to the page's full title (via `getNavTitle()`) including its emoji suffix.
-
-```mdx
-{/* Auto-resolves to "Build & Output ⚙️" */}
-<NavLink to="build" />
-
-{/* Custom text for contextual links */}
-<NavLink to="build">bundlers and build tools</NavLink>
-```
-
-Prefer the self-closing form (`<NavLink to="..." />`) when linking to a page by its title. Use custom children only when the surrounding sentence needs different wording for readability.
-
-## Adding a New Guide
-
-Use the `/add-guide` skill for the full 9-step conversion workflow, MDX page and component templates, glossary editorial guidance, and common pitfalls.
-
-## Navigation Item Formatting
-
-Every content page's MDX frontmatter `title` must include an emoji suffix (e.g., `"Logic & Condition Errors ⚡"`). This convention applies to all guides (NPM Package, Architecture, Testing, Prompt Engineering, and any future guides).
-
-The sidebar `SidebarItem` component (`src/components/Sidebar.tsx`) parses each title with the regex `/^(.+)\s+([\u0080-\u{10FFFF}]+)$/u` to split the text from the trailing emoji. The `PageItem` in `CommandMenu.tsx` uses the same pattern.
-
-Layout rules for navigation items:
-- Text and icon/badge must always be in **separate `<span>` elements** within navigation items.
-- The parent container uses `justify-between` so text aligns left and icons/badges align to the right edge.
-- New pages must follow this emoji-suffix pattern for consistency across all guides.
-
-## Error Troubleshooting
-
-| Error | Cause | Fix |
-|-------|-------|-----|
-| `Duplicate page ID "foo"` | Two MDX files have the same `id` in frontmatter | Change one of the IDs to be unique |
-| `unknown guide "bar"` | MDX frontmatter `guide` field doesn't match a registered guide ID | Use a valid guide ID from the **Guides** table above |
-| `Unknown link ID "baz"` | `linkRefs` in MDX frontmatter references an ID that doesn't exist in `src/data/linkRegistry/` | Add the link entry to the appropriate guide file in `src/data/linkRegistry/` |
-| `startPageId not in sections` | Guide's `startPageId` isn't listed in its `*_GUIDE_SECTIONS` array | Add the start page ID to the first section of the guide |
-| Sidebar shows raw page ID instead of title | Page title missing emoji suffix, or page not in `staticTitles`/`contentPages` | Ensure the MDX `title` ends with an emoji, or add a `staticTitles` entry for non-MDX pages |
+For full guide creation, use the `/add-guide` skill.
 
 ## Pre-Push Checklist
 
-- Run `pnpm install` before running lint or build to ensure dependencies are installed.
-- Run `pnpm validate` for the full pipeline (`validate:data` + `lint` + `build`), or run each step individually: `pnpm validate:data`, then `pnpm lint`, then `pnpm build`. Validation and lint catch issues faster and cheaper than a full build.
-- When fixing lint errors, try `pnpm lint --fix` first to auto-fix what ESLint can handle, then manually fix any remaining issues.
+- `pnpm install` then `pnpm validate` (or `validate:data` + `lint` + `build` individually).
+- Try `pnpm lint --fix` first for auto-fixable lint errors.
+
+## Reference
+
+Detailed conventions (read on-demand, not needed for most tasks):
+
+- `docs/CONTENT_REFERENCE.md` — MDX frontmatter, link registry, glossary, footnotes, cross-page links, navigation formatting
+- `docs/DEVELOPMENT_REFERENCE.md` — `ds()` helper, routing, page ordering, build validation, TypeScript/ESLint config, error troubleshooting

--- a/docs/CONTENT_REFERENCE.md
+++ b/docs/CONTENT_REFERENCE.md
@@ -1,0 +1,83 @@
+# Content Authoring Reference
+
+Detailed conventions for MDX content, link registry, glossary, and cross-page navigation. See root `CLAUDE.md` for project overview and essential patterns.
+
+## MDX Frontmatter
+
+| Field | Required | Type | Description |
+|-------|----------|------|-------------|
+| `id` | Yes | `string` | Unique page identifier (kebab-case). Must match the guide's `*_GUIDE_SECTIONS` array. |
+| `title` | Yes | `string` | Display title with emoji suffix (e.g., `"Build & Output ⚙️"`). |
+| `guide` | No | `string` | Guide ID. Validated against known IDs at build time. |
+| `group` | No | `string` | Section grouping label. |
+| `linkRefs` | No | `array` | `{id, note?}` objects referencing link registry entries. Unknown IDs throw errors. |
+| `usedFootnotes` | No | `number[]` | Footnote numbers in the MDX body via `<FnRef n={N} />`. Controls footnote vs. "Further Reading" placement. |
+
+## Link Registry
+
+External URLs managed centrally in `src/data/linkRegistry/`. Single source of truth for URL metadata (URL, label, source, description, tags). Split by guide; barrel `index.ts` re-exports merged array + lookup maps.
+
+### Adding a link
+
+1. Add a `RegistryLink` entry to `src/data/linkRegistry/<guideId>Links.ts` with a `{source}-{topic}` slug ID.
+2. Reference from MDX frontmatter via `linkRefs`:
+   ```yaml
+   linkRefs:
+     - id: "your-registry-id"
+     - id: "another-id"
+       note: "Page-specific context"
+   usedFootnotes: [1, 2]
+   ```
+3. Add `resourceCategory` and `tags`/`desc` for External Resources page visibility.
+4. For glossary terms, use `linkId` in `GlossaryTerm` to reference entries.
+
+### Registry connections
+
+- **MDX frontmatter** → `linkRefs` resolved to `SectionLink[]` by `src/content/registry.ts`
+- **External Resources page** → entries with `resourceCategory` appear as curated resources
+- **Glossary** → `GlossaryTerm.linkId` references a registry entry
+- **`overallResources.ts`** → derives `ResourceGroup[]` from entries with `resourceCategory`
+
+## Glossary
+
+Searchable table in `src/components/GlossaryPage.tsx`. Data in `src/data/glossaryTerms/`, split by guide.
+
+### GlossaryTerm fields
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `term` | Yes | Display name. Title-case for proper nouns, lowercase for general concepts. |
+| `definition` | Yes | One to two sentences for a backend engineer. Use `<code>` for inline code. |
+| `linkId` | Yes | ID of a `RegistryLink` in `src/data/linkRegistry/`. Must exist. |
+| `sectionId` | No | ID of a content page where this concept is taught. |
+
+### Adding a term
+
+1. Ensure the `RegistryLink` exists in `src/data/linkRegistry/`.
+2. Add the term to the appropriate guide file in `src/data/glossaryTerms/`.
+3. Set `sectionId` if the term is explained on a guide page.
+4. Run `pnpm validate` to catch broken references.
+
+For editorial guidance on what qualifies as a glossary term, see the `/add-guide` skill.
+
+## Footnotes & References
+
+Content pages support two kinds of bottom-of-page links via `linkRefs` in MDX frontmatter:
+
+- **Footnotes** — numbered references tied to content via `<FnRef n={N} />` markers. `data-fn` attributes enable tooltip behavior in `FootnoteTooltip.tsx`.
+- **Further Reading** — supplemental links not referenced by `<FnRef>` in the body.
+
+Both should include `note` descriptions in `linkRefs` when possible.
+
+## Cross-Page Links
+
+`NavLink` and `NavPill` (`src/components/mdx/NavLink.tsx`) create inline cross-page links. Self-closing form auto-resolves to the page's full title:
+
+```mdx
+<NavLink to="build" />                      {/* → "Build & Output ⚙️" */}
+<NavLink to="build">bundlers</NavLink>      {/* custom text */}
+```
+
+## Navigation Item Formatting
+
+Every MDX `title` must include an emoji suffix. The sidebar (`SidebarItem` in `Sidebar.tsx`) and command menu (`PageItem` in `CommandMenu.tsx`) parse titles with `/^(.+)\s+([\u0080-\u{10FFFF}]+)$/u` to split text from trailing emoji. Text and icon must be in separate `<span>` elements with `justify-between`.

--- a/docs/DEVELOPMENT_REFERENCE.md
+++ b/docs/DEVELOPMENT_REFERENCE.md
@@ -1,0 +1,66 @@
+# Development Reference
+
+Detailed conventions for component development, routing, and tooling. See root `CLAUDE.md` for project overview and essential patterns.
+
+## Dark Style Helper (`ds()`)
+
+`ds()` in `src/helpers/darkStyle.ts` selects between light/dark values for inline styles:
+
+```typescript
+ds(light: string, dark: string, isDark: boolean): string
+```
+
+Use for interactive components with dynamic colors from data (can't use Tailwind `dark:` variants). Use Tailwind `dark:` variants for all static colors.
+
+```tsx
+<div style={{ background: ds(item.accent, item.darkAccent, isDark) }}>  {/* dynamic */}
+<div className="bg-white dark:bg-slate-800">                           {/* static */}
+```
+
+## Routing
+
+The router resolves pages in order:
+
+1. **Search-param pages** — `searchParamPages` in `src/data/componentPages.tsx`
+2. **Simple component pages** — `simpleComponentPages` in `src/data/componentPages.tsx`
+3. **MDX content pages** — auto-discovered via `import.meta.glob` in `src/content/registry.ts`
+
+All guide pages are MDX and auto-route. Only non-MDX pages need `componentPages.tsx` entries.
+
+## Page Ordering
+
+Each guide's `*_GUIDE_SECTIONS` array (in its data file) automatically drives: sidebar, command menu, prev/next links, and home page tiles via `src/data/guideRegistry.ts`.
+
+`<GuideStartContent>` auto-derives learning-path sub-items from sections and renders a Resources section at the bottom (External Resources, Glossary, Checklist tiles). Do not add manual Resources steps to `StartPageData`.
+
+Top-level resource pages (`external-resources`, `glossary`) are NOT in any guide's navigation.
+
+## Build Validation (`pnpm validate:data`)
+
+| Check | What it catches |
+|-------|----------------|
+| Duplicate link registry IDs | Two entries with the same `id` in `src/data/linkRegistry/` |
+| Glossary `linkId` references | Term pointing to non-existent link registry entry |
+| Glossary `sectionId` references | Term pointing to non-existent page ID |
+| Duplicate page IDs | Same page ID in two different guides |
+| `startPageId` not in sections | Guide start page missing from its `*_GUIDE_SECTIONS` |
+
+## Command Menu (CMD-K)
+
+Provides searchable access to: all guide pages (grouped by section), glossary terms (navigates to Glossary with prefilled search), and external resources (opens URL in new tab).
+
+## TypeScript & Linting
+
+**TypeScript:** Strict mode, `noUnusedLocals`, `noUnusedParameters`, `noFallthroughCasesInSwitch`, `erasableSyntaxOnly`. Target ES2022.
+
+**ESLint:** Flat config (`eslint.config.js`), extending `js.configs.recommended`, `tseslint.configs.recommended`, `reactHooks.configs.flat.recommended`, `reactRefresh.configs.vite`.
+
+## Error Troubleshooting
+
+| Error | Fix |
+|-------|-----|
+| `Duplicate page ID "foo"` | Change one MDX `id` to be unique |
+| `unknown guide "bar"` | Use a valid guide ID from the Guides table |
+| `Unknown link ID "baz"` | Add entry to `src/data/linkRegistry/<guideId>Links.ts` |
+| `startPageId not in sections` | Add start page ID to guide's `*_GUIDE_SECTIONS` |
+| Sidebar shows raw page ID | Ensure MDX `title` ends with emoji |

--- a/src/content/ai-infra/CLAUDE.md
+++ b/src/content/ai-infra/CLAUDE.md
@@ -1,12 +1,12 @@
 # AI Infrastructure — Guide CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns (MDX conventions, dark mode, styling, link registry, glossary, build commands). This file covers **ai-infra**-specific context only.
-
 ## Audience & Purpose
 
-Frontend engineers learning AI infrastructure — from model serving and vector databases to GPU clusters and training pipelines. Each layer is explained with analogies to familiar frontend concepts like Express middleware, React state, and data-fetching patterns.
+Frontend engineers learning AI infrastructure — from model serving and vector databases to GPU clusters and training pipelines. Each layer explained with analogies to familiar frontend concepts.
 
 ## Section Structure
+
+Defined in `AI_INFRA_GUIDE_SECTIONS` in `src/data/aiInfraData/navigation.ts`.
 
 | Section Label | Page IDs |
 |--------------|----------|
@@ -15,76 +15,19 @@ Frontend engineers learning AI infrastructure — from model serving and vector 
 | Workflows | `ai-workflows`, `ai-wf-simple-chat`, `ai-wf-rag`, `ai-wf-agent`, `ai-wf-finetune` |
 | Putting It Together | `ai-key-terms` |
 
-Defined in `AI_INFRA_GUIDE_SECTIONS` in `src/data/aiInfraData/navigation.ts`.
-
-## File Locations
-
-| Category | Path |
-|----------|------|
-| Content pages | `src/content/ai-infra/*.mdx` |
-| Data directory | `src/data/aiInfraData/` (barrel-exported) |
-| Type definitions | `src/data/aiInfraData/types.ts` |
-| Layer data | `src/data/aiInfraData/layers.ts` |
-| Workflow data | `src/data/aiInfraData/workflows.ts` |
-| Navigation & start page | `src/data/aiInfraData/navigation.ts` |
-| Interactive components | `src/components/mdx/ai-infra/` |
-| Link registry | `src/data/linkRegistry/aiInfraLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/aiInfraTerms.ts` |
+Data directory: `src/data/aiInfraData/` — `types.ts`, `layers.ts`, `workflows.ts`, `navigation.ts`.
 
 ## Interactive Components
 
-| Component | Props | Data Source | Purpose |
-|-----------|-------|-------------|---------|
-| `InfraLayerExplorer` | `layerId: string` | `INFRA_LAYERS` in `layers.ts` | Interactive layer explorer with clickable concept cards showing name, description, frontend analogy, and tools |
-| `WorkflowExplorer` | *(none)* | `INFRA_WORKFLOWS` in `workflows.ts` | Interactive workflow selector showing all workflows with tab navigation |
-| `WorkflowDetail` | `workflowId: string` | `INFRA_WORKFLOWS` in `workflows.ts` | Single workflow step-by-step flow with layer badges |
+| Component | Props | Purpose |
+|-----------|-------|---------|
+| `InfraLayerExplorer` | `layerId` | Interactive layer explorer with clickable concept cards |
+| `WorkflowExplorer` | *(none)* | Interactive workflow selector with tab navigation |
+| `WorkflowDetail` | `workflowId` | Single workflow step-by-step flow with layer badges |
 
 ## Guide-Specific Conventions
 
-### Layer-based architecture
-
-The guide is organized around 5 infrastructure layers defined in `INFRA_LAYERS`. Each `InfraLayer` has:
-
-- `id`, `title`, `subtitle`, `icon` — Display metadata
-- `color`, `accent`, `darkAccent` — Theme colors for dark mode support
-- `summary` — Layer overview text
-- `concepts` — Array of `InfraConcept` objects, each with `name`, `what` (description), `analogy` (frontend analogy), and `tools` (real-world tools list)
-
-### Frontend analogy pattern
-
-Every `InfraConcept` includes an `analogy` field that maps the AI concept to a familiar frontend equivalent. This is the primary teaching device of the guide.
-
-### Workflow visualization
-
-`INFRA_WORKFLOWS` defines 4 common AI architectures (simple chat, RAG, agents, fine-tuning). Each workflow has `steps` referencing infrastructure layers by name, showing how data flows through the stack. The overview page (`ai-workflows`) uses `<WorkflowExplorer />` for comparing all workflows; individual workflow pages (`ai-wf-*.mdx`) use `<WorkflowDetail workflowId="..." />` for single-workflow detail.
-
-### Workflow page template
-
-Workflow pages (`ai-wf-*.mdx`) follow a consistent structure:
-
-1. `<SectionTitle>` + `<Toc>` + `<SectionIntro>`
-2. Overview with `<SectionList>` / `<ColItem>`
-3. When to use this pattern
-4. `<WorkflowDetail workflowId="..." />`
-5. Key considerations
-6. Frontend `<Explainer>` analogy box
-
-### Key terms
-
-Key terms for the guide are defined as glossary entries in `src/data/glossaryTerms/aiInfraTerms.ts`. The `ai-key-terms` page links to the Glossary filtered by the AI Infrastructure guide.
-
-### Data types
-
-Key interfaces in `src/data/aiInfraData/types.ts`:
-
-- `InfraLayer` — id/title/subtitle/icon/color/accent/darkAccent/summary/concepts
-- `InfraConcept` — name/what/analogy/tools
-- `InfraWorkflow` — id/title/description/steps
-- `WorkflowStep` — layer/label/icon
-
-## Adding a New Page
-
-1. Create `src/content/ai-infra/ai-<slug>.mdx` with frontmatter (`id`, `title` with emoji, `guide: "ai-infra"`).
-2. Add the page ID to `AI_INFRA_GUIDE_SECTIONS` in `src/data/aiInfraData/navigation.ts` under the correct section label.
-3. For layer pages, add an `InfraLayer` entry to `INFRA_LAYERS` in `layers.ts` and use `<InfraLayerExplorer layerId="..." />` in the MDX.
-4. Register any new components in `src/components/mdx/index.ts`.
+- **Layer-based architecture:** 5 layers in `INFRA_LAYERS`. Each has `concepts` array of `InfraConcept` objects with `name`, `what`, `analogy`, and `tools`.
+- **Frontend analogy pattern:** Every `InfraConcept.analogy` maps AI concept to a frontend equivalent. Primary teaching device.
+- **Workflow visualization:** `INFRA_WORKFLOWS` defines 4 AI architectures. Overview page uses `<WorkflowExplorer />`; individual pages use `<WorkflowDetail workflowId="..." />`.
+- **Workflow page template:** `<SectionTitle>` + `<Toc>` + `<SectionIntro>` → overview → when to use → `<WorkflowDetail>` → key considerations → `<Explainer>`.

--- a/src/content/architecture/CLAUDE.md
+++ b/src/content/architecture/CLAUDE.md
@@ -1,12 +1,12 @@
 # Architecture Guide — Guide CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns (MDX conventions, dark mode, styling, link registry, glossary, build commands). This file covers **architecture**-specific context only.
-
 ## Audience & Purpose
 
-Backend engineers learning frontend architecture patterns — tech stacks, full-stack frameworks, and how layers connect. Assumes familiarity with databases, servers, and APIs. Teaches how frontend stacks are assembled, what each layer does, and how to compare alternatives.
+Backend engineers learning frontend architecture patterns — tech stacks, full-stack frameworks, and how layers connect. Assumes familiarity with databases, servers, and APIs.
 
 ## Section Structure
+
+Defined in `ARCH_GUIDE_SECTIONS` in `src/data/archData/navigation.ts`.
 
 | Section Label | Page IDs |
 |--------------|----------|
@@ -15,72 +15,39 @@ Backend engineers learning frontend architecture patterns — tech stacks, full-
 | Full-Stack Frameworks | `arch-frameworks-intro`, `arch-fw-nextjs`, `arch-fw-react-router`, `arch-fw-tanstack-start`, `arch-fw-remix` |
 | Putting It Together | `arch-how-it-connects` |
 
-Defined in `ARCH_GUIDE_SECTIONS` in `src/data/archData/navigation.ts`.
-
-## File Locations
-
-| Category | Path |
-|----------|------|
-| Content pages | `src/content/architecture/*.mdx` |
-| Data directory | `src/data/archData/` (barrel-exported) |
-| Type definitions | `src/data/archData/types.ts` |
-| Stack data | `src/data/archData/stacks.ts` |
-| Framework data | `src/data/archData/frameworks.ts` |
-| Navigation & start page | `src/data/archData/navigation.ts` |
-| Interactive components | `src/components/mdx/architecture/` |
-| Shared ProsCons component | `src/components/mdx/ProsCons.tsx` |
-| Link registry | `src/data/linkRegistry/architectureLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/architectureTerms.ts` |
+Data directory: `src/data/archData/` — `types.ts`, `stacks.ts`, `frameworks.ts`, `navigation.ts` (barrel-exported).
 
 ## Interactive Components
 
-All components accept a string ID prop that looks up data from the `archData/` files.
+All accept a string ID prop that looks up data from `archData/`.
 
-| Component | Props | Data Source | Purpose |
-|-----------|-------|-------------|---------|
-| `StackExplorer` | `stackId: string` | `STACK_PAGES` in `stacks.ts` | Interactive stack layer explorer with clickable component bars |
-| `StackProsCons` | `stackId: string` | `STACK_PAGES` in `stacks.ts` | Pros/cons comparison (delegates to shared `ProsCons`) |
-| `LayerDiagram` | *(none)* | `LAYER_COLORS` in `stacks.ts` | 4-layer architecture visualization (Frontend, Server, Runtime, Database) |
-| `DataFlowDiagram` | *(none)* | `DATA_FLOW` + `LAYER_COLORS` in `stacks.ts` | 6-step data flow through a web app stack |
-| `FrameworkExplorer` | `frameworkId: string` | `FRAMEWORK_PAGES` in `frameworks.ts` | Interactive framework capability explorer |
-| `FrameworkProsCons` | `frameworkId: string` | `FRAMEWORK_PAGES` in `frameworks.ts` | Pros/cons for frameworks (delegates to shared `ProsCons`) |
+| Component | Props | Purpose |
+|-----------|-------|---------|
+| `StackExplorer` | `stackId` | Interactive stack layer explorer with clickable component bars |
+| `StackProsCons` | `stackId` | Pros/cons comparison (delegates to shared `ProsCons`) |
+| `LayerDiagram` | *(none)* | 4-layer architecture visualization |
+| `DataFlowDiagram` | *(none)* | 6-step data flow through a web app stack |
+| `FrameworkExplorer` | `frameworkId` | Interactive framework capability explorer |
+| `FrameworkProsCons` | `frameworkId` | Pros/cons for frameworks |
 
 ## Guide-Specific Conventions
 
 ### Stack page template
 
-Every stack page (`arch-stack-*.mdx`) follows an identical structure:
-
-1. `<SectionTitle>` + `<Toc>` + `<SectionIntro>`
-2. Overview with `<SectionList>` / `<ColItem>`
-3. `<StackExplorer stackId="..." />`
-4. `<StackProsCons stackId="..." />`
-5. Backend `<Explainer>` analogy box
-
-New stack pages must follow this template exactly.
+Every `arch-stack-*.mdx`: `<SectionTitle>` + `<Toc>` + `<SectionIntro>` → overview with `<SectionList>`/`<ColItem>` → `<StackExplorer>` → `<StackProsCons>` → backend `<Explainer>` analogy.
 
 ### Framework page template
 
-Framework pages (`arch-fw-*.mdx`) follow a similar structure:
-
-1. `<SectionTitle>` + `<Toc>` + `<SectionIntro>`
-2. `<FrameworkExplorer frameworkId="..." />`
-3. `<FrameworkProsCons frameworkId="..." />`
-
-### Data types
-
-- **`StackPageData`** — Contains `id`, `name`, `components` array (`StackComponent[]`), `pros`, `cons`, `bestFor`, and color fields.
-- **`FrameworkPageData`** — Contains `id`, `name`, `capabilities` array (`FrameworkCapability[]`), `pros`, `cons`, `bestFor`, and color fields.
-- Both types include `color`, `accent`, and `darkAccent` for dark mode support in interactive components.
+Every `arch-fw-*.mdx`: `<SectionTitle>` + `<Toc>` + `<SectionIntro>` → `<FrameworkExplorer>` → `<FrameworkProsCons>`.
 
 ### Adding a new stack
 
-1. Add a `StackPageData` entry to `STACK_PAGES` in `src/data/archData/stacks.ts`.
-2. Create `src/content/architecture/arch-stack-<name>.mdx` following the stack page template.
-3. Add the page ID to `ARCH_GUIDE_SECTIONS` in `navigation.ts` under "Stack Alternatives".
+1. Add `StackPageData` entry to `STACK_PAGES` in `stacks.ts`.
+2. Create `arch-stack-<name>.mdx` following the stack page template.
+3. Add page ID to `ARCH_GUIDE_SECTIONS` under "Stack Alternatives".
 
 ### Adding a new framework
 
-1. Add a `FrameworkPageData` entry to `FRAMEWORK_PAGES` in `src/data/archData/frameworks.ts`.
-2. Create `src/content/architecture/arch-fw-<name>.mdx` following the framework page template.
-3. Add the page ID to `ARCH_GUIDE_SECTIONS` in `navigation.ts` under "Full-Stack Frameworks".
+1. Add `FrameworkPageData` entry to `FRAMEWORK_PAGES` in `frameworks.ts`.
+2. Create `arch-fw-<name>.mdx` following the framework page template.
+3. Add page ID to `ARCH_GUIDE_SECTIONS` under "Full-Stack Frameworks".

--- a/src/content/auth/CLAUDE.md
+++ b/src/content/auth/CLAUDE.md
@@ -1,12 +1,12 @@
 # Auth for Frontend Engineers — Guide CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns (MDX conventions, dark mode, styling, link registry, glossary, build commands). This file covers **auth**-specific context only.
-
 ## Audience & Purpose
 
-Backend engineers who understand authentication and authorization on the server side but need to implement them in a frontend context. Teaches tokens, JWTs, OAuth 2.0/OIDC, frontend auth patterns (React context, protected routes, silent refresh), and security threats.
+Backend engineers who understand server-side auth but need to implement it in a frontend context. Teaches tokens, JWTs, OAuth 2.0/OIDC, frontend auth patterns, and security threats.
 
 ## Section Structure
+
+Defined in `AUTH_GUIDE_SECTIONS` in `src/data/authData/navigation.ts`.
 
 | Section Label | Page IDs |
 |--------------|----------|
@@ -15,68 +15,23 @@ Backend engineers who understand authentication and authorization on the server 
 | Protocols & Patterns | `auth-oauth`, `auth-frontend` |
 | Security & Review | `auth-security`, `auth-quiz` |
 
-The `auth-checklist` page is part of the cross-guide Checklists group (see `checklistPages` in `guideRegistry.ts`).
-
-Defined in `AUTH_GUIDE_SECTIONS` in `src/data/authData/navigation.ts`.
-
-## File Locations
-
-| Category | Path |
-|----------|------|
-| Content pages | `src/content/auth/*.mdx` |
-| Data directory | `src/data/authData/` (barrel-exported) |
-| Type definitions | `src/data/authData/types.ts` |
-| Concept data | `src/data/authData/concepts.ts` |
-| Navigation & start page | `src/data/authData/navigation.ts` |
-| Interactive components | `src/components/mdx/auth/` |
-| Link registry | `src/data/linkRegistry/authLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/authTerms.ts` |
+Data directory: `src/data/authData/` — `types.ts`, `concepts.ts`, `navigation.ts`. See type definitions in `types.ts`.
 
 ## Interactive Components
 
-| Component | Props | Data Source | Purpose |
-|-----------|-------|-------------|---------|
-| `ConceptCards` | `sectionId: string` | `AuthConceptSection[]` in `concepts.ts` | Cards with term, definition, analogy, and examples |
-| `JwtParts` | *(none)* | `JwtPart[]` in `concepts.ts` | Interactive JWT header/payload/signature breakdown |
-| `OAuthFlow` | *(none)* | `OAuthFlowStep[]` in `concepts.ts` | Step-by-step Authorization Code flow diagram |
-| `AuthPatterns` | *(none)* | `AuthPattern[]` in `concepts.ts` | Recommended vs. avoid patterns with code examples |
-| `SecurityThreats` | *(none)* | `SecurityThreat[]` in `concepts.ts` | Threats with severity levels (critical/high/medium) |
-| `AuthChecklist` | *(none)* | `AuthChecklistItem[]` in `concepts.ts` | Categorized implementation checklist |
-| `AuthQuiz` | *(none)* | `QuizQuestion[]` in `concepts.ts` | Multiple-choice questions with explanations |
+| Component | Props | Purpose |
+|-----------|-------|---------|
+| `ConceptCards` | `sectionId` | Cards with term, definition, analogy, and examples |
+| `JwtParts` | *(none)* | Interactive JWT header/payload/signature breakdown |
+| `OAuthFlow` | *(none)* | Step-by-step Authorization Code flow diagram |
+| `AuthPatterns` | *(none)* | Recommended vs. avoid patterns with code examples |
+| `SecurityThreats` | *(none)* | Threats with severity levels (critical/high/medium) |
+| `AuthChecklist` | *(none)* | Categorized implementation checklist |
+| `AuthQuiz` | *(none)* | Multiple-choice questions with explanations |
 
 ## Guide-Specific Conventions
 
-### Sequential learning path
-
-The start page uses numbered steps 1–5 plus a bonus section. Pages are designed to be read in order — each builds on the previous.
-
-### SectionMeta pattern
-
-Several data arrays include a `SectionMeta` object (e.g., `JwtSectionMeta`, `OAuthSectionMeta`, `SecuritySectionMeta`) with `heading`, `intro`, and `keyTakeaway` fields. Components render these as section structure: a heading, an introductory paragraph, and a key takeaway callout. This is unique to the auth guide.
-
-### Concept cards
-
-`ConceptCards` renders terms with four fields each: `term`, `definition`, `analogy` (maps backend concept to frontend), and `examples` array. The `color`/`darkColor` fields control card accent colors.
-
-### Threat severity
-
-`SecurityThreats` uses the `ThreatSeverity` union (`'critical' | 'high' | 'medium'`) to color-code threat cards by risk level.
-
-### Data types
-
-Key interfaces in `src/data/authData/types.ts`:
-
-- `AuthConcept` — term/definition/analogy/color/darkColor/examples
-- `AuthConceptSection` — id/heading/intro/keyTakeaway + concepts array
-- `JwtPart` — name/color/json/desc
-- `OAuthFlowStep` — step/label/detail/actor
-- `AuthPattern` — name/recommendation/avoid/code
-- `SecurityThreat` — name/risk/defense/severity
-- `QuizQuestion` — q/options/answer/explanation
-
-## Adding a New Page
-
-1. Create `src/content/auth/<page-id>.mdx` with frontmatter (`id`, `title` with emoji, `guide: "auth"`).
-2. Add the page ID to `AUTH_GUIDE_SECTIONS` in `src/data/authData/navigation.ts` under the correct section label.
-3. If adding data-driven content, define the data types in `types.ts` and add the data to `concepts.ts`.
-4. Create the component in `src/components/mdx/auth/` and register it in `src/components/mdx/index.ts`.
+- **Sequential learning path:** Pages designed to be read in order (steps 1–5 plus bonus).
+- **SectionMeta pattern:** Data arrays include `SectionMeta` objects with `heading`, `intro`, `keyTakeaway` for structured section rendering. Unique to auth guide.
+- **Concept cards:** Four fields each: `term`, `definition`, `analogy` (maps backend→frontend), `examples`. Colors via `color`/`darkColor`.
+- **Threat severity:** `SecurityThreats` uses `ThreatSeverity` union (`'critical' | 'high' | 'medium'`) for color-coded threat cards.

--- a/src/content/checklist/CLAUDE.md
+++ b/src/content/checklist/CLAUDE.md
@@ -1,18 +1,10 @@
 # Checklists — Content CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns. This file covers
-> checklist-specific conventions only.
-
 ## Purpose
 
-Cross-guide implementation checklists. Each checklist is associated with
-a source guide but lives in this shared directory.
+Cross-guide implementation checklists. Each checklist is associated with a source guide but lives in this shared directory.
 
-## Conventions
-
-### MDX Template
-
-Every checklist page follows this structure:
+## MDX Template
 
 ```mdx
 ---
@@ -29,21 +21,11 @@ title: "<Title> ✅"
 <ChecklistComponent />
 ```
 
-### Styling
+## Styling
 
-All checklists use the shared `ChecklistBase` component
-(`src/components/mdx/ChecklistBase.tsx`), which provides:
+All checklists use `ChecklistBase` (`src/components/mdx/ChecklistBase.tsx`): progress bar, "Copy as Markdown" button, "Deselect All" button, sections with icon headings, checkbox items with checked line-through styling.
 
-- **Progress bar** at top: blue-500/blue-400, showing count + percentage
-- **Copy as Markdown** button above the checklist
-- **Deselect All** button (appears when items are checked)
-- **Sections** with icon + name headings
-- **Items** as `<label>` with native checkbox, accent-blue-500
-- **Checked state**: line-through text-slate-400
-
-### Data
-
-Each checklist's data lives in its source guide's data file:
+## Data Sources
 
 | Checklist | Data Source | Wrapper Component |
 |-----------|-----------|-------------------|
@@ -52,16 +34,8 @@ Each checklist's data lives in its source guide's data file:
 | Auth Implementation | `src/data/authData/concepts.ts` | `AuthChecklist` |
 | CLAUDE.md Checklist | `src/data/promptData/navigation.ts` | `ClaudeMdChecklist` |
 
-### Floating Header
+## Rules
 
-Checklist pages show a "Go to Guide" link in the floating header that
-navigates to the source guide's start page. The mapping is defined in
-`checklistPages` in `src/data/guideRegistry.ts`.
-
-### DO NOT
-
-- Do NOT add `<NavPill>` "Back to Start Here" links
-- Do NOT add a `guide:` field to frontmatter (guide association is
-  managed by `checklistPages` in `guideRegistry.ts`)
-- Do NOT include `<Toc>` sections in checklist pages
-- Do NOT create custom checkbox styling — use `ChecklistBase`
+- Do NOT add `guide:` field to frontmatter (guide association managed by `checklistPages` in `guideRegistry.ts`)
+- Do NOT add `<NavPill>` "Back to Start Here" links, `<Toc>` sections, or custom checkbox styling
+- Checklist pages show a "Go to Guide" floating header link (mapping in `checklistPages` in `guideRegistry.ts`)

--- a/src/content/ci-cd/CLAUDE.md
+++ b/src/content/ci-cd/CLAUDE.md
@@ -1,12 +1,12 @@
 # CI/CD & GitHub Actions — Guide CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns (MDX conventions, dark mode, styling, link registry, glossary, build commands). This file covers **ci-cd**-specific context only.
-
 ## Audience & Purpose
 
-Developers who understand building apps but have not set up CI/CD before. Teaches pipelines, GitHub Actions, YAML workflows, and common deployment patterns from scratch.
+Developers who understand building apps but have not set up CI/CD before. Teaches pipelines, GitHub Actions, YAML workflows, and deployment patterns from scratch.
 
 ## Section Structure
+
+Defined in `CICD_GUIDE_SECTIONS` in `src/data/cicdData.ts`. All data in this single file.
 
 | Section Label | Page IDs |
 |--------------|----------|
@@ -15,51 +15,17 @@ Developers who understand building apps but have not set up CI/CD before. Teache
 | Hands-On | `cicd-yaml`, `cicd-patterns` |
 | Reference | `cicd-gotchas` |
 
-Defined in `CICD_GUIDE_SECTIONS` in `src/data/cicdData.ts`.
-
-## File Locations
-
-| Category | Path |
-|----------|------|
-| Content pages | `src/content/ci-cd/*.mdx` |
-| All guide data | `src/data/cicdData.ts` (single file) |
-| Interactive components | `src/components/mdx/ci-cd/` |
-| Link registry | `src/data/linkRegistry/cicdLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/cicdTerms.ts` |
-
 ## Interactive Components
 
-| Component | Props | Data Source | Purpose |
-|-----------|-------|-------------|---------|
-| `PipelineStages` | *(none)* | `PIPELINE_STAGES` | Visualizes the 5 pipeline stages (Trigger, Build, Test, Lint & Quality, Deploy) |
-| `YamlExplorer` | *(none)* | `YAML_LINES` | Interactive line-by-line YAML annotation; click any line to see its explanation |
-| `PatternCards` | *(none)* | `CICD_PATTERNS` + `PATTERN_TAG_STYLES` | CI/CD pattern cards with color-coded tags |
-| `GotchaAccordion` | *(none)* | `CICD_TIPS` | Expandable gotchas and tips |
+| Component | Props | Purpose |
+|-----------|-------|---------|
+| `PipelineStages` | *(none)* | Visualizes the 5 pipeline stages |
+| `YamlExplorer` | *(none)* | Interactive line-by-line YAML annotation |
+| `PatternCards` | *(none)* | CI/CD pattern cards with color-coded tags |
+| `GotchaAccordion` | *(none)* | Expandable gotchas and tips |
 
 ## Guide-Specific Conventions
 
-### Single data file
-
-All data lives in `cicdData.ts` — types, pipeline stages, GHA concepts, YAML lines, patterns, tag styles, tips, and navigation. The guide is compact enough that a single file works well.
-
-### YAML annotation system
-
-`YAML_LINES` is an array of `{ line: string, note: string | null }` objects. Each line represents a line from a real GitHub Actions workflow file. Lines with a non-null `note` are interactive — clicking them reveals the annotation. The `YamlExplorer` component renders this.
-
-### Pattern categorization
-
-`CICD_PATTERNS` assigns each pattern a `tag` string (e.g., "Essential", "Testing", "Performance"). `PATTERN_TAG_STYLES` maps each tag to `{ bg, text, border, darkBg, darkText, darkBorder }` for consistent badge rendering in light/dark modes.
-
-### GHA terminology
-
-`GHA_CONCEPTS` defines term/definition pairs for GitHub Actions building blocks (Workflow, Event, Job, Step, Action, Runner). These are used on the `cicd-github-actions` page.
-
-### Dark mode
-
-Pipeline stages use `color`/`darkColor` fields. Pattern tags use the `PatternTagStyle` interface with separate light/dark properties.
-
-## Adding a New Page
-
-1. Create `src/content/ci-cd/<page-id>.mdx` with frontmatter (`id`, `title` with emoji, `guide: "ci-cd"`).
-2. Add the page ID to `CICD_GUIDE_SECTIONS` in `src/data/cicdData.ts` under the correct section label.
-3. If adding new data-driven content, add the data interface and constants to `cicdData.ts`.
+- **YAML annotation:** `YAML_LINES` array of `{ line, note }` objects. Lines with non-null `note` are interactive in `YamlExplorer`.
+- **Pattern categorization:** `CICD_PATTERNS` assigns tags; `PATTERN_TAG_STYLES` maps to `{ bg, text, border, darkBg, darkText, darkBorder }`.
+- **GHA terminology:** `GHA_CONCEPTS` defines term/definition pairs for GitHub Actions building blocks (Workflow, Event, Job, Step, Action, Runner).

--- a/src/content/kubernetes/CLAUDE.md
+++ b/src/content/kubernetes/CLAUDE.md
@@ -1,12 +1,12 @@
 # Kubernetes & Helm — Guide CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns (MDX conventions, dark mode, styling, link registry, glossary, build commands). This file covers **kubernetes**-specific context only.
-
 ## Audience & Purpose
 
-Frontend engineers who deploy apps but want to understand what happens after `git push`. Teaches containers, Docker, Kubernetes, Helm, and deployment pipelines using frontend-to-infrastructure analogies throughout.
+Frontend engineers who deploy apps but want to understand what happens after `git push`. Teaches containers, Docker, Kubernetes, Helm, and deployment pipelines using frontend-to-infrastructure analogies.
 
 ## Section Structure
+
+Defined in `K8S_GUIDE_SECTIONS` in `src/data/k8sData.ts`. All data in this single file.
 
 | Section Label | Page IDs |
 |--------------|----------|
@@ -15,63 +15,19 @@ Frontend engineers who deploy apps but want to understand what happens after `gi
 | Configuration | `k8s-yaml`, `k8s-helm` |
 | The Full Picture | `k8s-ecosystem`, `k8s-flow` |
 
-Defined in `K8S_GUIDE_SECTIONS` in `src/data/k8sData.ts`.
-
-## File Locations
-
-| Category | Path |
-|----------|------|
-| Content pages | `src/content/kubernetes/*.mdx` |
-| All guide data | `src/data/k8sData.ts` (single file) |
-| Interactive components | `src/components/mdx/kubernetes/` |
-| Link registry | `src/data/linkRegistry/kubernetesLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/kubernetesTerms.ts` |
-
 ## Interactive Components
 
-All components accept a `sectionId: string` prop that looks up the matching `K8sSection` from `K8S_SECTIONS` by its `id` field.
+All accept `sectionId: string` matching a `K8sSection.id` in `K8S_SECTIONS`.
 
-| Component | Props | Data Source | Purpose |
-|-----------|-------|-------------|---------|
-| `K8sAnalogyCard` | `sectionId: string` | `K8S_SECTIONS` | Renders the frontend ↔ infra analogy card for a section |
-| `K8sConceptList` | `sectionId: string` | `K8S_SECTIONS` | Renders the concept term/definition list for a section |
-| `K8sCodeBlock` | `sectionId: string` | `K8S_SECTIONS` | Renders the code example (e.g., Dockerfile, YAML manifest) for a section |
-| `K8sFlowDiagram` | `sectionId: string` | `K8S_SECTIONS` | Renders a color-coded flow diagram (e.g., deployment pipeline steps) |
+| Component | Props | Purpose |
+|-----------|-------|---------|
+| `K8sAnalogyCard` | `sectionId` | Frontend ↔ infra analogy card |
+| `K8sConceptList` | `sectionId` | Concept term/definition list |
+| `K8sCodeBlock` | `sectionId` | Code example (Dockerfile, YAML manifest) |
+| `K8sFlowDiagram` | `sectionId` | Color-coded flow diagram |
 
 ## Guide-Specific Conventions
 
-### Dual perspective structure
-
-Every `K8sSection` has both a `frontend` and an `infra` field — short paragraphs that explain the same concept from the frontend engineer's familiar perspective and the infrastructure perspective. This is the defining convention of the guide.
-
-### Analogy mapping
-
-The `K8sAnalogy` type maps a `frontend` concept to an `infra` concept with an `explain` field. For example: `npm / package.json` maps to `Kubernetes / Helm Charts`. The `K8sAnalogyCard` component renders these as a visual comparison.
-
-### Single data file
-
-All data lives in `k8sData.ts` — types (`K8sSection`, `K8sAnalogy`, `K8sConcept`, `K8sCodeExample`, `K8sFlowStep`), the `K8S_SECTIONS` array, and navigation/start page data.
-
-### K8sSection structure
-
-Each section in `K8S_SECTIONS` has:
-
-- `id` — Matches the section prop passed to all components
-- `icon`, `title`, `subtitle` — Display metadata
-- `frontend`, `infra` — Dual perspective text
-- `analogy?` — Optional `K8sAnalogy` (frontend ↔ infra mapping)
-- `concepts?` — Optional `K8sConcept[]` (term/definition pairs)
-- `codeExample?` — Optional `K8sCodeExample` (title + code string)
-- `flow?` — Optional `K8sFlowStep[]` (step/label/detail with `color`/`darkColor`)
-- `keyTakeaway` — Summary sentence rendered as a callout
-
-### Flow diagram colors
-
-`K8sFlowStep` entries have `color` and `darkColor` fields for light/dark mode rendering in `K8sFlowDiagram`.
-
-## Adding a New Page
-
-1. Add a `K8sSection` entry to `K8S_SECTIONS` in `src/data/k8sData.ts` with all required fields.
-2. Create `src/content/kubernetes/k8s-<slug>.mdx` with frontmatter (`id`, `title` with emoji, `guide: "kubernetes"`).
-3. Use the section components in the MDX body: `<K8sAnalogyCard sectionId="..." />`, `<K8sConceptList sectionId="..." />`, etc.
-4. Add the page ID to `K8S_GUIDE_SECTIONS` in `k8sData.ts` under the correct section label.
+- **Dual perspective:** Every `K8sSection` has `frontend` and `infra` fields — same concept from two viewpoints.
+- **Analogy mapping:** `K8sAnalogy` maps `frontend` concept to `infra` concept with `explain` field. `K8sAnalogyCard` renders as visual comparison.
+- **Section structure:** Each `K8sSection` has: `id`, `icon`, `title`, `subtitle`, `frontend`, `infra`, optional `analogy`/`concepts`/`codeExample`/`flow`, and `keyTakeaway`.

--- a/src/content/nextjs-abstractions/CLAUDE.md
+++ b/src/content/nextjs-abstractions/CLAUDE.md
@@ -2,69 +2,28 @@
 
 ## Audience & Purpose
 
-Engineers who have been working with Next.js and are separating their architecture into a standalone React SPA frontend and a Node.js backend (Express, Fastify, or similar). The guide covers the backend and middleware concepts that Next.js abstracts away, helping readers understand what they need to implement themselves.
+Engineers separating a Next.js app into a standalone React SPA frontend and a Node.js backend (Express, Fastify). Covers backend and middleware concepts that Next.js abstracts away.
 
 ## Section Structure
 
-| Section Label | Page IDs | Topic |
-|--------------|----------|-------|
-| *(start)* | `nja-start` | Learning path overview |
-| Request Lifecycle | `nja-routing`, `nja-ssr`, `nja-api-routes`, `nja-middleware` | How requests flow from URL to response |
-| Security & Auth | `nja-auth`, `nja-cors`, `nja-csp` | Authentication, CORS, and content security |
-| Data & Config | `nja-data-fetching`, `nja-env-config`, `nja-database` | Data fetching, env vars, and database access |
-| Build & Ship | `nja-build-bundling`, `nja-error-handling`, `nja-deployment` | Build pipelines, error handling, and deployment |
+| Section Label | Page IDs |
+|--------------|----------|
+| *(start)* | `nja-start` |
+| Request Lifecycle | `nja-routing`, `nja-ssr`, `nja-api-routes`, `nja-middleware` |
+| Security & Auth | `nja-auth`, `nja-cors`, `nja-csp` |
+| Data & Config | `nja-data-fetching`, `nja-env-config`, `nja-database` |
+| Build & Ship | `nja-build-bundling`, `nja-error-handling`, `nja-deployment` |
 
-## File Locations
-
-| Type | Path |
-|------|------|
-| Data (types, concepts, checklist, navigation) | `src/data/njaData/` |
-| Link registry | `src/data/linkRegistry/njaLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/njaTerms.ts` |
-| MDX content pages | `src/content/nextjs-abstractions/` |
-| Checklist page | `src/content/checklist/nja-checklist.mdx` |
-| Interactive components | `src/components/mdx/nextjs-abstractions/` |
+Data directory: `src/data/njaData/` — concepts, checklist, navigation.
 
 ## Interactive Components
 
-### ConceptDetail
-- **File:** `src/components/mdx/nextjs-abstractions/ConceptDetail.tsx`
-- **Props:** `{ conceptId: string }` — matches `NjaConcept.id` in `concepts.ts`
-- **Data:** `NJA_CONCEPTS` from `src/data/njaData/concepts.ts`
-- **Renders:** Two side-by-side cards ("What Next.js Does" vs. "What You Need"), a difficulty badge, and a "For Your Stack" section with framework-specific bullets (Express, Fastify, and optionally PostgreSQL)
-
-### NjaChecklist
-- **File:** `src/components/mdx/nextjs-abstractions/NjaChecklist.tsx`
-- **Props:** None
-- **Data:** `NJA_CHECKLIST` from `src/data/njaData/checklist.ts`
-- **Renders:** Wraps shared `ChecklistBase` with a 6-phase migration checklist
-
-## Data Types
-
-### NjaConcept
-Each concept page maps to one `NjaConcept` object:
-- `id` — matches the concept page suffix (e.g., `routing`, `ssr`)
-- `title` — display name
-- `icon` — emoji
-- `color` / `darkColor` — accent colors for the comparison cards
-- `whatNextDoes` — HTML string describing what Next.js handles
-- `whatYouNeed` — HTML string describing what you implement yourself
-- `keyTerms` — array of term names (cross-reference glossary)
-- `difficulty` — `beginner` | `intermediate` | `advanced`
-- `stackNotes` — array of `StackNote` objects with per-framework guidance
-
-### StackNote
-Framework-specific migration guidance:
-- `framework` — `Express` | `Fastify` | `PostgreSQL`
-- `icon` — emoji identifier
-- `note` — HTML string with the guidance
-- `packages` — optional array of npm package names
+- **`ConceptDetail`** (`conceptId: string`) — Two side-by-side cards ("What Next.js Does" vs. "What You Need"), difficulty badge, and "For Your Stack" section with framework-specific bullets.
+- **`NjaChecklist`** — Wraps shared `ChecklistBase` with a 6-phase migration checklist. Data from `njaData/checklist.ts`.
 
 ## Conventions
 
-- Each concept page uses `<ConceptDetail conceptId="..." />` — no inline data
-- "For Your Stack" notes are generalized (no TanStack/airgapped-specific references)
-- Key terms auto-enrich from the glossary via `enrichGlossaryTermsDOM`
-- CSP is an original section not in the source artifact
-- Checklist uses shared `ChecklistBase` pattern
-- All titles end with emoji suffix per project convention
+- Each concept page uses `<ConceptDetail conceptId="..." />` — no inline data.
+- "For Your Stack" notes are generalized (no TanStack/airgapped-specific references).
+- Key terms auto-enrich from glossary via `enrichGlossaryTermsDOM`.
+- Checklist uses shared `ChecklistBase` pattern.

--- a/src/content/npm-package/CLAUDE.md
+++ b/src/content/npm-package/CLAUDE.md
@@ -1,14 +1,12 @@
 # Web App vs. NPM Package — Guide CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns (MDX conventions, dark mode, styling, link registry, glossary, build commands). This file covers **npm-package**-specific context only.
-
 ## Audience & Purpose
 
 Backend engineers learning to build and publish npm packages. Assumes familiarity with backend CI/CD, package managers, and compiled languages. Teaches npm/pnpm, bundlers, TypeScript config, `package.json` exports, semver, CI pipelines, and publishing workflows.
 
 ## Section Structure
 
-Sections are defined in `NPM_GUIDE_SECTIONS` in `src/data/npmPackageData.ts`.
+Sections defined in `NPM_GUIDE_SECTIONS` in `src/data/npmPackageData.ts`.
 
 | Section Label | Page IDs |
 |--------------|----------|
@@ -17,74 +15,28 @@ Sections are defined in `NPM_GUIDE_SECTIONS` in `src/data/npmPackageData.ts`.
 | CI Pipeline & Checks | `ci-overview`, `ci-linting`, `ci-build`, `ci-testing`, `ci-repo-maintenance` |
 | Developer Experience | `storybook` |
 
-The `checklist` page is part of the cross-guide Checklists group (see `checklistPages` in `guideRegistry.ts`).
-
-## File Locations
-
-| Category | Path |
-|----------|------|
-| Content pages | `src/content/npm-package/*.mdx` |
-| Guide data | `src/data/npmPackageData.ts` |
-| Roadmap step data | `src/data/roadmapSteps.ts` |
-| Checklist item data | `src/data/checklistItems.ts` |
-| Interactive components | `src/components/mdx/npm-package/` |
-| Link registry | `src/data/linkRegistry/npmPackageLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/npmPackageTerms.ts` |
+Additional data files beyond the standard layout: `src/data/roadmapSteps.ts` (roadmap step data), `src/data/checklistItems.ts` (checklist item data).
 
 ## Interactive Components
 
-### Standard section components (all main pages)
-
-- **`RoadmapSteps`** — Renders the interactive roadmap visualization on the start page. Data from `src/data/roadmapSteps.ts`. No props needed.
-- **`PublishChecklist`** — Pre-publish checklist with progress bar and "Copy as Markdown" button. Data from `src/data/checklistItems.ts`. No props needed.
-
-### CI page layout components (CI pages only)
-
-All exported from `src/components/mdx/npm-package/CILayout.tsx`:
-
 | Component | Props | Purpose |
 |-----------|-------|---------|
+| `RoadmapSteps` | *(none)* | Interactive roadmap on start page. Data from `roadmapSteps.ts`. |
+| `PublishChecklist` | *(none)* | Pre-publish checklist with progress bar. Data from `checklistItems.ts`. |
 | `CIOverviewCards` | `children` | Grid container for numbered overview cards |
-| `CIFullExample` | `children` | Full workflow YAML example with emoji header and syntax-highlighted `<span>` elements |
-| `CIStep` | `heading: string`, `id?: string` | Section heading with optional TOC anchor |
-| `CIStepText` | `children` | Body text block within a `CIStep` |
-| `CIYaml` | `children` | Monospace YAML code block (dark background) |
-| `YamlHeading` | `children?` (default: "GitHub Actions Example") | Label above YAML blocks |
-| `CITip` | `children` | Blue callout box for tips and advice |
-| `MaintenanceTool` | `name`, `emoji`, `desc`, `why`, `yaml?`, `children?` | Tool card with description, rationale, and optional YAML |
+| `CIFullExample` | `children` | Full workflow YAML with syntax-highlighted `<span>` elements |
+| `CIStep` | `heading`, `id?` | Section heading with optional TOC anchor |
+| `CIStepText` | `children` | Body text within a `CIStep` |
+| `CIYaml` | `children` | Monospace YAML code block |
+| `YamlHeading` | `children?` | Label above YAML blocks |
+| `CITip` | `children` | Blue callout box |
+| `MaintenanceTool` | `name`, `emoji`, `desc`, `why`, `yaml?`, `children?` | Tool card with description and optional YAML |
 | `GoodTestsList` | `children` | Styled `<ul>` for test best practices |
-| `AiPromptsAccordion` | `prompts: { label, prompt }[]` | Collapsible accordion with copy-to-clipboard AI prompt examples |
+| `AiPromptsAccordion` | `prompts: { label, prompt }[]` | Collapsible accordion with copy-to-clipboard AI prompts |
 
 ## Guide-Specific Conventions
 
-### Dual comparison structure
-
-Most main section pages present content in a **"Web App" vs. "NPM Package"** side-by-side format. Each side is introduced with a `<SectionSubheading>` using globe (web app) and package (npm) emojis. New main section pages should follow this pattern.
-
-### Package manager switching
-
-All command references use `<Cmd npm="..." pnpm="..." />`, never hardcoded command strings. The component reads the global npm/pnpm toggle from `usePM()` context.
-
-### CI page layout
-
-CI pages (`ci-overview`, `ci-linting`, `ci-build`, `ci-testing`, `ci-repo-maintenance`) use the CI-specific layout components listed above instead of the standard `SectionList`/`ColItem` pattern. This provides a structured visual style for CI pipeline content with YAML blocks, tip callouts, and overview cards. Each CI page follows a consistent structure: `<SectionTitle>` → `<SectionIntro>` → content sections with `<YamlHeading>` + `<CIYaml>` blocks → `<CITip>`.
-
-### Cross-guide links
-
-CI pages link to related pages in other guides using `<NavLink>` and `<NavPill>`:
-- Testing Guide pages (e.g., `test-overview`, `test-best-practices`)
-- Prompt Engineering pages (e.g., `prompt-mistakes-style`)
-- Other npm-package pages (e.g., `build`, `storybook`)
-
-### Footnote usage
-
-This guide uses footnotes heavily — typically 3–7 per page. Set the `usedFootnotes` frontmatter array and use `<FnRef n={N} />` markers in the MDX body for each inline citation.
-
-## Adding a New Page
-
-1. Create a new `.mdx` file in `src/content/npm-package/`.
-2. Add frontmatter with `id`, `title` (must end with emoji), `guide: "npm-package"`, and optionally `linkRefs`/`usedFootnotes`.
-3. Add the page ID to `NPM_GUIDE_SECTIONS` in `src/data/npmPackageData.ts` under the correct section label.
-4. For main section pages, follow the dual comparison structure (Web App vs. NPM Package).
-5. For CI pages, use the CI layout components from `CILayout.tsx`.
-6. Add any new link registry entries to `src/data/linkRegistry/npmPackageLinks.ts`.
+- **Dual comparison:** Most pages use "Web App" vs. "NPM Package" side-by-side format with `<SectionSubheading>` using globe/package emojis.
+- **Package manager switching:** All commands use `<Cmd npm="..." pnpm="..." />`, never hardcoded strings.
+- **CI page layout:** CI pages (`ci-*`) use CI layout components (above) instead of `SectionList`/`ColItem`. Structure: `<SectionTitle>` → `<SectionIntro>` → content with `<YamlHeading>` + `<CIYaml>` → `<CITip>`.
+- **Footnote usage:** Typically 3–7 footnotes per page. Set `usedFootnotes` frontmatter and use `<FnRef n={N} />`.

--- a/src/content/prompt-engineering/CLAUDE.md
+++ b/src/content/prompt-engineering/CLAUDE.md
@@ -1,12 +1,12 @@
 # Prompt Engineering — Guide CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns (MDX conventions, dark mode, styling, link registry, glossary, build commands). This file covers **prompt-engineering**-specific context only.
-
 ## Audience & Purpose
 
-Developers (any background) learning practical patterns for working with AI coding assistants. This is the largest guide with 22+ pages. Covers common AI-generated code mistakes, context management techniques, CLI commands, and advanced tooling (MCP, skills, hooks).
+Developers (any background) learning practical patterns for working with AI coding assistants. Largest guide with 22+ pages. Covers common AI-generated code mistakes, context management techniques, CLI commands, and advanced tooling (MCP, skills, hooks).
 
 ## Section Structure
+
+Defined in `PROMPT_GUIDE_SECTIONS` in `src/data/promptData/navigation.ts`.
 
 | Section Label | Page IDs |
 |--------------|----------|
@@ -16,73 +16,40 @@ Developers (any background) learning practical patterns for working with AI codi
 | Tooling & Reference | `prompt-coding-tools`, `prompt-cli-reference`, `prompt-meta-tooling` |
 | Advanced Tools | `prompt-tools-mcp`, `prompt-tools-skills`, `prompt-tools-hooks`, `prompt-tools-optimization` |
 
-The `prompt-claudemd-checklist` page is part of the cross-guide Checklists group (see `checklistPages` in `guideRegistry.ts`).
-
-Defined in `PROMPT_GUIDE_SECTIONS` in `src/data/promptData/navigation.ts`.
-
-## File Locations
-
-| Category | Path |
-|----------|------|
-| Content pages | `src/content/prompt-engineering/*.mdx` |
-| Data directory | `src/data/promptData/` (barrel-exported) |
-| Type definitions | `src/data/promptData/types.ts` |
-| Mistake data | `src/data/promptData/mistakes.ts` |
-| Technique data | `src/data/promptData/techniques.ts` |
-| CLI command data | `src/data/promptData/cli.ts` |
-| Coding tools data | `src/data/promptData/codingTools.ts` |
-| Navigation & start page | `src/data/promptData/navigation.ts` |
-| Interactive components | `src/components/mdx/prompt-engineering/` |
-| Link registry | `src/data/linkRegistry/promptLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/promptTerms.ts` |
+Data directory: `src/data/promptData/` — `types.ts`, `mistakes.ts`, `techniques.ts`, `cli.ts`, `codingTools.ts`, `navigation.ts`.
 
 ## Interactive Components
 
-| Component | Props | Data Source | Purpose |
-|-----------|-------|-------------|---------|
-| `SeverityBadge` | `categoryId: string` | `MISTAKE_CATEGORIES` in `mistakes.ts` | Renders the severity level badge (high/medium/low) for a mistake category |
-| `MistakeList` | `categoryId: string` | `MISTAKE_CATEGORIES` in `mistakes.ts` | Renders mistake items for a category (no badge — use `SeverityBadge` separately) |
-| `TechniqueDetail` | `techniqueId: string` | `CONTEXT_TECHNIQUES` in `techniques.ts` | Deep-dive technique explainer with code example |
-| `CLIReference` | *(none)* | `CLI_GROUPS` in `cli.ts` | Searchable, filterable CLI command table |
-| `TestingMistakes` | `context?: 'e2e' \| 'unit'` | `TESTING_MISTAKES` in `mistakes.ts` | Testing-specific mistake cards, optionally filtered |
-| `ClaudeMdChecklist` | *(none)* | `CLAUDEMD_CHECKLIST` in `navigation.ts` | Interactive CLAUDE.md configuration checklist |
-| `ToolDetail` | `toolId: string`, `section?: string` | `TOOL_TECHNIQUES` in `techniques.ts` | Tool explainer with conditional sections (overview, bestFor, implementation, examples, tips) |
-| `MetaTooling` | `toolId: string` | `META_TOOLS` in `techniques.ts` | Meta-tooling pattern details |
-| `CodingToolExplorer` | *(none)* | `AI_CODING_TOOLS` in `codingTools.ts` | Interactive AI coding tool comparison |
+| Component | Props | Purpose |
+|-----------|-------|---------|
+| `SeverityBadge` | `categoryId` | Severity level badge (high/medium/low) for a mistake category |
+| `MistakeList` | `categoryId` | Mistake items for a category (no badge) |
+| `TechniqueDetail` | `techniqueId` | Deep-dive technique explainer with code example |
+| `CLIReference` | *(none)* | Searchable, filterable CLI command table |
+| `TestingMistakes` | `context?: 'e2e' \| 'unit'` | Testing-specific mistake cards |
+| `ClaudeMdChecklist` | *(none)* | Interactive CLAUDE.md configuration checklist |
+| `ToolDetail` | `toolId`, `section?` | Tool explainer; sections: overview, bestFor, implementation, examples, tips |
+| `MetaTooling` | `toolId` | Meta-tooling pattern details |
+| `CodingToolExplorer` | *(none)* | Interactive AI coding tool comparison |
 
 ## Guide-Specific Conventions
 
 ### Mistake category pages
 
-Pages in "Common AI Mistakes" use severity badges instead of emoji. This is an exception to the project-wide emoji-suffix convention for page titles.
+**Exception to emoji convention:** Mistake pages do NOT have emoji suffixes in `title`. They use severity badges (H/M/L) in sidebar/command menu and `<SeverityBadge>` on-page.
 
-**Title convention:** Common AI Mistakes pages do NOT have emoji suffixes in their MDX frontmatter `title`. Instead, they use severity level badges (H/M/L) in the sidebar and command menu, and a `<SeverityBadge>` component on the page.
+Layout: `<SectionTitle>` → `<SeverityBadge categoryId="..." />` → `<SectionIntro>` → `<Toc>` → `<MistakeList categoryId="..." />`.
 
-**Page layout:** Every mistake category page must place `<SeverityBadge categoryId="..." />` immediately after `<SectionTitle>`, before `<SectionIntro>`. The `<MistakeList>` component renders only the mistake items — it does not include the severity badge.
+When adding a new mistake page, also add severity badge entries to `severityBadges` in both `Sidebar.tsx` and `CommandMenu.tsx`.
 
-Each `MistakeCategory` in `mistakes.ts` has a `severity` level (`high`, `medium`, `low`) that controls badge color. The `SEVERITY_COLORS` object defines light/dark theme colors for each level. When adding a new mistake page, also add its severity badge entry to `severityBadges` in both `Sidebar.tsx` and `CommandMenu.tsx`.
+### Technique pages
 
-### Technique detail pages
-
-Context management pages use `<TechniqueDetail techniqueId="..." />`. Each technique has a `details` array and optional `codeExample` with monospace rendering.
+Context management pages use `<TechniqueDetail techniqueId="..." />`. Each technique has a `details` array and optional `codeExample`.
 
 ### CLI reference
 
-`<CLIReference />` renders a complex table with search, category filtering, and type filtering (all/AI-only/human-only). Commands in `CLI_GROUPS` can be tagged as `human: true` to distinguish human-typed from AI-triggered commands.
+`<CLIReference />` renders a table with search, category filtering, and type filtering (all/AI-only/human-only). Commands can be tagged `human: true`.
 
 ### Tool detail sections
 
-`<ToolDetail toolId="..." section="overview" />` supports section-conditional rendering. Valid sections: `overview`, `bestFor`, `implementation`, `examples`, `tips`. When `section` is omitted, all sections render.
-
-### Adding a new mistake category
-
-1. Add a `MistakeCategory` to `MISTAKE_CATEGORIES` in `src/data/promptData/mistakes.ts`.
-2. Create `src/content/prompt-engineering/prompt-mistakes-<slug>.mdx` — the title must **not** have an emoji suffix. Place `<SeverityBadge categoryId="..." />` right after `<SectionTitle>`, then `<SectionIntro>`, `<Toc>`, and `<MistakeList categoryId="..." />`.
-3. Add the page ID to `PROMPT_GUIDE_SECTIONS` under "Common AI Mistakes" in `navigation.ts`.
-4. Add a severity badge entry for the page ID to `severityBadges` in both `src/components/Sidebar.tsx` and `src/components/CommandMenu.tsx`.
-
-### Adding a new technique
-
-1. Add a `ContextTechnique` to `CONTEXT_TECHNIQUES` in `src/data/promptData/techniques.ts`.
-2. Create the MDX page using `<TechniqueDetail techniqueId="..." />`.
-3. Add the page ID to the appropriate section in `PROMPT_GUIDE_SECTIONS`.
+`<ToolDetail toolId="..." section="overview" />` supports section-conditional rendering. Omit `section` to render all.

--- a/src/content/testing/CLAUDE.md
+++ b/src/content/testing/CLAUDE.md
@@ -1,12 +1,12 @@
 # Testing Guide — Guide CLAUDE.md
 
-> Root `/CLAUDE.md` covers project-wide patterns (MDX conventions, dark mode, styling, link registry, glossary, build commands). This file covers **testing**-specific context only.
-
 ## Audience & Purpose
 
-Backend engineers learning frontend testing fundamentals. Assumes familiarity with backend testing concepts (unit tests, mocking, CI). Teaches the testing pyramid, what to test at each level, best practices, and how to choose the right tools for unit, component, and E2E tests.
+Backend engineers learning frontend testing fundamentals. Assumes familiarity with backend testing concepts (unit tests, mocking, CI). Teaches the testing pyramid, what to test at each level, and tool selection.
 
 ## Section Structure
+
+Defined in `TESTING_GUIDE_SECTIONS` in `src/data/testingData.ts`. All data in this single file.
 
 | Section Label | Page IDs |
 |--------------|----------|
@@ -15,57 +15,18 @@ Backend engineers learning frontend testing fundamentals. Assumes familiarity wi
 | Comparing Tests | `test-comparison`, `test-best-practices` |
 | Reference | `test-tools` |
 
-The `test-review-checklist` page is part of the cross-guide Checklists group (see `checklistPages` in `guideRegistry.ts`).
-
-Defined in `TESTING_GUIDE_SECTIONS` in `src/data/testingData.ts`.
-
-## File Locations
-
-| Category | Path |
-|----------|------|
-| Content pages | `src/content/testing/*.mdx` |
-| All guide data | `src/data/testingData.ts` (single file) |
-| Interactive components | `src/components/mdx/testing/` |
-| Link registry | `src/data/linkRegistry/testingLinks.ts` |
-| Glossary terms | `src/data/glossaryTerms/testingTerms.ts` |
-
 ## Interactive Components
 
-| Component | Props | Data Source | Purpose |
-|-----------|-------|-------------|---------|
-| `TestingPyramid` | *(none)* | `PYRAMID_LEVELS` | Interactive 3-level pyramid; clicking a level navigates to its page |
-| `TestTypeDetail` | `type: TestType` | `PYRAMID_LEVELS` | "What to test" vs. "What NOT to test" card with code example |
-| `TestPracticeCards` | *(none)* | `PRACTICE_CARDS` | Do's and don'ts cards (green/red border) |
-| `TestChecklist` | *(none)* | `CHECKLIST_ITEMS` | Interactive checkbox list with progress bar |
-| `TestToolsGrid` | *(none)* | `TEST_TOOLS` + `TAG_COLORS` | Filterable grid of testing tools by test type |
+| Component | Props | Purpose |
+|-----------|-------|---------|
+| `TestingPyramid` | *(none)* | Interactive 3-level pyramid; clicking a level navigates to its page |
+| `TestTypeDetail` | `type: TestType` | "What to test" vs. "What NOT to test" card with code example |
+| `TestPracticeCards` | *(none)* | Do's and don'ts cards (green/red border) |
+| `TestChecklist` | *(none)* | Interactive checkbox list with progress bar |
+| `TestToolsGrid` | *(none)* | Filterable grid of testing tools by test type |
 
 ## Guide-Specific Conventions
 
-### Testing pyramid model
-
-The guide organizes content around three test types defined as the `TestType` union: `'unit' | 'component' | 'e2e'`. Each level is defined in `PYRAMID_LEVELS` with `color`, `accent`, `darkAccent`, "what to test" / "what NOT to test" arrays, and a code example.
-
-### Single data file
-
-All data lives in `testingData.ts` — types, pyramid levels, practice cards, checklist items, test tools, tag colors, section definitions, and start page data. This is intentionally a single file since the data is compact.
-
-### Test type page pattern
-
-Each test type page (`test-unit.mdx`, `test-component.mdx`, `test-e2e.mdx`) uses:
-
-```mdx
-<TestTypeDetail type="unit" />
-```
-
-This renders the structured "what to test" / "what NOT to test" layout with a code example, all driven from `PYRAMID_LEVELS` data.
-
-### Tag-based filtering
-
-`TestToolsGrid` uses `TAG_COLORS` to map test type strings to light/dark color pairs for badge rendering. Tools in `TEST_TOOLS` have a `tags` array of `TestType` values.
-
-## Adding a New Page
-
-1. Create `src/content/testing/<page-id>.mdx` with frontmatter (`id`, `title` with emoji, `guide: "testing"`).
-2. Add the page ID to `TESTING_GUIDE_SECTIONS` in `src/data/testingData.ts` under the correct section label.
-3. Use standard layout components (`SectionTitle`, `Toc`, `SectionIntro`, `SectionSubheading`, `SectionList`, `ColItem`).
-4. For test-type-specific pages, use `<TestTypeDetail type="..." />`.
+- **Testing pyramid model:** Content organized around `TestType` union: `'unit' | 'component' | 'e2e'`. Each level in `PYRAMID_LEVELS` with colors, "what to test"/"what NOT to test" arrays, and code example.
+- **Test type pages:** Each (`test-unit.mdx`, etc.) uses `<TestTypeDetail type="..." />`.
+- **Tag-based filtering:** `TestToolsGrid` uses `TAG_COLORS` to map test types to badge colors. Tools have `tags` array of `TestType` values.


### PR DESCRIPTION
## Summary

This PR adds a new "Next.js Abstractions" guide as the ninth independent guide in the application, and refactors the root `CLAUDE.md` documentation to be more concise while extracting detailed content authoring and development conventions into separate reference documents.

## Key Changes

### New Guide: Next.js Abstractions
- Added `nextjs-abstractions` guide to the guides table in root `CLAUDE.md`
- Guide covers backend and middleware concepts that Next.js abstracts away, helping engineers understand what they need to implement when separating a Next.js app into a standalone React SPA frontend and Node.js backend
- Includes 15 content pages organized into 5 sections: Request Lifecycle, Security & Auth, Data & Config, and Build & Ship
- Interactive components: `ConceptDetail` (side-by-side "What Next.js Does" vs. "What You Need" cards) and `NjaChecklist` (6-phase migration checklist)
- Data directory: `src/data/njaData/` with concepts, checklist, and navigation
- Link registry and glossary terms in standard locations

### Documentation Refactoring
- **Root `CLAUDE.md`**: Condensed from ~400 lines to ~150 lines, focusing on project overview, tech stack, commands, and key patterns
  - Simplified tech stack section to single-line format
  - Removed detailed MDX frontmatter reference (moved to `docs/CONTENT_REFERENCE.md`)
  - Removed dark style helper documentation (moved to `docs/DEVELOPMENT_REFERENCE.md`)
  - Removed routing and build validation details (moved to `docs/DEVELOPMENT_REFERENCE.md`)
  - Streamlined project structure descriptions
  - Removed MDX frontmatter reference table

- **New `docs/CONTENT_REFERENCE.md`**: Comprehensive guide for content authors
  - MDX frontmatter field reference with descriptions
  - Link registry conventions and how to add links
  - Glossary term structure and editorial guidance
  - Footnotes and cross-page link patterns

- **New `docs/DEVELOPMENT_REFERENCE.md`**: Technical reference for developers
  - Dark style helper (`ds()`) usage patterns
  - Routing resolution order and page ordering conventions
  - Build validation checks and error troubleshooting
  - Command menu and TypeScript/ESLint configuration details

- **Updated guide-specific `CLAUDE.md` files**: All 9 guides now have condensed guide-specific documentation
  - Removed redundant references to root `CLAUDE.md` patterns
  - Simplified file location tables to data directory paths only
  - Condensed interactive component tables (removed "Data Source" column)
  - Removed detailed guide-specific conventions sections where not essential

### Developer Experience
- Added `.claudeignore` file to exclude large data files (link registries, glossary terms, monolithic data files) from AI context, allowing focused exploration of guide structure and logic

## Implementation Details

- Updated guide count from 8 to 9 in root `CLAUDE.md`
- Maintained consistent documentation structure across all guide-specific `CLAUDE.md` files
- All new documentation follows the same concise, reference-style format
- No changes to application logic, components, or data structures—purely documentation and guide addition

https://claude.ai/code/session_01Bbi9wg3xfZ3Ch4uRqBfgpp