### PR TITLE
Add copy button and file extension badges to CodeAccordion

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -116,7 +116,7 @@ function IconRail({
           data-testid={`sidebar-guide-icon-${guide.id}`}
         >
           <span className="text-lg leading-none">{guide.icon}</span>
-          <span className={tooltipCls}>{guide.title}</span>
+          <span className={tooltipCls}>{guide.singlePage ? 'Single Page Guides' : guide.title}</span>
         </button>
       ))}
 
@@ -224,7 +224,7 @@ function ContentPanel({
       {/* Header */}
       <div className="flex items-center justify-between px-4 h-11 border-b border-slate-200 dark:border-slate-700 shrink-0">
         <span className="text-sm font-semibold text-slate-900 dark:text-slate-100 truncate">
-          {guide.title}
+          {guide.singlePage ? 'Single Page Guides' : guide.title}
         </span>
         <div className="flex items-center gap-0.5 shrink-0 ml-2">
           <button

--- a/src/components/mdx/SectionLayout.tsx
+++ b/src/components/mdx/SectionLayout.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useState, useRef } from 'react'
+import clsx from 'clsx'
 
 export function SectionIntro({ children }: { children: React.ReactNode }) {
   return <div className="section-intro text-sm text-slate-800 dark:text-slate-300 leading-7 mb-6">{children}</div>
@@ -51,18 +52,65 @@ export function SectionList({ children }: { children: React.ReactNode }) {
   return <div className="mb-5">{children}</div>
 }
 
-export function CodeAccordion({ title, children }: { title: string; children: React.ReactNode }) {
+export function CodeAccordion({ title, children, ext }: { title: string; children: React.ReactNode; ext?: string }) {
   const [open, setOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+  const contentRef = useRef<HTMLDivElement>(null)
+
+  const handleCopy = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    const codeEl = contentRef.current?.querySelector('code')
+    const text = codeEl?.textContent ?? contentRef.current?.innerText ?? ''
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    })
+  }
+
   return (
     <div className="my-4 border border-slate-200 dark:border-slate-700 rounded-xl overflow-hidden">
-      <button
-        className="w-full py-3.5 px-4 bg-slate-50 dark:bg-slate-800 border-none cursor-pointer flex items-center justify-between text-sm font-semibold text-slate-900 dark:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors duration-150"
+      <div
+        className="w-full py-3.5 px-4 bg-slate-50 dark:bg-slate-800 cursor-pointer flex items-center justify-between text-sm font-semibold text-slate-900 dark:text-slate-100 hover:bg-slate-100 dark:hover:bg-slate-700 transition-colors duration-150"
         onClick={() => setOpen(o => !o)}
       >
-        <span>{title}</span>
-        <span className={`text-xs inline-block transition-transform duration-200 ${open ? 'rotate-180' : ''}`}>{'\u25BC'}</span>
-      </button>
-      {open && <div className="px-4 pb-4">{children}</div>}
+        <span className="flex items-center gap-2">
+          {title}
+          {ext && (
+            <span className="text-[10px] font-bold uppercase tracking-wider px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400">
+              {ext}
+            </span>
+          )}
+        </span>
+        <span className="flex items-center gap-2">
+          <button
+            className={clsx(
+              'font-sans text-xs font-semibold py-1 px-2.5 border rounded-md cursor-pointer transition-all duration-150 shrink-0',
+              copied
+                ? 'border-green-500 text-green-500 bg-green-50 dark:bg-green-500/10'
+                : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 text-gray-500 dark:text-slate-400 hover:border-blue-500 dark:hover:border-blue-400 hover:text-blue-500 dark:hover:text-blue-400'
+            )}
+            onClick={handleCopy}
+          >
+            {copied ? '\u2713 Copied!' : 'Copy All'}
+          </button>
+          <span className={`text-xs inline-block transition-transform duration-200 ${open ? 'rotate-180' : ''}`}>{'\u25BC'}</span>
+        </span>
+      </div>
+      <div ref={contentRef} className={clsx('px-4 pb-4', !open && 'hidden')}>
+        {children}
+      </div>
     </div>
+  )
+}
+
+export function MdxPre(props: React.ComponentProps<'pre'>) {
+  return (
+    <pre
+      {...props}
+      className={clsx(
+        'rounded-xl p-4 overflow-auto text-xs leading-relaxed font-mono my-4 bg-[#1e293b] dark:bg-[#0d1117] text-[#e2e8f0] dark:text-[#e6edf3]',
+        props.className
+      )}
+    />
   )
 }

--- a/src/components/mdx/index.ts
+++ b/src/components/mdx/index.ts
@@ -4,7 +4,7 @@ import { FnRef } from './FnRef'
 import { NavLink, NavPill } from './NavLink'
 import { StepJump } from './StepJump'
 import { TocLink } from './TocLink'
-import { SectionIntro, Toc, Explainer, Gotcha, ColItem, SectionNote, SectionTitle, SectionSubheading, SectionList, CodeAccordion } from './SectionLayout'
+import { SectionIntro, Toc, Explainer, Gotcha, ColItem, SectionNote, SectionTitle, SectionSubheading, SectionList, CodeAccordion, MdxPre } from './SectionLayout'
 // npm-package
 import {
   CIStep, CIStepText, CIYaml, YamlHeading, CITip, CIOverviewCards, CIOverviewCard,
@@ -66,6 +66,7 @@ import { NjaChecklist } from './nextjs-abstractions/NjaChecklist'
 import { GuideStartContent } from './GuideStartContent'
 
 export const mdxComponents: MDXComponents = {
+  pre: MdxPre,
   Cmd,
   FnRef,
   NavLink,

--- a/src/content/wp-agents/wp-agents-guide.mdx
+++ b/src/content/wp-agents/wp-agents-guide.mdx
@@ -129,7 +129,7 @@ Verify it worked by checking for ACF fields:
 cat src/api/wp-schema.json | grep -A5 '"acf"'
 ```
 
-<CodeAccordion title="wp-acf-schema-discovery.mjs — Full Script">
+<CodeAccordion title="wp-acf-schema-discovery.mjs — Full Script" ext="MJS">
 
 ```javascript
 #!/usr/bin/env node
@@ -412,7 +412,7 @@ node fetch-wp-samples.mjs \
   --output src/api/wp-sample-data.json
 ```
 
-<CodeAccordion title="fetch-wp-samples.mjs — Full Script">
+<CodeAccordion title="fetch-wp-samples.mjs — Full Script" ext="MJS">
 
 ```javascript
 #!/usr/bin/env node
@@ -633,6 +633,8 @@ git push
 
 Claude Code Web reads `CLAUDE.md` files in your repo for project context and instructions. Create one that tells Claude how to work with your WordPress data:
 
+<CodeAccordion title="CLAUDE.md — WordPress Codegen Instructions" ext="MD">
+
 ```markdown
 # CLAUDE.md
 
@@ -690,6 +692,8 @@ When asked to generate mock data / test fixtures:
 - Playwright or Cypress for e2e tests
 - Vite bundler
 ```
+
+</CodeAccordion>
 
 Commit this file:
 


### PR DESCRIPTION
## Summary
Enhanced the `CodeAccordion` component with improved code snippet functionality, including a copy-to-clipboard button and optional file extension badges. Also added a new `MdxPre` component for consistent code block styling.

## Key Changes
- **CodeAccordion enhancements:**
  - Added `ext` prop to display file extension badges (e.g., "MJS", "MD")
  - Implemented "Copy All" button that copies code content to clipboard with visual feedback
  - Changed button element to div for better semantic structure and event handling
  - Added `useRef` hook to reference code content for copying
  - Integrated `clsx` utility for conditional styling

- **New MdxPre component:**
  - Created dedicated `MdxPre` component for consistent pre/code block styling
  - Registered in MDX components export for automatic use in markdown files
  - Provides dark mode support with appropriate color schemes

- **Documentation updates:**
  - Added `ext="MJS"` to two CodeAccordion instances in wp-agents guide
  - Wrapped CLAUDE.md example with CodeAccordion and `ext="MD"` badge

- **Sidebar improvements:**
  - Updated guide title display to show "Single Page Guides" for single-page guide types

## Implementation Details
- Copy functionality uses `navigator.clipboard.writeText()` with 2-second success state feedback
- File extension badges use uppercase styling with appropriate dark mode colors
- Copy button styling changes based on state (default vs. copied confirmation)
- Content reference prevents event propagation to avoid unintended accordion toggles

https://claude.ai/code/session_01RWXJP7B3u13HzX3mQZS5ZA