### PR TITLE
Rewrite BetterAuth guide for conceptual depth over code snippets

### DIFF
--- a/src/content/better-auth/ba-client.mdx
+++ b/src/content/better-auth/ba-client.mdx
@@ -12,7 +12,7 @@ linkRefs:
 
 <Toc>
   <TocLink id="toc-create">Creating the client</TocLink>
-  <TocLink id="toc-signup">Sign up & sign in</TocLink>
+  <TocLink id="toc-auth">Sign up & sign in</TocLink>
   <TocLink id="toc-session">Using the session hook</TocLink>
   <TocLink id="toc-types">Type inference</TocLink>
 </Toc>
@@ -23,11 +23,14 @@ BetterAuth provides framework-specific client imports. For React, you get reacti
 
 <SectionSubheading id="toc-create">Creating the client</SectionSubheading>
 
+`createAuthClient` creates a typed wrapper around fetch that knows all your server's auth endpoints. The `baseURL` tells it where your auth handler is mounted. Importing from `better-auth/react` (instead of `better-auth/client`) gives you reactive hooks like `useSession` in addition to imperative methods.
+
+The client auto-discovers your server's capabilities. If your server config has `emailAndPassword` enabled, the client exposes `signIn.email()` and `signUp.email()`. If you add social providers, `signIn.social()` appears. Plugins extend the client the same way — add `twoFactor()` on the server, add `twoFactorClient()` on the client, and you get `authClient.twoFactor.verifyTotp()`.
+
 <CodeAccordion title="src/lib/auth-client.ts" code={`import { createAuthClient } from "better-auth/react"
 
 export const authClient = createAuthClient({
   baseURL: "http://localhost:3000",
-  // fetchOptions: { credentials: "include" }
 })
 
 // Destructure for convenience
@@ -39,32 +42,28 @@ export const {
   getSession,
 } = authClient`} />
 
-<SectionSubheading id="toc-signup">Sign up & sign in</SectionSubheading>
+<SectionSubheading id="toc-auth">Sign up & sign in</SectionSubheading>
 
-<CodeAccordion title="SignUp.tsx" code={`import { signUp } from "@/lib/auth-client"
+Auth methods return a `{ data, error }` result type rather than throwing exceptions. This makes error handling explicit — you always check `error` before using `data`. On success, `data` contains `{ user, session }`. The sign-up and sign-in APIs follow the same shape, differing only in that sign-up requires a `name` field.
 
-async function handleSignUp(email: string, password: string, name: string) {
-  const { data, error } = await signUp.email({
-    email,
-    password,
-    name,
-  })
-  if (error) {
-    console.error(error.message)
-  }
-  // data contains { user, session }
-}`} />
+<CodeAccordion title="Auth flow example" code={`import { signUp, signIn } from "@/lib/auth-client"
 
-<CodeAccordion title="SignIn.tsx" code={`import { signIn } from "@/lib/auth-client"
+// Sign up — creates user + session
+const { data, error } = await signUp.email({
+  email,
+  password,
+  name,
+})
 
-async function handleSignIn(email: string, password: string) {
-  const { data, error } = await signIn.email({
-    email,
-    password,
-  })
-}`} />
+// Sign in — looks up user, verifies password, creates session
+const { data, error } = await signIn.email({
+  email,
+  password,
+})`} />
 
 <SectionSubheading id="toc-session">Using the session hook</SectionSubheading>
+
+`useSession` subscribes to auth state changes via internal atom signals. When any auth action completes — sign-in, sign-out, token refresh — all `useSession` consumers re-render automatically. You don't need to set up context providers, pass callbacks, or manually invalidate. The hook returns `{ data, isPending, error }`, where `data` is the full session object (user, session metadata) or `null` if unauthenticated.
 
 <CodeAccordion title="Dashboard.tsx" code={`import { useSession } from "@/lib/auth-client"
 
@@ -82,22 +81,23 @@ function Dashboard() {
   )
 }`} />
 
-<SectionNote>
-The `useSession` hook is reactive — it automatically re-renders when sign-in, sign-out, or session refresh happens. Certain endpoints trigger atom signals that keep all `useSession` consumers in sync.
-</SectionNote>
-
 <SectionSubheading id="toc-types">Type inference</SectionSubheading>
 
-<CodeAccordion title="types.ts — Infer types from your config" code={`import type { auth } from "./auth" // your server auth instance
+BetterAuth's type system is one of its strongest features. Your client automatically knows about fields added by plugins — if you add the RBAC plugin, `session.user.role` appears in autocomplete without any manual type definitions. This works through the `$Infer` utility on your server auth instance.
+
+For monorepo setups where the client and server live in separate packages, pass your server's auth type as a generic to `createAuthClient`. This gives you the same end-to-end type safety without a direct import of the server module.
+
+<CodeAccordion title="Type inference patterns" code={`import type { auth } from "./auth" // your server auth instance
 
 // Infer session & user types from your config + plugins
 type Session = typeof auth.$Infer.Session
 type User = typeof auth.$Infer.Session.user
 
 // For separate client/server projects, pass the type generic
-import { createAuthClient } from "better-auth/react"
-import type { auth } from "server/auth"
-
 const authClient = createAuthClient<typeof auth>({
   baseURL: "http://localhost:3000",
 })`} />
+
+<Explainer title="Why this matters">
+Without type inference, adding a plugin like `organization()` would mean manually defining `session.user.organizationId`, `session.activeOrganization`, etc. With `$Infer`, plugin fields flow through your entire codebase automatically — the type system becomes a living document of your auth capabilities.
+</Explainer>

--- a/src/content/better-auth/ba-database.mdx
+++ b/src/content/better-auth/ba-database.mdx
@@ -13,31 +13,46 @@ linkRefs:
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
 <Toc>
-  <TocLink id="toc-adapters">ORM adapters</TocLink>
+  <TocLink id="toc-pattern">The adapter pattern</TocLink>
+  <TocLink id="toc-adapters">Choosing an adapter</TocLink>
+  <TocLink id="toc-examples">Adapter examples</TocLink>
   <TocLink id="toc-redis">Secondary storage (Redis)</TocLink>
 </Toc>
 
 <SectionIntro>
-BetterAuth supports three official ORM adapters plus a built-in Kysely adapter for raw connection strings. You can also use secondary storage (like Redis) for high-performance session lookups.
+BetterAuth never talks to your database directly. Instead, it uses an adapter layer that translates auth operations into your ORM's query language. This means you keep your existing ORM, schema workflow, and migration tooling — BetterAuth just plugs into it.
 </SectionIntro>
 
-<SectionSubheading id="toc-adapters">ORM adapters</SectionSubheading>
+<SectionSubheading id="toc-pattern">The adapter pattern</SectionSubheading>
 
-<CodeAccordion title="Drizzle" code={`import { betterAuth } from "better-auth"
+When BetterAuth needs to create a user, look up a session, or store an OAuth account link, it calls adapter methods like `create`, `findOne`, and `update`. The adapter translates these into the query syntax your ORM understands. This is why you can switch between Drizzle and Prisma without changing any auth logic — only the adapter import changes.
+
+The `generate` CLI command also uses adapter awareness: it outputs schema in the correct format for your ORM (Drizzle schema files, Prisma schema blocks, etc.), so your auth tables follow the same conventions as the rest of your database.
+
+<SectionSubheading id="toc-adapters">Choosing an adapter</SectionSubheading>
+
+<DefinitionTable>
+  <DefRow term="Drizzle">Best for most new projects. Supports joins mode for 2-3x faster session lookups. Works with PostgreSQL, MySQL, and SQLite.</DefRow>
+  <DefRow term="Prisma">The most popular TypeScript ORM. Use this if your project already uses Prisma and you don't want to add a second ORM.</DefRow>
+  <DefRow term="MongoDB">For document-database projects. Adapter handles the translation from BetterAuth's relational model to MongoDB collections.</DefRow>
+  <DefRow term="Raw connection string">BetterAuth's built-in Kysely adapter. Pass a `Pool` or connection URL directly — no external ORM needed. Good for minimal setups.</DefRow>
+</DefinitionTable>
+
+<SectionSubheading id="toc-examples">Adapter examples</SectionSubheading>
+
+The adapter is passed to the `database` key in your config. Here's what Drizzle and Prisma look like — MongoDB and raw connection strings follow the same one-import pattern.
+
+<CodeAccordion title="Drizzle adapter" code={`import { betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
 import { db } from "./db"
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, {
     provider: "pg", // "mysql" | "sqlite"
-    // schema, // pass your drizzle schema for joins
   }),
-  experimental: {
-    joins: true, // 2-3x faster session lookups
-  },
 })`} />
 
-<CodeAccordion title="Prisma" code={`import { betterAuth } from "better-auth"
+<CodeAccordion title="Prisma adapter" code={`import { betterAuth } from "better-auth"
 import { prismaAdapter } from "better-auth/adapters/prisma"
 import { PrismaClient } from "@prisma/client"
 
@@ -49,24 +64,13 @@ export const auth = betterAuth({
   }),
 })`} />
 
-<CodeAccordion title="MongoDB" code={`import { betterAuth } from "better-auth"
-import { mongodbAdapter } from "better-auth/adapters/mongodb"
-import { client } from "./db"
-
-export const auth = betterAuth({
-  database: mongodbAdapter(client),
-})`} />
-
-<CodeAccordion title="Raw connection string" code={`import { betterAuth } from "better-auth"
-import { Pool } from "pg"
-
-export const auth = betterAuth({
-  database: new Pool({
-    connectionString: process.env.DATABASE_URL,
-  }),
-})`} />
+<Explainer title="Joins mode (Drizzle)">
+By default, BetterAuth makes separate queries for sessions and users. With `experimental.joins: true` and a Drizzle schema passed to the adapter, it uses SQL joins instead — reducing session lookups from 2 queries to 1. This is a 2-3x performance improvement and is recommended for production.
+</Explainer>
 
 <SectionSubheading id="toc-redis">Secondary storage (Redis)</SectionSubheading>
+
+For high-traffic applications, you can add Redis as a secondary storage layer. When configured, BetterAuth reads sessions from Redis first (sub-millisecond lookups) and falls back to the database. This is useful when session lookup latency matters — think thousands of concurrent users — but for most apps, the default database storage with cookie caching is sufficient.
 
 <CodeAccordion title="auth.ts — Redis secondary storage" code={`import { betterAuth } from "better-auth"
 import { createRedisStorage } from "@better-auth/redis-storage"
@@ -83,5 +87,5 @@ export const auth = betterAuth({
 })`} />
 
 <SectionNote>
-When secondary storage is defined, sessions are stored there by default (not the database). Set `storeSessionInDatabase: true` if you want both. For fully stateless mode, omit the database entirely and enable cookie caching.
+When secondary storage is defined, sessions are stored there by default (not the database). Set `storeSessionInDatabase: true` if you want both. For most applications, skip Redis entirely and use cookie caching instead — it eliminates database lookups for a configurable window without any extra infrastructure.
 </SectionNote>

--- a/src/content/better-auth/ba-plugins.mdx
+++ b/src/content/better-auth/ba-plugins.mdx
@@ -11,13 +11,25 @@ linkRefs:
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
 <Toc>
+  <TocLink id="toc-how">How plugins work</TocLink>
   <TocLink id="toc-browse">Browse plugins</TocLink>
   <TocLink id="toc-example">Example: Adding 2FA + Passkeys</TocLink>
+  <TocLink id="toc-composition">Plugin composition</TocLink>
 </Toc>
 
 <SectionIntro>
-Plugins are what make BetterAuth genuinely comprehensive. Each plugin adds server endpoints, client methods, and database schema — and the CLI handles migration for all of them.
+Plugins are what make BetterAuth genuinely comprehensive. Rather than building a monolithic auth library that ships everything, BetterAuth uses a composable plugin architecture where each feature — 2FA, passkeys, organizations, SSO — is an independent module you opt into.
 </SectionIntro>
+
+<SectionSubheading id="toc-how">How plugins work</SectionSubheading>
+
+Each plugin can do three things: add **server endpoints** (new API routes under `/api/auth/`), add **client methods** (typed functions on the auth client), and add **database tables or columns** (schema extensions). When you add a plugin to your server config, re-running `npx auth@latest generate` automatically includes the plugin's tables in your schema output.
+
+This means the workflow for adding any feature is always the same:
+
+1. Add the plugin to your **server** config (`plugins: [...]`)
+2. Add the matching client plugin to your **client** config
+3. Re-run `generate` and `migrate` to update your database schema
 
 <SectionSubheading id="toc-browse">Browse plugins</SectionSubheading>
 
@@ -25,20 +37,16 @@ Plugins are what make BetterAuth genuinely comprehensive. Each plugin adds serve
 
 <SectionSubheading id="toc-example">Example: Adding 2FA + Passkeys</SectionSubheading>
 
+Here's what it looks like in practice. The server plugins add the auth logic and database tables. The client plugins add typed methods like `twoFactor.verifyTotp()` and `passkey.register()` — these don't exist on the client until you add the plugins.
+
 <CodeAccordion title="auth.ts — Server plugins" code={`import { betterAuth } from "better-auth"
 import { twoFactor, passkey } from "better-auth/plugins"
 
 export const auth = betterAuth({
   database: drizzleAdapter(db, { provider: "pg" }),
   plugins: [
-    twoFactor({
-      issuer: "My App",
-      // otpOptions: { digits: 6, period: 30 }
-    }),
-    passkey({
-      rpID: "myapp.com",
-      rpName: "My App",
-    }),
+    twoFactor({ issuer: "My App" }),
+    passkey({ rpID: "myapp.com", rpName: "My App" }),
   ],
 })`} />
 
@@ -46,18 +54,15 @@ export const auth = betterAuth({
 import { twoFactorClient, passkeyClient } from "better-auth/client/plugins"
 
 export const authClient = createAuthClient({
-  plugins: [
-    twoFactorClient(),
-    passkeyClient(),
-  ],
-})
-
-// Now available:
-// authClient.twoFactor.enable()
-// authClient.twoFactor.verifyTotp({ code })
-// authClient.passkey.register()
-// authClient.passkey.authenticate()`} />
+  plugins: [twoFactorClient(), passkeyClient()],
+})`} />
 
 <Gotcha title="Both server and client plugins required">
 Both server and client plugins are usually required. Adding `twoFactor()` on the server without `twoFactorClient()` on the client means you won't get the typed methods. After adding plugins, re-run `npx auth@latest generate` to update your schema.
 </Gotcha>
+
+<SectionSubheading id="toc-composition">Plugin composition</SectionSubheading>
+
+Plugins are designed to compose. The `organization` plugin adds multi-tenant workspaces. The `access` plugin adds role-based permissions. Used together, you get org-level RBAC — roles scoped to organizations, not just globally. Similarly, `twoFactor` and `passkey` can coexist, giving users a choice of second factors.
+
+This composability is why BetterAuth can match the feature set of paid services like Clerk while remaining self-hosted. You pick exactly the features you need, and each one integrates cleanly with the others through shared primitives like sessions and user records.

--- a/src/content/better-auth/ba-sessions.mdx
+++ b/src/content/better-auth/ba-sessions.mdx
@@ -11,20 +11,31 @@ linkRefs:
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
 <Toc>
+  <TocLink id="toc-lifecycle">The session lifecycle</TocLink>
   <TocLink id="toc-strategies">Session strategies</TocLink>
   <TocLink id="toc-config">Session config options</TocLink>
   <TocLink id="toc-stateless">Fully stateless (no database)</TocLink>
 </Toc>
 
 <SectionIntro>
-BetterAuth supports multiple session strategies, from database-backed sessions with Redis caching to fully stateless JWT-based sessions with zero database.
+BetterAuth supports multiple session strategies, from database-backed sessions with Redis caching to fully stateless JWT-based sessions with zero database. Understanding the trade-offs helps you pick the right approach for your app.
 </SectionIntro>
+
+<SectionSubheading id="toc-lifecycle">The session lifecycle</SectionSubheading>
+
+When a user signs in, BetterAuth creates a session record (in the database, Redis, or a signed cookie depending on your config), generates a session token, and sets it as an HTTP-only cookie. On subsequent requests, the cookie is sent automatically by the browser. BetterAuth reads the token, validates it, and resolves the session — either by looking it up in the database, checking Redis, or verifying a JWT signature.
+
+Sessions expire after a configurable duration (`expiresIn`). To avoid forcing users to re-authenticate frequently, BetterAuth can silently refresh the session on active requests (`updateAge`). Cookie caching (`cookieCache`) adds another optimization: it stores session data directly in the cookie for a short window, eliminating database lookups entirely for cached requests.
 
 <SectionSubheading id="toc-strategies">Session strategies</SectionSubheading>
 
 <BauthSessionCards />
 
+The strategy you choose determines what's stored in the session cookie. **Compact** stores just a session ID (smallest cookie, requires a DB or Redis lookup on every request). **JWT** stores the session payload as a signed but readable token (no DB lookup, but the payload is visible to the client). **JWE** encrypts the JWT payload (no DB lookup, and the client can't read the contents).
+
 <SectionSubheading id="toc-config">Session config options</SectionSubheading>
+
+The three key decisions are `expiresIn`, `updateAge`, and `cookieCache`. **`expiresIn`** controls the maximum session lifetime — shorter is more secure, longer is more convenient. **`updateAge`** controls how often the session's expiry is refreshed on active use — this balances database writes against session freshness. **`cookieCache`** eliminates database lookups for a configurable window by storing session data in the cookie itself.
 
 <CodeAccordion title="auth.ts — Session configuration" code={`export const auth = betterAuth({
   // ...
@@ -34,17 +45,18 @@ BetterAuth supports multiple session strategies, from database-backed sessions w
     cookieCache: {
       enabled: true,
       maxAge: 60 * 5,   // 5 min cache
-      // strategy: "compact" | "jwt" | "jwe"
-      // version: 1,  // bump to invalidate all sessions
     },
   },
 })`} />
 
 <SectionSubheading id="toc-stateless">Fully stateless (no database)</SectionSubheading>
 
+Since v1.4, you can omit the database config entirely. In stateless mode, sessions live exclusively in signed cookies — no database reads or writes for auth at all. This is ideal for MVPs, internal tools, or apps where social OAuth is sufficient and you don't need to store user profiles server-side.
+
+The trade-off is clear: no database means no server-side session revocation. You can't "log out all devices" or invalidate a specific session from the server. If that's acceptable for your use case, stateless mode eliminates all auth infrastructure beyond the BetterAuth handler itself.
+
 <CodeAccordion title="auth.ts — Stateless mode" code={`import { betterAuth } from "better-auth"
 
-// Since v1.4: omit database entirely
 export const auth = betterAuth({
   socialProviders: {
     google: {
@@ -57,5 +69,5 @@ export const auth = betterAuth({
 })`} />
 
 <SectionNote>
-Stateless mode is great for lightweight apps where you only need social OAuth and don't need to store user data server-side. You can still call `getAccessToken()` and `accountInfo()` without a database.
+Stateless mode still supports `getAccessToken()` and `accountInfo()` — these work by reading the OAuth tokens stored in the session cookie. You can still call social provider APIs without a database.
 </SectionNote>

--- a/src/content/better-auth/ba-setup.mdx
+++ b/src/content/better-auth/ba-setup.mdx
@@ -13,7 +13,7 @@ linkRefs:
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
 <Toc>
-  <TocLink id="toc-install">Install</TocLink>
+  <TocLink id="toc-mental-model">The mental model</TocLink>
   <TocLink id="toc-env">Environment variables</TocLink>
   <TocLink id="toc-server">Server config</TocLink>
   <TocLink id="toc-mount">Mount the handler</TocLink>
@@ -21,21 +21,23 @@ linkRefs:
 </Toc>
 
 <SectionIntro>
-Getting started is straightforward. Install the package, create a server config, mount the handler, and create a client.
+Setting up BetterAuth follows a consistent pattern regardless of framework: install the package (`pnpm add better-auth`), create a server config that describes your auth rules, mount it as an HTTP handler, and generate your database schema. This page walks through each step and explains what's happening under the hood.
 </SectionIntro>
 
-<SectionSubheading id="toc-install">Install</SectionSubheading>
+<SectionSubheading id="toc-mental-model">The mental model</SectionSubheading>
 
-<CodeAccordion title="npm" code="npm install better-auth" />
-<CodeAccordion title="pnpm" code="pnpm add better-auth" />
-<CodeAccordion title="bun" code="bun add better-auth" />
+BetterAuth's setup is a three-part pipeline: **config → handler → mount**. You describe *what* auth features you want in a config object (database, providers, plugins). BetterAuth compiles that into an HTTP handler that exposes all the necessary endpoints — sign-in, sign-up, callback, session, verify, etc. You then mount that handler on your backend framework at a catch-all route. The framework never needs to know what auth is doing; it just forwards requests.
 
 <SectionSubheading id="toc-env">Environment variables</SectionSubheading>
+
+BetterAuth needs two environment variables. `BETTER_AUTH_SECRET` is used to sign session tokens and must be a strong random string. `BETTER_AUTH_URL` tells the library where your server lives, which is needed for OAuth callback URLs and cookie domains.
 
 <CodeAccordion title=".env" code={`BETTER_AUTH_SECRET=your-random-secret-key-here
 BETTER_AUTH_URL=http://localhost:3000`} />
 
 <SectionSubheading id="toc-server">Server config</SectionSubheading>
+
+The `betterAuth()` function takes a config object and returns an auth instance. The config is where you declare everything: which database adapter to use, which auth methods to enable (email/password, social, passwordless), and which plugins to load. This is the single source of truth for your entire auth setup — every feature, table, and endpoint derives from it.
 
 <CodeAccordion title="src/lib/auth.ts" code={`import { betterAuth } from "better-auth"
 import { drizzleAdapter } from "better-auth/adapters/drizzle"
@@ -52,9 +54,9 @@ export const auth = betterAuth({
 
 <SectionSubheading id="toc-mount">Mount the handler</SectionSubheading>
 
-The handler can be mounted on any framework. Here are the three most common approaches:
+The auth instance exposes a `.handler` method that accepts a standard `Request` and returns a `Response`. You mount it at a catch-all route (typically `/api/auth/**`) so BetterAuth can own the entire auth URL namespace. All endpoints — `/api/auth/sign-in`, `/api/auth/callback/google`, `/api/auth/session`, etc. — are handled automatically. Your framework just forwards the raw request.
 
-<CodeAccordion title="Hono" code={`import { Hono } from "hono"
+<CodeAccordion title="Hono (example — works similarly in Express, Elysia, Fastify)" code={`import { Hono } from "hono"
 import { auth } from "./lib/auth"
 
 const app = new Hono()
@@ -64,26 +66,14 @@ app.on(["GET", "POST"], "/api/auth/**", (c) => {
 
 export default app`} />
 
-<CodeAccordion title="Express" code={`import express from "express"
-import { toNodeHandler } from "better-auth/node"
-import { auth } from "./lib/auth"
-
-const app = express()
-app.all("/api/auth/*", toNodeHandler(auth))`} />
-
-<CodeAccordion title="Elysia" code={`import { Elysia } from "elysia"
-import { auth } from "./lib/auth"
-
-const app = new Elysia()
-  .mount(auth.handler)
-  .listen(3000)`} />
+<Explainer title="Framework adapters">
+For frameworks that don't use the Web Standard `Request`/`Response` API (like Express), BetterAuth provides adapters such as `toNodeHandler(auth)`. The concept is the same — mount at a catch-all route and let BetterAuth handle everything under that prefix.
+</Explainer>
 
 <SectionSubheading id="toc-schema">Generate & migrate schema</SectionSubheading>
+
+BetterAuth manages its own database tables (users, sessions, accounts, verifications). Rather than shipping static SQL, the CLI inspects your config — including any plugins you've added — and generates the correct schema for your ORM. This means adding a plugin like `organization()` later is just: add the plugin to your config, re-run generate, and migrate. The schema always stays in sync with your features.
 
 <CodeAccordion title="terminal" code={`npx auth@latest generate   # generates schema for your ORM
 npx drizzle-kit generate     # create migration file
 npx drizzle-kit migrate      # apply migration`} />
-
-<Explainer title="How generate works">
-The `auth generate` command inspects your BetterAuth config (including plugins) and outputs the correct schema for your ORM. If you add the `organization()` plugin later, just re-run generate and migrate.
-</Explainer>

--- a/src/content/better-auth/ba-social.mdx
+++ b/src/content/better-auth/ba-social.mdx
@@ -11,16 +11,25 @@ linkRefs:
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
 <Toc>
+  <TocLink id="toc-how">How social auth works</TocLink>
   <TocLink id="toc-config">Server configuration</TocLink>
   <TocLink id="toc-client">Client-side social sign-in</TocLink>
-  <TocLink id="toc-state">Passing additional OAuth state</TocLink>
+  <TocLink id="toc-state">Passing data through the OAuth flow</TocLink>
 </Toc>
 
 <SectionIntro>
-Adding social login is just a few lines of config. BetterAuth supports Google, GitHub, Apple, Discord, Microsoft, Twitter, and many more. You can also use the `genericOAuth` plugin for any OAuth 2.0 / OIDC provider.
+Social auth in BetterAuth is declarative, not imperative. You declare which OAuth providers you want in your server config, and the client SDK automatically gets typed `signIn.social()` methods. No manual redirect URL construction, no callback route handlers, no token exchange logic.
 </SectionIntro>
 
+<SectionSubheading id="toc-how">How social auth works</SectionSubheading>
+
+When a user clicks "Sign in with Google," BetterAuth handles the entire OAuth dance behind the scenes: it generates the authorization URL with the correct scopes and redirect URI, redirects the user to the provider, receives the callback with an authorization code, exchanges it for tokens, fetches the user's profile, creates or links an account in your database, issues a session, and sets the session cookie. All you provide is the OAuth client ID and secret.
+
+BetterAuth supports Google, GitHub, Apple, Discord, Microsoft, Twitter, and many more out of the box. For any OAuth 2.0 / OIDC provider not in the built-in list, the `genericOAuth` plugin handles arbitrary providers.
+
 <SectionSubheading id="toc-config">Server configuration</SectionSubheading>
+
+Each provider entry in `socialProviders` needs just a `clientId` and `clientSecret`. BetterAuth registers the callback URL at `/api/auth/callback/<provider>` automatically — you just need to add that URL to your OAuth app's allowed redirects in the provider's dashboard.
 
 <CodeAccordion title="auth.ts — Social providers" code={`import { betterAuth } from "better-auth"
 
@@ -35,14 +44,12 @@ export const auth = betterAuth({
       clientId: process.env.GITHUB_CLIENT_ID!,
       clientSecret: process.env.GITHUB_CLIENT_SECRET!,
     },
-    discord: {
-      clientId: process.env.DISCORD_CLIENT_ID!,
-      clientSecret: process.env.DISCORD_CLIENT_SECRET!,
-    },
   },
 })`} />
 
 <SectionSubheading id="toc-client">Client-side social sign-in</SectionSubheading>
+
+On the client, `signIn.social({ provider: "google" })` triggers a full-page redirect to the provider's consent screen. After the user authorizes, they're redirected back to your app with an active session. There's no popup window or iframe — it's the standard OAuth redirect flow that users expect.
 
 <CodeAccordion title="SocialLogin.tsx" code={`import { signIn } from "@/lib/auth-client"
 
@@ -63,30 +70,30 @@ function SocialLogin() {
   )
 }`} />
 
-<SectionSubheading id="toc-state">Passing additional OAuth state</SectionSubheading>
+<SectionSubheading id="toc-state">Passing data through the OAuth flow</SectionSubheading>
 
-Since v1.4, you can pass arbitrary data through the OAuth flow and access it in hooks:
+Since v1.4, you can attach arbitrary data to the OAuth flow via `additionalData`. This is useful for preserving context that needs to survive the redirect — referral codes, UTM parameters, onboarding flow state, or which pricing plan the user selected before signing up. The data is serialized into the OAuth state parameter and accessible in server hooks after the callback.
 
-<CodeAccordion title="auth-client.ts — Passing state" code={`await signIn.social({
+<CodeAccordion title="Client → Server: passing and accessing OAuth state" code={`// Client: attach data to the social sign-in
+await signIn.social({
   provider: "google",
   additionalData: {
     referralCode: "ABC123",
     source: "landing-page",
   },
-})`} />
+})
 
-<CodeAccordion title="auth.ts — Accessing state in server hooks" code={`import { betterAuth } from "better-auth"
+// Server: access the data in hooks
 import { getOAuthState, createAuthMiddleware } from "better-auth/api"
 
 export const auth = betterAuth({
-  // ... config
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
       const data = await getOAuthState<{
         referralCode: string
         source: string
       }>()
-      console.log(data) // { referralCode: "ABC123", source: "landing-page" }
+      // data = { referralCode: "ABC123", source: "landing-page" }
     }),
   },
 })`} />

--- a/src/content/better-auth/ba-tanstack.mdx
+++ b/src/content/better-auth/ba-tanstack.mdx
@@ -13,17 +13,25 @@ linkRefs:
 <SectionTitle>{frontmatter.title}</SectionTitle>
 
 <Toc>
+  <TocLink id="toc-why">Why a special plugin?</TocLink>
   <TocLink id="toc-cookie">Server: TanStack Start cookie plugin</TocLink>
   <TocLink id="toc-route">Mount the handler as an API route</TocLink>
-  <TocLink id="toc-client">Client: React hooks</TocLink>
   <TocLink id="toc-ssr">Server-side session access</TocLink>
 </Toc>
 
 <SectionIntro>
-BetterAuth has first-class support for TanStack Start. A dedicated cookie plugin ensures sessions work correctly with TanStack Start's SSR cookie handling.
+BetterAuth has first-class support for TanStack Start. A dedicated cookie plugin ensures sessions work correctly with TanStack Start's SSR cookie handling, and the standard client SDK works out of the box for React hooks.
 </SectionIntro>
 
+<SectionSubheading id="toc-why">Why a special plugin?</SectionSubheading>
+
+In a client-side SPA, auth cookies are set by the browser in response to HTTP headers — the standard `Set-Cookie` flow. But in SSR frameworks like TanStack Start, the server renders the initial HTML before the browser is involved. If the server needs to set or read a cookie during rendering (e.g., to check a session in a route loader), it can't use browser APIs — it needs to go through the framework's cookie API.
+
+The `tanstackStartCookies()` plugin bridges this gap. It intercepts BetterAuth's cookie operations and routes them through TanStack Start's cookie handling, so sessions work correctly whether the page is server-rendered or client-rendered.
+
 <SectionSubheading id="toc-cookie">Server: TanStack Start cookie plugin</SectionSubheading>
+
+Add the plugin to your server config. It must be the **last plugin** in the array because it wraps all cookie operations from other plugins.
 
 <CodeAccordion title="src/lib/auth.ts" code={`import { betterAuth } from "better-auth"
 import { tanstackStartCookies } from "better-auth/tanstack-start"
@@ -45,6 +53,8 @@ The `tanstackStartCookies()` plugin was renamed from `reactStartCookies()` in v1
 
 <SectionSubheading id="toc-route">Mount the handler as an API route</SectionSubheading>
 
+TanStack Start uses file-based API routing. You create a catch-all route file at `src/routes/api/auth/$.ts` — the `$` segment acts as a wildcard, forwarding all `/api/auth/*` requests to BetterAuth's handler. This is the same pattern as mounting on Hono or Express, just expressed through file conventions.
+
 <CodeAccordion title="src/routes/api/auth/$.ts" code={`import { auth } from "@/lib/auth"
 import { createAPIFileRoute } from "@tanstack/react-start/api"
 
@@ -53,13 +63,11 @@ export const APIRoute = createAPIFileRoute("/api/auth/$")({
   POST: ({ request }) => auth.handler(request),
 })`} />
 
-<SectionSubheading id="toc-client">Client: React hooks</SectionSubheading>
-
-<CodeAccordion title="src/lib/auth-client.ts" code={`import { createAuthClient } from "better-auth/react"
-
-export const { useSession, signIn, signUp, signOut } = createAuthClient()`} />
-
 <SectionSubheading id="toc-ssr">Server-side session access</SectionSubheading>
+
+The standard pattern for auth-guarded routes in SSR frameworks is: route loader runs on server → checks session via request headers → redirects unauthenticated users or passes the session to the component. In TanStack Start, this maps to `createServerFn` (to access the server request) combined with `beforeLoad` (to gate the route).
+
+The key insight is that `auth.api.getSession()` works on the server by reading cookies from the request headers — the same session cookie the browser sends. No separate server-side session store or token validation is needed.
 
 <CodeAccordion title="src/routes/dashboard.tsx — Loader with auth guard" code={`import { createFileRoute, redirect } from "@tanstack/react-router"
 import { createServerFn } from "@tanstack/react-start"
@@ -92,6 +100,6 @@ function DashboardPage() {
   return <h1>Welcome, {session.user.name}</h1>
 }`} />
 
-<Explainer title="Route-level auth guards">
-You can use `auth.api.getSession()` in any server function or loader by passing the request headers. This pattern works great with TanStack Router's `beforeLoad` for route-level auth guards.
+<Explainer title="Client hooks still work">
+You don't need to choose between server-side and client-side session access. Use `beforeLoad` for route guards and initial data, and `useSession()` from the client SDK for reactive UI updates after the page loads. Both read from the same session cookie.
 </Explainer>

--- a/src/data/betterAuthData.ts
+++ b/src/data/betterAuthData.ts
@@ -231,7 +231,7 @@ export const BAUTH_GUIDE_MANIFEST: GuideManifest = {
     description: 'The comprehensive TypeScript authentication framework \u2014 setup, plugins, sessions, social auth, and TanStack integration.',
     category: 'security',
     dateCreated: '2026-03-04',
-    dateModified: '2026-03-04',
+    dateModified: '2026-03-05',
     sections: BAUTH_GUIDE_SECTIONS,
   },
   startPageData: BAUTH_START_PAGE_DATA,


### PR DESCRIPTION
Add prose explaining the "why" and mental models before each code section, reduce redundant code variants (3 pkg managers → inline mention, 4 DB adapters → 2 + DefinitionTable, merged sign-up/sign-in, merged OAuth state blocks, removed duplicate client SDK block in TanStack page), and introduce shared components (Explainer, DefinitionTable, Gotcha) for conceptual framing across all 7 code-heavy pages.

https://claude.ai/code/session_01277DY9x1o9TarmRdEzXJf3